### PR TITLE
Improve Codex and Gemini skill loading sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,25 +15,15 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   load-bearing `next-action`, and finalizer verdicts remain anchored on
   `Status` plus `Self-verification`. Structural routing now uses only
   the shared `## Structural Issue` block.
-
-### Fixed
-
-- **Codex `[[skills.config]]` path silently failed to load skills.**
-  `sync.ts` emitted a relative `path = ".codex/skills/<slug>/SKILL.md"`
-  for every codex agent TOML. Codex resolves such paths against the
-  agent TOML's parent directory (`.codex/agents/`), producing
-  `.codex/agents/.codex/skills/<slug>/SKILL.md` — a location that does
-  not exist. `SkillConfig.path` is typed `AbsolutePathBuf` and the
-  canonicalize step no-ops on failure, so skills never loaded and no
-  error surfaced. The path is now absolute (`resolve(targetRoot,
-  ".codex", "skills", <slug>, "SKILL.md")`), which matches Codex's
-  documented examples and is also safe across the user-level
-  (`~/.codex/agents/`) and project-level layer merge, where a relative
-  path could silently bind to a different project's skill tree.
-  `.codex/` is gitignored, so the absolute prefix does not leak into
-  factory commits. **Existing target repos must re-run
-  `node .harness/loom/sync.ts --provider codex` to regenerate
-  `.codex/agents/*.toml`.**
+- **Codex and Gemini sync now injects required skill loading into agent
+  bodies.** `sync.ts` derives the required skills from canonical
+  `.harness/loom/agents/*.md` `skills:` frontmatter, prepends a
+  `Required Skill Loading` block to Codex `developer_instructions` and
+  Gemini agent bodies, and still mirrors skill directories under
+  `.codex/skills/` and `.gemini/skills/`. Codex no longer emits
+  `[[skills.config]]`; current experiments showed Codex subagents see
+  skill metadata by default but need explicit `$skill-name` mentions for
+  full body loading.
 
 ## [0.3.0] — 2026-04-22
 

--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ Project documentation (target-root `*.md` files, `docs/`) is authored **directly
 - **git** — recommended for reviewing generated harness changes and recovering local experiments through your normal VCS flow.
 - **At least one supported assistant CLI**, authenticated:
   - [Claude Code](https://code.claude.com/docs) — primary target; canonical staging in `.harness/loom/` is derived into `.claude/` via `node .harness/loom/sync.ts --provider claude`.
-  - [Codex CLI](https://developers.openai.com/codex/cli) — derived into `.codex/` via `node .harness/loom/sync.ts --provider codex`.
-  - [Gemini CLI](https://geminicli.com/docs/) — derived into `.gemini/` via `node .harness/loom/sync.ts --provider gemini`.
+  - [Codex CLI](https://developers.openai.com/codex/cli) — derived into `.codex/` via `node .harness/loom/sync.ts --provider codex`; generated agent TOMLs explicitly mention required `$skill-name` bodies.
+  - [Gemini CLI](https://geminicli.com/docs/) — derived into `.gemini/` via `node .harness/loom/sync.ts --provider gemini`; generated agent bodies name the required skills because Gemini frontmatter rejects `skills:`.
 
 ## Install The Factory
 
@@ -271,7 +271,7 @@ A few terms recur across commands, files, and state. Knowing these is enough to 
 |---------|---------|
 | `/harness-init [<target>]` | Scaffold the canonical `.harness/loom/` staging tree plus the `.harness/cycle/` runtime state into a target project. Writes runtime skills, the `harness-planner` agent, the generic `harness-finalizer` cycle-end skeleton, and the `hook.sh` + `sync.ts` self-contained copies under `.harness/loom/`. Seeds `state.md`, `events.md`, `epics/`, and `finalizer/tasks/`, but no goal or request snapshot placeholder. Rerunning install reseeds both namespaces. Touches no platform tree. |
 | `/harness-auto-setup [<target>] [--provider <list>]` | Safely set up or refresh a target harness. Fresh targets receive the foundation plus repo-grounded pair/finalizer recommendations. Existing targets are snapshotted under `.harness/_snapshots/auto-setup/`, active or unknown cycles are warned and preserved in the snapshot before discard/reseed, registered pairs and customized finalizer intent are reconstructed on current templates, and the command stops with an explicit sync handoff. Touches no platform tree. |
-| `node .harness/loom/sync.ts --provider <list>` | Deploy canonical `.harness/loom/` into platform trees (`.claude/`, `.codex/`, `.gemini/`). One-way; never writes back into `.harness/loom/`. Provider selection is explicit: a bare invocation with no provider flags is an error. |
+| `node .harness/loom/sync.ts --provider <list>` | Deploy canonical `.harness/loom/` into platform trees (`.claude/`, `.codex/`, `.gemini/`). One-way; never writes back into `.harness/loom/`. Provider selection is explicit: a bare invocation with no provider flags is an error. Claude keeps agent `skills:` frontmatter; Codex and Gemini receive required skill-loading prompts in generated agent bodies. |
 | `/harness-pair-dev --add <slug> "<purpose>" [--from <existing-pair>] [--reviewer <slug> ...] [--before <slug> \| --after <slug>]` | Author a new producer-reviewer pair anchored to the current codebase. `<purpose>` is required. `--from` accepts only a currently registered pair as a template-first overlay source: current harness shape stays fixed while compatible source domain guidance is preserved. It is not a snapshot, filesystem path, or provider-tree import. Default is 1:1; repeat `--reviewer` for 1:N reviewer topology. Authoring writes only into `.harness/loom/`; re-run `node .harness/loom/sync.ts --provider <list>` afterward. |
 | `/harness-pair-dev --improve <slug> "<purpose>" [--before <slug> \| --after <slug>]` | Improve an existing registered pair with positional `<purpose>` as the primary revision axis, then fold in rubric hygiene and current repo evidence. If a pair has become two different jobs, use explicit add/improve/remove steps. Re-run sync afterward to refresh platform trees. |
 | `/harness-pair-dev --remove <slug>` | Safely unregister a pair and delete only pair-owned `.harness/loom/` files. Removal refuses foundation/singleton targets and active-cycle references in `## Next` or live EPIC roster/current fields before mutating, preserves `.harness/cycle/` task/review history, and touches no provider tree; re-run sync afterward. |
@@ -315,8 +315,8 @@ Platform pins applied by `sync.ts`:
 | Platform | Model | Hook event | Notes |
 |----------|-------|------------|-------|
 | Claude | `inherit` | `Stop` | `.claude/settings.json` triggers `.harness/loom/hook.sh`. |
-| Codex | `gpt-5.4`, `model_reasoning_effort: xhigh` | `Stop` | Subagents do not use mini models. |
-| Gemini | `gemini-3.1-pro-preview` | `AfterAgent` | Skills are mirrored into the platform tree. |
+| Codex | `gpt-5.4`, `model_reasoning_effort: xhigh` | `Stop` | Agent TOMLs prepend required `$skill-name` mentions to `developer_instructions`; skills are mirrored under `.codex/skills/`. |
+| Gemini | `gemini-3.1-pro-preview` | `AfterAgent` | Agent bodies name the required skills; skills are mirrored under `.gemini/skills/`. |
 
 ## When To Use It
 

--- a/plugins/harness-loom/skills/harness-init/scripts/sync.ts
+++ b/plugins/harness-loom/skills/harness-init/scripts/sync.ts
@@ -21,7 +21,7 @@
 //   `.claude/` may belong to the user, not to a prior harness deploy, and
 //   silently overwriting it would clobber unrelated settings.
 //
-// Wipe-and-overwrite contract (goals.md L68):
+// Wipe-and-overwrite contract:
 //   For each selected platform, sync deletes only files/directories under
 //   `agents/` and `skills/` whose name (or basename) starts with `harness-`
 //   before reseeding from `.harness/loom/`. Non-harness assets the user
@@ -31,13 +31,14 @@
 // Platform contract (verified against official specs):
 //   - Codex subagents pin `model = "gpt-5.4"`, `model_reasoning_effort = "xhigh"`.
 //     Agent body goes in `developer_instructions = """..."""` — NOT `prompt`.
-//     Skills are referenced via repeated `[[skills.config]]` tables.
+//     Required skill bodies are loaded through explicit `$skill-name` mentions
+//     prepended to developer_instructions; sync does not emit `[[skills.config]]`.
 //     Source: developers.openai.com/codex/subagents
 //   - Claude agents pin `model: inherit`. Skills are loaded by directory.
 //   - Gemini agents pin `model: gemini-3.1-pro-preview`. Frontmatter is
 //     `.strict()` and rejects unknown keys (including `skills`). Skills are
-//     auto-loaded globally from `.gemini/skills/` and surfaced to every agent
-//     via progressive disclosure — no per-agent reference needed.
+//     mirrored globally under `.gemini/skills/`; required skill names are
+//     prepended to the agent body so the runtime can activate them explicitly.
 //     Source: github.com/google-gemini/gemini-cli (packages/core/src/agents/agentLoader.ts)
 //   - Each platform's hook setting wires to `bash .harness/loom/hook.sh
 //     <platform>` (Stop for claude/codex, AfterAgent for gemini).
@@ -57,7 +58,7 @@ import {
   access,
 } from "node:fs/promises";
 import { constants as FS } from "node:fs";
-import { join, dirname, relative, resolve } from "node:path";
+import { join, dirname, relative } from "node:path";
 import process from "node:process";
 
 // All supported platform trees are derived deploy targets. `.harness/loom/`
@@ -194,15 +195,55 @@ function injectModelIntoFrontmatter(fm: Record<string, unknown>, pin: PlatformPi
   return out;
 }
 
+function uniqueSkills(skills: unknown): string[] {
+  if (!Array.isArray(skills)) return [];
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const skill of skills) {
+    if (typeof skill !== "string") continue;
+    const slug = skill.trim();
+    if (slug.length === 0 || seen.has(slug)) continue;
+    seen.add(slug);
+    out.push(slug);
+  }
+  return out;
+}
+
+function skillLoadingBlock(skills: string[], platform: "codex" | "gemini"): string {
+  if (skills.length === 0) return "";
+  const names = skills.join(", ");
+  const mentions = skills.map((skill) => `$${skill}`).join(", ");
+  const lines = ["## Required Skill Loading", ""];
+  if (platform === "codex") {
+    lines.push(
+      `Before performing this role, explicitly load and follow these skill bodies: ${mentions}.`,
+      "Codex exposes skill metadata by default; these mentions are required so the full SKILL.md bodies enter context.",
+      "Do not rely on metadata-only skill visibility.",
+    );
+  } else {
+    lines.push(
+      `Before performing this role, activate and follow these skill bodies by name: ${names}.`,
+      `If the platform accepts $skill-name mentions, the equivalent mentions are: ${mentions}.`,
+      "Do not rely on metadata-only skill visibility.",
+    );
+  }
+  return lines.join("\n");
+}
+
+function withSkillLoading(body: string, skills: string[], platform: "codex" | "gemini"): string {
+  const block = skillLoadingBlock(skills, platform);
+  if (!block) return body.trimEnd();
+  return `${block}\n\n${body.trimStart().trimEnd()}`;
+}
+
 function renderCodexAgentToml(
   fm: Record<string, unknown>,
   body: string,
   pin: PlatformPin,
-  targetRoot: string,
 ): string {
   const name = String(fm.name ?? "");
   const description = String(fm.description ?? "");
-  const skills = Array.isArray(fm.skills) ? (fm.skills as string[]) : [];
+  const bodyWithSkillLoading = withSkillLoading(body, uniqueSkills(fm.skills), "codex");
   const tomlLines: string[] = [];
   tomlLines.push(`name = ${JSON.stringify(name)}`);
   tomlLines.push(`description = ${JSON.stringify(description)}`);
@@ -211,23 +252,9 @@ function renderCodexAgentToml(
   if (pin.reasoning) tomlLines.push(`model_reasoning_effort = ${JSON.stringify(pin.reasoning)}`);
   // Codex spec puts the agent prompt in `developer_instructions`, not `prompt`.
   tomlLines.push('developer_instructions = """');
-  tomlLines.push(body.trimEnd());
+  tomlLines.push(bodyWithSkillLoading);
   tomlLines.push('"""');
   tomlLines.push("");
-  // Codex loads skills via repeated `[[skills.config]]` tables, one per skill
-  // — not a single `skills = [...]` array. `SkillConfig.path` is typed as
-  // `AbsolutePathBuf`; a relative value is resolved against the agent TOML's
-  // parent directory (`.codex/agents/`) and then silently no-ops when the
-  // canonicalize step fails, so the skill quietly never loads. Emit absolute
-  // paths to bypass that resolution entirely. `.codex/` is gitignored, so the
-  // machine-specific prefix does not leak into factory commits.
-  for (const skill of skills) {
-    const absSkillPath = resolve(targetRoot, ".codex", "skills", skill, "SKILL.md");
-    tomlLines.push("[[skills.config]]");
-    tomlLines.push(`path = ${JSON.stringify(absSkillPath)}`);
-    tomlLines.push("enabled = true");
-    tomlLines.push("");
-  }
   return tomlLines.join("\n");
 }
 
@@ -453,7 +480,7 @@ async function deployCodex(targetRoot: string, agents: AgentFile[], skills: Skil
   await wipeHarnessEntries(agentsDir, ".toml", deleted);
   await wipeHarnessEntries(skillsDir, null, deleted);
   for (const a of agents) {
-    const toml = renderCodexAgentToml(a.frontmatter, a.body, PIN.codex, targetRoot);
+    const toml = renderCodexAgentToml(a.frontmatter, a.body, PIN.codex);
     const dst = join(agentsDir, `${a.name}.toml`);
     await writeFile(dst, toml);
     copied.push(dst);
@@ -482,11 +509,12 @@ async function deployGemini(targetRoot: string, agents: AgentFile[], skills: Ski
   for (const a of agents) {
     const fm = injectModelIntoFrontmatter(a.frontmatter, PIN.gemini);
     // Gemini's localAgentSchema is .strict() and rejects unknown keys like
-    // `skills` (which is a Claude-canonical field). Skills load globally from
-    // `.gemini/skills/` and surface to every agent via progressive disclosure
-    // — there is no per-agent `skills` reference in Gemini frontmatter.
+    // `skills` (which is a Claude-canonical field). Mirror skills globally
+    // under `.gemini/skills/`, then inject the required skill names into the
+    // body so the agent can explicitly activate them.
+    const bodyWithSkillLoading = withSkillLoading(a.body, uniqueSkills(fm.skills), "gemini");
     delete fm.skills;
-    const out = renderClaudeFrontmatter(fm) + a.body;
+    const out = renderClaudeFrontmatter(fm) + bodyWithSkillLoading + "\n";
     const dst = join(agentsDir, `${a.name}.md`);
     await writeFile(dst, out);
     copied.push(dst);

--- a/tests/sync.test.mjs
+++ b/tests/sync.test.mjs
@@ -42,6 +42,9 @@ test("sync --provider claude derives .claude/{agents, skills, settings.json} fro
     assert.ok(existsSync(join(target, ".claude/skills/harness-orchestrate/SKILL.md")));
     assert.ok(existsSync(join(target, ".claude/skills/harness-planning/SKILL.md")));
     assert.ok(existsSync(join(target, ".claude/skills/harness-context/SKILL.md")));
+    const planner = readFileSync(join(target, ".claude/agents/harness-planner.md"), "utf8");
+    assert.match(planner, /^skills:\n  - harness-planning\n  - harness-context$/m);
+    assert.doesNotMatch(planner, /Required Skill Loading/);
 
     // settings.json hook wires the loom hook.sh rather than a cycle-owned path.
     const settings = JSON.parse(readFileSync(join(target, ".claude/settings.json"), "utf8"));
@@ -116,6 +119,33 @@ test("sync --provider gemini writes AfterAgent settings.json pointing at .harnes
     assert.equal(item.type, "command");
     assert.equal(item.command, "bash .harness/loom/hook.sh gemini");
     assert.equal(item.timeout, 60000);
+  } finally {
+    cleanupDir(target);
+  }
+});
+
+test("sync --provider gemini strips skills frontmatter but injects required skill loading into agent bodies", () => {
+  const target = makeTempDir();
+  try {
+    installTo(target);
+    assert.equal(runNode(SYNC_SCRIPT, ["--provider", "gemini"], { cwd: target }).status, 0);
+
+    const planner = readFileSync(join(target, ".gemini/agents/harness-planner.md"), "utf8");
+    const finalizer = readFileSync(join(target, ".gemini/agents/harness-finalizer.md"), "utf8");
+
+    assert.doesNotMatch(planner, /^skills:/m);
+    assert.match(planner, /^## Required Skill Loading$/m);
+    assert.match(planner, /activate and follow these skill bodies by name: harness-planning, harness-context\./);
+    assert.match(planner, /\$harness-planning, \$harness-context/);
+    assert.match(planner, /^# Planner$/m);
+
+    assert.doesNotMatch(finalizer, /^skills:/m);
+    assert.match(finalizer, /activate and follow these skill bodies by name: harness-context\./);
+    assert.match(finalizer, /\$harness-context/);
+    assert.doesNotMatch(finalizer, /\$harness-planning/);
+
+    assert.ok(existsSync(join(target, ".gemini/skills/harness-planning/SKILL.md")));
+    assert.ok(existsSync(join(target, ".gemini/skills/harness-context/SKILL.md")));
   } finally {
     cleanupDir(target);
   }
@@ -247,45 +277,29 @@ test("sync errors on bare invocation — deploy is always an explicit opt-in", (
   }
 });
 
-test("sync --provider codex emits absolute [[skills.config]] paths that actually exist", () => {
+test("sync --provider codex omits skills.config and injects required skill mentions into agent bodies", () => {
   const target = makeTempDir();
   try {
     installTo(target);
     assert.equal(runNode(SYNC_SCRIPT, ["--provider", "codex"], { cwd: target }).status, 0);
 
-    // Every generated codex agent TOML must encode absolute skill paths.
-    // Relative `.codex/skills/...` resolves against `.codex/agents/` and then
-    // silently no-ops when canonicalize fails — hence this guard.
-    const agentsDir = join(target, ".codex/agents");
-    const tomls = readdirSync(agentsDir).filter((n) => n.endsWith(".toml"));
-    assert.ok(tomls.length > 0, "codex agent TOMLs must exist after sync");
+    const planner = readFileSync(join(target, ".codex/agents/harness-planner.toml"), "utf8");
+    const finalizer = readFileSync(join(target, ".codex/agents/harness-finalizer.toml"), "utf8");
 
-    let pathLinesAsserted = 0;
-    for (const name of tomls) {
-      const body = readFileSync(join(agentsDir, name), "utf8");
-      const pathLines = body
-        .split("\n")
-        .filter((l) => /^path\s*=\s*"/.test(l));
-      for (const line of pathLines) {
-        const match = line.match(/^path\s*=\s*"([^"]+)"/);
-        assert.ok(match, `could not parse path line in ${name}: ${line}`);
-        const p = match[1];
-        assert.match(
-          p,
-          /^\/.+\/\.codex\/skills\/[^/]+\/SKILL\.md$/,
-          `${name} path must be absolute .codex/skills/<slug>/SKILL.md, got: ${p}`,
-        );
-        assert.ok(
-          existsSync(p),
-          `${name} references skill path that does not exist on disk: ${p}`,
-        );
-        pathLinesAsserted += 1;
-      }
-    }
-    assert.ok(
-      pathLinesAsserted > 0,
-      "at least one [[skills.config]] path must have been asserted",
-    );
+    assert.doesNotMatch(planner, /\[\[skills\.config\]\]/);
+    assert.doesNotMatch(planner, /^path\s*=\s*"/m);
+    assert.match(planner, /^developer_instructions = """$/m);
+    assert.match(planner, /^## Required Skill Loading$/m);
+    assert.match(planner, /\$harness-planning, \$harness-context/);
+    assert.match(planner, /Codex exposes skill metadata by default/);
+    assert.match(planner, /^# Planner$/m);
+
+    assert.doesNotMatch(finalizer, /\[\[skills\.config\]\]/);
+    assert.match(finalizer, /\$harness-context/);
+    assert.doesNotMatch(finalizer, /\$harness-planning/);
+
+    assert.ok(existsSync(join(target, ".codex/skills/harness-planning/SKILL.md")));
+    assert.ok(existsSync(join(target, ".codex/skills/harness-context/SKILL.md")));
   } finally {
     cleanupDir(target);
   }


### PR DESCRIPTION
## Summary
- remove Codex [[skills.config]] emission and inject explicit required skill-loading prompts into Codex developer_instructions
- inject the same required skill-loading prompt into Gemini agent bodies while keeping Claude skills frontmatter unchanged
- update sync docs/changelog and tests for the new Codex/Gemini behavior

## Validation
- node --test tests/*.mjs