### PR TITLE
Release v0.3.0 milestone

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Weave Producer-Reviewer agent harnesses with auto-execution hooks and self-improving skill loops.",
-    "version": "0.2.2"
+    "version": "0.3.0"
   },
   "plugins": [
     {
       "name": "harness-loom",
       "source": "./plugins/harness-loom",
       "description": "Producer-Reviewer harness generator for Claude Code, Codex CLI, and Gemini CLI.",
-      "version": "0.2.2",
+      "version": "0.3.0",
       "tags": ["harness", "agent-team", "producer-reviewer", "orchestration", "multi-platform"],
       "category": "productivity"
     }

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,7 @@ AGENTS.md
 # Ephemeral goal markdown fed to `/harness-orchestrate <goal.md>` during
 # factory self-testing. Rewritten per cycle; never part of the repo history.
 goals.md
+
+# Local development knowledge generated during self-install cycles. Keep it out
+# of factory commits unless it is intentionally promoted into tracked docs.
+develop-docs/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,104 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.3.0] — 2026-04-22
+
+### Added
+
+- **`/harness-auto-setup` setup-and-refresh workflow.**
+  New factory-side skill that safely installs, refreshes, or converges
+  a target harness. Fresh targets are seeded through the foundation
+  installer and receive repo-grounded pair/finalizer recommendations.
+  Existing targets snapshot `.harness/loom/` and `.harness/cycle/`
+  under `.harness/_snapshots/auto-setup/<timestamp>/`, warn before
+  discarding active or unknown cycle state, reseed the foundation,
+  reconstruct valid registered pairs and customized finalizer intent
+  against current templates, and stop with an explicit
+  `node .harness/loom/sync.ts --provider <list>` handoff. Auto-setup
+  never writes `.claude/`, `.codex/`, or `.gemini/` directly.
+- **`/harness-pair-dev --remove <pair-slug>` guarded removal.**
+  Safely unregisters a pair and deletes only pair-owned `.harness/loom/`
+  files. Removal refuses foundation/singleton targets, missing pairs,
+  paths outside `.harness/loom/{agents,skills}/`, active-cycle
+  references in `## Next`, and live EPIC roster/current fields before
+  mutating anything. Shared agents and skills referenced by other
+  registered pairs are preserved. `.harness/cycle/` task and review
+  history stays intact — historical evidence is runtime state, not
+  pair-authoring state.
+- **`/harness-pair-dev --add --from <existing-pair-slug>` template-first
+  overlay.** `--add` now accepts an optional `--from` anchored to a
+  currently registered pair. The new pair is authored from current
+  templates first, then compatible source-pair domain material
+  (identity, vocabulary, methodology, taboos, reviewer axes, extra
+  domain skills) is overlaid on top. `<purpose>` wins over source
+  intent on conflict, and the new pair skill plus `harness-context`
+  remain mandatory `skills:` entries. Snapshot paths, filesystem paths,
+  and derived platform paths are explicitly rejected.
+- **Deterministic pair-dev helper.**
+  `plugins/harness-loom/skills/harness-pair-dev/scripts/pair-dev.ts`
+  validates `--add`/`--improve`/`--remove` arguments, resolves `--from`
+  evidence from the current registry, and performs guarded removal
+  with active-cycle safety checks. Add/improve return preparation JSON
+  only; authoring bodies remains an LLM turn responsibility.
+- **`references/authoring/from-overlay.md`.**
+  New pair-authoring rubric describing the `--from` template-first
+  overlay contract: mandatory new shape, preserve-by-default rules,
+  skill preservation rule (`<new-pair-skill>` + `harness-context`
+  first), and rename/conflict resolution.
+
+### Changed
+
+- **`/harness-pair-dev` command surface tightened.**
+  `--add` and `--improve` now both require a positional `<purpose>`
+  string. Placement anchors (`--before`/`--after`) are documented on
+  both. `register-pair.ts --unregister` is reserved for the internal
+  `--remove` path; file deletion and active-cycle safety checks live
+  in `/harness-pair-dev --remove`, not in the registry helper.
+- **`/harness-init` scope narrowed to foundation-only.**
+  Install still reseeds `.harness/loom/` and `.harness/cycle/` every
+  rerun, but existing-target refresh with pair/finalizer convergence
+  now belongs to `/harness-auto-setup`. `harness-init` does not
+  snapshot live harness state, parse old registry intent, or preserve
+  customized finalizer work.
+- **READMEs, AGENTS.md, and CLAUDE.md realigned to the 0.3.0 surface.**
+  English README and the four pointer-doc translations surface
+  `/harness-auto-setup` as the preferred setup entry, replace the
+  removed `--split` command with `--remove`, and show `--from` as
+  overlay source rather than evidence-only. The Codex marketplace
+  `longDescription` and `defaultPrompt` entries now advertise
+  auto-setup and remove instead of split.
+
+### Removed
+
+- **`/harness-pair-dev --split` command.**
+  Split is no longer a single pair-dev command. The equivalent
+  workflow is a user-directed multi-step sequence of `--add` +
+  `--improve` + `--remove`. Running `--split` returns an explicit
+  "unsupported in v0.3.0" error pointing at the replacement steps.
+- **`/harness-pair-dev --improve --hint` flag.**
+  Revision intent now travels exclusively through the required
+  positional `<purpose>`. Running `--hint` returns an explicit
+  "unsupported in v0.3.0" error.
+
+### Migration
+
+For projects upgrading from v0.2.x to v0.3.0:
+
+1. Prefer `/harness-auto-setup` for existing-target refresh. It
+   snapshots `.harness/loom/` and `.harness/cycle/` before touching
+   anything and reconstructs valid registered pairs against current
+   templates, so manually tuned pair bodies are preserved as snapshot
+   evidence and folded back in through the overlay rules.
+2. If you previously invoked `/harness-pair-dev --split <slug>`,
+   replace it with an explicit `--add` + `--improve` + `--remove`
+   sequence. The clean-break error message names the replacement.
+3. If you previously invoked
+   `/harness-pair-dev --improve <slug> --hint "<text>"`, move the
+   hint body into the new required positional `<purpose>` argument.
+4. After any pair-dev mutation or auto-setup run, re-run
+   `node .harness/loom/sync.ts --provider <list>` from the target
+   root to refresh the derived platform trees.
+
 ## [0.2.2] — 2026-04-21
 
 ### Changed
@@ -519,7 +617,8 @@ First public release.
 - **Repo scaffolding** — README, CONTRIBUTING, SECURITY,
   CODE_OF_CONDUCT, PRIVACY, TERMS, and `.github/` issue + PR templates.
 
-[Unreleased]: https://github.com/KingGyuSuh/harness-loom/compare/v0.2.2...HEAD
+[Unreleased]: https://github.com/KingGyuSuh/harness-loom/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/KingGyuSuh/harness-loom/releases/tag/v0.3.0
 [0.2.2]: https://github.com/KingGyuSuh/harness-loom/releases/tag/v0.2.2
 [0.2.1]: https://github.com/KingGyuSuh/harness-loom/releases/tag/v0.2.1
 [0.2.0]: https://github.com/KingGyuSuh/harness-loom/releases/tag/v0.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,35 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- **Runtime and role output surfaces reduced to load-bearing fields.**
+  Dispatch envelopes now expose `Turn intent` as the subagent-facing
+  copy of `Next.Intent`, pair producer/reviewer output blocks no longer
+  carry generic advisory routing fields, planner output keeps the
+  load-bearing `next-action`, and finalizer verdicts remain anchored on
+  `Status` plus `Self-verification`. Structural routing now uses only
+  the shared `## Structural Issue` block.
+
+### Fixed
+
+- **Codex `[[skills.config]]` path silently failed to load skills.**
+  `sync.ts` emitted a relative `path = ".codex/skills/<slug>/SKILL.md"`
+  for every codex agent TOML. Codex resolves such paths against the
+  agent TOML's parent directory (`.codex/agents/`), producing
+  `.codex/agents/.codex/skills/<slug>/SKILL.md` — a location that does
+  not exist. `SkillConfig.path` is typed `AbsolutePathBuf` and the
+  canonicalize step no-ops on failure, so skills never loaded and no
+  error surfaced. The path is now absolute (`resolve(targetRoot,
+  ".codex", "skills", <slug>, "SKILL.md")`), which matches Codex's
+  documented examples and is also safe across the user-level
+  (`~/.codex/agents/`) and project-level layer merge, where a relative
+  path could silently bind to a different project's skill tree.
+  `.codex/` is gitignored, so the absolute prefix does not leak into
+  factory commits. **Existing target repos must re-run
+  `node .harness/loom/sync.ts --provider codex` to regenerate
+  `.codex/agents/*.toml`.**
+
 ## [0.3.0] — 2026-04-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,25 +15,15 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   load-bearing `next-action`, and finalizer verdicts remain anchored on
   `Status` plus `Self-verification`. Structural routing now uses only
   the shared `## Structural Issue` block.
-
-### Fixed
-
-- **Codex `[[skills.config]]` path silently failed to load skills.**
-  `sync.ts` emitted a relative `path = ".codex/skills/<slug>/SKILL.md"`
-  for every codex agent TOML. Codex resolves such paths against the
-  agent TOML's parent directory (`.codex/agents/`), producing
-  `.codex/agents/.codex/skills/<slug>/SKILL.md` — a location that does
-  not exist. `SkillConfig.path` is typed `AbsolutePathBuf` and the
-  canonicalize step no-ops on failure, so skills never loaded and no
-  error surfaced. The path is now absolute (`resolve(targetRoot,
-  ".codex", "skills", <slug>, "SKILL.md")`), which matches Codex's
-  documented examples and is also safe across the user-level
-  (`~/.codex/agents/`) and project-level layer merge, where a relative
-  path could silently bind to a different project's skill tree.
-  `.codex/` is gitignored, so the absolute prefix does not leak into
-  factory commits. **Existing target repos must re-run
-  `node .harness/loom/sync.ts --provider codex` to regenerate
-  `.codex/agents/*.toml`.**
+- **Codex and Gemini sync now injects required skill loading into agent
+  bodies.** `sync.ts` derives the required skills from canonical
+  `.harness/loom/agents/*.md` `skills:` frontmatter, prepends a
+  `Required Skill Loading` block to Codex `developer_instructions` and
+  Gemini agent bodies, and still mirrors skill directories under
+  `.codex/skills/` and `.gemini/skills/`. Codex no longer emits
+  `[[skills.config]]`; current experiments showed Codex subagents see
+  skill metadata by default but need explicit `$skill-name` mentions for
+  full body loading.
 
 ## [0.3.0] — 2026-04-22
 

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Re-run this command after any pair edits or finalizer edits. `.harness/loom/` is
 
 ### 3. Add The First Pairs
 
-Create pairs that match how work actually decomposes in your repo. Every pair slug must start with the `harness-` prefix, and every pair must include at least one reviewer.
+Create pairs that match how work actually decomposes in your repo. Canonical pair slugs use the `harness-` prefix, and every pair must include at least one reviewer. Assistants may accept a bare name such as `document`, but generated files and registry entries are always written as `harness-document`.
 
 ```text
 /harness-pair-dev --add harness-game-design "Spec snake.py features and edge cases"

--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ Project documentation (target-root `*.md` files, `docs/`) is authored **directly
 - **git** — recommended for reviewing generated harness changes and recovering local experiments through your normal VCS flow.
 - **At least one supported assistant CLI**, authenticated:
   - [Claude Code](https://code.claude.com/docs) — primary target; canonical staging in `.harness/loom/` is derived into `.claude/` via `node .harness/loom/sync.ts --provider claude`.
-  - [Codex CLI](https://developers.openai.com/codex/cli) — derived into `.codex/` via `node .harness/loom/sync.ts --provider codex`.
-  - [Gemini CLI](https://geminicli.com/docs/) — derived into `.gemini/` via `node .harness/loom/sync.ts --provider gemini`.
+  - [Codex CLI](https://developers.openai.com/codex/cli) — derived into `.codex/` via `node .harness/loom/sync.ts --provider codex`; generated agent TOMLs explicitly mention required `$skill-name` bodies.
+  - [Gemini CLI](https://geminicli.com/docs/) — derived into `.gemini/` via `node .harness/loom/sync.ts --provider gemini`; generated agent bodies name the required skills because Gemini frontmatter rejects `skills:`.
 
 ## Install The Factory
 
@@ -271,7 +271,7 @@ A few terms recur across commands, files, and state. Knowing these is enough to 
 |---------|---------|
 | `/harness-init [<target>]` | Scaffold the canonical `.harness/loom/` staging tree plus the `.harness/cycle/` runtime state into a target project. Writes runtime skills, the `harness-planner` agent, the generic `harness-finalizer` cycle-end skeleton, and the `hook.sh` + `sync.ts` self-contained copies under `.harness/loom/`. Seeds `state.md`, `events.md`, `epics/`, and `finalizer/tasks/`, but no goal or request snapshot placeholder. Rerunning install reseeds both namespaces. Touches no platform tree. |
 | `/harness-auto-setup [<target>] [--provider <list>]` | Safely set up or refresh a target harness. Fresh targets receive the foundation plus repo-grounded pair/finalizer recommendations. Existing targets are snapshotted under `.harness/_snapshots/auto-setup/`, active or unknown cycles are warned and preserved in the snapshot before discard/reseed, registered pairs and customized finalizer intent are reconstructed on current templates, and the command stops with an explicit sync handoff. Touches no platform tree. |
-| `node .harness/loom/sync.ts --provider <list>` | Deploy canonical `.harness/loom/` into platform trees (`.claude/`, `.codex/`, `.gemini/`). One-way; never writes back into `.harness/loom/`. Provider selection is explicit: a bare invocation with no provider flags is an error. |
+| `node .harness/loom/sync.ts --provider <list>` | Deploy canonical `.harness/loom/` into platform trees (`.claude/`, `.codex/`, `.gemini/`). One-way; never writes back into `.harness/loom/`. Provider selection is explicit: a bare invocation with no provider flags is an error. Claude keeps agent `skills:` frontmatter; Codex and Gemini receive required skill-loading prompts in generated agent bodies. |
 | `/harness-pair-dev --add <slug> "<purpose>" [--from <existing-pair>] [--reviewer <slug> ...] [--before <slug> \| --after <slug>]` | Author a new producer-reviewer pair anchored to the current codebase. `<purpose>` is required. `--from` accepts only a currently registered pair as a template-first overlay source: current harness shape stays fixed while compatible source domain guidance is preserved. It is not a snapshot, filesystem path, or provider-tree import. Default is 1:1; repeat `--reviewer` for 1:N reviewer topology. Authoring writes only into `.harness/loom/`; re-run `node .harness/loom/sync.ts --provider <list>` afterward. |
 | `/harness-pair-dev --improve <slug> "<purpose>" [--before <slug> \| --after <slug>]` | Improve an existing registered pair with positional `<purpose>` as the primary revision axis, then fold in rubric hygiene and current repo evidence. If a pair has become two different jobs, use explicit add/improve/remove steps. Re-run sync afterward to refresh platform trees. |
 | `/harness-pair-dev --remove <slug>` | Safely unregister a pair and delete only pair-owned `.harness/loom/` files. Removal refuses foundation/singleton targets and active-cycle references in `## Next` or live EPIC roster/current fields before mutating, preserves `.harness/cycle/` task/review history, and touches no provider tree; re-run sync afterward. |
@@ -315,8 +315,8 @@ Platform pins applied by `sync.ts`:
 | Platform | Model | Hook event | Notes |
 |----------|-------|------------|-------|
 | Claude | `inherit` | `Stop` | `.claude/settings.json` triggers `.harness/loom/hook.sh`. |
-| Codex | `gpt-5.4`, `model_reasoning_effort: xhigh` | `Stop` | Subagents do not use mini models. |
-| Gemini | `gemini-3.1-pro-preview` | `AfterAgent` | Skills are mirrored into the platform tree. |
+| Codex | `gpt-5.4`, `model_reasoning_effort: xhigh` | `Stop` | Agent TOMLs prepend required `$skill-name` mentions to `developer_instructions`; skills are mirrored under `.codex/skills/`. |
+| Gemini | `gemini-3.1-pro-preview` | `AfterAgent` | Agent bodies name the required skills; skills are mirrored under `.gemini/skills/`. |
 
 ## When To Use It
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [English](README.md) | [한국어](docs/README.ko.md) | [日本語](docs/README.ja.md) | [简体中文](docs/README.zh-CN.md) | [Español](docs/README.es.md)
 
-[![Version](https://img.shields.io/badge/version-0.2.2-blue.svg)](./CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.3.0-blue.svg)](./CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](./LICENSE)
 [![Platforms](https://img.shields.io/badge/platforms-Claude%20Code%20%7C%20Codex%20%7C%20Gemini-purple.svg)](#multi-platform)
 
@@ -20,14 +20,14 @@ Once your chosen model stack is already capable enough to produce production-qua
 
 `harness-loom` is for teams that already see production-quality potential in their assistant stack and now want it to behave like a system rather than a session.
 
-This repo is the factory. It seeds a target-side runtime harness made of:
+This repo is the factory. It seeds or converges a target-side runtime harness made of:
 
 - a planner and orchestrator
 - a shared control plane under `.harness/`
 - a common runtime context for all subagents
 - project-specific producer-reviewer pairs that you add over time
 
-A target's `.harness/` is split into two sibling namespaces — `loom/` is the canonical staging tree owned by install and sync, and `cycle/` holds runtime state owned by the orchestrator. Out-of-cycle artifacts (target-root `*.md`, `docs/`, release notes, audit output) are written directly at the target root by the cycle-end **Finalizer** turn, not inside `.harness/`. Platform trees (`.claude/`, `.codex/`, `.gemini/`) are derived from `.harness/loom/` on demand.
+A target's `.harness/` is split into two sibling namespaces — `loom/` is the canonical staging tree owned by setup and pair authoring, and `cycle/` holds runtime state owned by the orchestrator. Out-of-cycle artifacts (target-root `*.md`, `docs/`, release notes, audit output) are written directly at the target root by the cycle-end **Finalizer** turn, not inside `.harness/`. Platform trees (`.claude/`, `.codex/`, `.gemini/`) are derived from `.harness/loom/` on demand.
 
 ## Why This Shape
 
@@ -39,12 +39,12 @@ A target's `.harness/` is split into two sibling namespaces — `loom/` is the c
 
 ## What Gets Installed
 
-When you run `/harness-init` inside a target repository, `harness-loom` installs a runtime harness rather than a one-off prompt template.
+When you run `/harness-init` inside a target repository, `harness-loom` installs a runtime harness rather than a one-off prompt template. When you run `/harness-auto-setup`, it uses that same foundation installer inside a safer setup/refresh workflow.
 
 ```text
 target project
 └── .harness/
-    ├── loom/                    # canonical staging (install + sync own)
+    ├── loom/                    # canonical staging (setup + pair authoring own; sync reads)
     │   ├── skills/
     │   │   ├── harness-orchestrate/
     │   │   ├── harness-planning/
@@ -58,15 +58,19 @@ target project
     │   ├── state.md
     │   ├── events.md
     │   └── epics/
+    ├── _snapshots/              # auto-setup provenance, when convergence runs
+    │   └── auto-setup/
     └── _archive/                # past cycles, created on goal-different reset
 ```
 
 Project documentation (target-root `*.md` files, `docs/`) is authored **directly in the target**, not inside `.harness/`. You then derive at least one platform tree with `node .harness/loom/sync.ts --provider claude` (and add `codex,gemini` for multi-platform), then add domain-specific pairs with `/harness-pair-dev`. The orchestrator runs as a four-state DFA — `Planner | Pair | Finalizer | Halt`. When every EPIC reaches terminal and the planner is done, it enters the **Finalizer state** and dispatches the singleton `harness-finalizer` agent before halting. The seeded `harness-finalizer` agent is a generic skeleton; you replace its body with the concrete cycle-end work this project needs — documentation refresh (`CLAUDE.md`, `AGENTS.md`, `docs/`), goal-coverage inspection against `events.md`, release prep, audit output, etc. You do not invoke the finalizer directly; the orchestrator dispatches it as the cycle-end turn before halting.
 
+`/harness-auto-setup` is the safer entry point for first setup or refresh. On a fresh target it seeds the foundation and emits repo-grounded pair/finalizer recommendations. On an existing target it snapshots live `.harness/loom/` and `.harness/cycle/` state under `.harness/_snapshots/auto-setup/<timestamp>/`, warns when the cycle looks active or unknown, refreshes the foundation, reconstructs valid registered pairs and customized finalizer intent on current templates, and stops with an explicit sync command. It never writes `.claude/`, `.codex/`, or `.gemini/` itself.
+
 ## Requirements
 
 - **Node.js ≥ 22.6** — scripts run via native TypeScript stripping; no build step, no `package.json`.
-- **git** — pair authoring relies on git history for rollback on `--split`.
+- **git** — recommended for reviewing generated harness changes and recovering local experiments through your normal VCS flow.
 - **At least one supported assistant CLI**, authenticated:
   - [Claude Code](https://code.claude.com/docs) — primary target; canonical staging in `.harness/loom/` is derived into `.claude/` via `node .harness/loom/sync.ts --provider claude`.
   - [Codex CLI](https://developers.openai.com/codex/cli) — derived into `.codex/` via `node .harness/loom/sync.ts --provider codex`.
@@ -77,7 +81,7 @@ Project documentation (target-root `*.md` files, `docs/`) is authored **directly
 There are two installs in practice:
 
 1. Install the **factory plugin** into Claude Code or Codex CLI.
-2. Inside each target repository, run `/harness-init` to seed `.harness/`, then `node .harness/loom/sync.ts --provider <list>` to deploy the assistant-specific runtime trees you actually want to use.
+2. Inside each target repository, run `/harness-auto-setup` to seed or converge `.harness/`, then `node .harness/loom/sync.ts --provider <list>` to deploy the assistant-specific runtime trees you actually want to use.
 
 The factory ships in the standard `plugins/<name>/` monorepo layout — the repo root holds `.claude-plugin/marketplace.json` and `.agents/plugins/marketplace.json`, and the actual plugin tree lives under `plugins/harness-loom/`.
 
@@ -133,7 +137,7 @@ Then, inside the Codex TUI, run `/plugins`, open the `Harness Loom` marketplace 
 
 Use Claude Code or Codex CLI to install the factory, then derive `.gemini/` inside the target project:
 
-1. From Claude Code or Codex CLI, install the factory and run `/harness-init` + `node .harness/loom/sync.ts --provider gemini` inside your target project. This deploys the target-side runtime (`.harness/loom/`, `.harness/cycle/`, `.gemini/agents/`, `.gemini/skills/`, `.gemini/settings.json` with `AfterAgent` hook).
+1. From Claude Code or Codex CLI, install the factory and run `/harness-auto-setup --provider gemini`, then `node .harness/loom/sync.ts --provider gemini` inside your target project. This deploys the target-side runtime (`.harness/loom/`, `.harness/cycle/`, `.gemini/agents/`, `.gemini/skills/`, `.gemini/settings.json` with `AfterAgent` hook).
 2. `cd` into that target project and run `gemini`. The CLI auto-loads workspace-scope `.gemini/agents/*.md`, `.gemini/skills/<slug>/SKILL.md`, and the `AfterAgent` hook from `.gemini/settings.json`.
 3. Your orchestrator cycle runs on Gemini end-to-end — factory authoring remains on Claude/Codex, execution can be any of the three.
 
@@ -141,15 +145,29 @@ Use Claude Code or Codex CLI to install the factory, then derive `.gemini/` insi
 
 Once the factory is installed in your assistant, the usual target-repo flow is:
 
-1. Seed `.harness/` with `/harness-init`.
+1. Seed or converge `.harness/` with `/harness-auto-setup`.
 2. Deploy at least one assistant runtime tree with `sync.ts`.
 3. Add the first producer-reviewer pairs for your repo.
 4. Optionally customize the cycle-end finalizer.
 5. Run `/harness-orchestrate <goal.md>`.
 
-### 1. Initialize The Target Repository
+### 1. Setup Or Refresh The Target Repository
 
 Open the target repository in Claude Code or Codex CLI and run:
+
+```text
+/harness-auto-setup --provider claude
+```
+
+Use a comma-separated provider list when you know the platform trees you will refresh:
+
+```text
+/harness-auto-setup --provider claude,codex,gemini
+```
+
+This seeds a fresh target through the foundation installer. If the target already has `.harness/loom/` or `.harness/cycle/`, it snapshots those namespaces before refresh, preserves active or unparsable cycle state in the snapshot before discard/reseed, rebuilds valid registered pair files and customized finalizer intent from current templates, and prints the exact `node .harness/loom/sync.ts --provider <list>` command to run next. The snapshot is machine provenance and convergence evidence, not a restored source of truth.
+
+If you only want a foundation reset with no convergence, run:
 
 ```text
 /harness-init
@@ -157,7 +175,7 @@ Open the target repository in Claude Code or Codex CLI and run:
 
 This writes the canonical staging tree under `.harness/loom/` and the runtime state scaffold under `.harness/cycle/`. It does not create `.claude/`, `.codex/`, or `.gemini/` yet.
 
-If you rerun `/harness-init` later, treat it as a reset of the target-side harness scaffolding: pair-authored `.harness/loom/` content and the current `.harness/cycle/` state are reseeded rather than preserved.
+If you rerun `/harness-init` later, treat it as a reset of the target-side harness scaffolding: pair-authored `.harness/loom/` content and the current `.harness/cycle/` state are reseeded rather than preserved. Use `/harness-auto-setup` for existing targets when you want snapshot-first refresh and current-contract reconstruction.
 
 ### 2. Deploy The Assistant Runtime You Actually Want To Use
 
@@ -184,7 +202,7 @@ Create pairs that match how work actually decomposes in your repo. Every pair sl
 /harness-pair-dev --add harness-impl "Implement snake.py against the spec" --reviewer harness-code-reviewer --reviewer harness-playtest-reviewer
 ```
 
-After authoring or improving pairs, run `sync.ts` again so the platform trees pick up the new agents and skills.
+After authoring, improving, or removing pairs, run `node .harness/loom/sync.ts --provider <list>` again so the platform trees pick up the current agents and skills.
 
 ### 4. Customize The Finalizer If You Need Cycle-End Work
 
@@ -219,7 +237,7 @@ Artifacts land under `.harness/cycle/epics/EP-N--<slug>/{tasks,reviews}/`. Runti
 
 Most users only need to customize three things:
 
-- **Pairs** — add, improve, and split producer-reviewer pairs until they reflect your repo's actual work decomposition and review axes.
+- **Pairs** — add, improve, and remove producer-reviewer pairs until they reflect your repo's actual work decomposition and review axes. If one pair has become two different jobs, add or improve the replacements explicitly, then remove the old pair.
 - **Finalizer body** — replace the default no-op only if your project needs cycle-end work at the target root.
 - **Goal files** — each cycle starts from a user-authored goal, usually `goal.md`.
 
@@ -250,10 +268,11 @@ A few terms recur across commands, files, and state. Knowing these is enough to 
 | Command | Purpose |
 |---------|---------|
 | `/harness-init [<target>]` | Scaffold the canonical `.harness/loom/` staging tree plus the `.harness/cycle/` runtime state into a target project. Writes runtime skills, the `harness-planner` agent, the generic `harness-finalizer` cycle-end skeleton, and the `hook.sh` + `sync.ts` self-contained copies under `.harness/loom/`. Rerunning install reseeds both namespaces. Touches no platform tree. |
+| `/harness-auto-setup [<target>] [--provider <list>]` | Safely set up or refresh a target harness. Fresh targets receive the foundation plus repo-grounded pair/finalizer recommendations. Existing targets are snapshotted under `.harness/_snapshots/auto-setup/`, active or unknown cycles are warned and preserved in the snapshot before discard/reseed, registered pairs and customized finalizer intent are reconstructed on current templates, and the command stops with an explicit sync handoff. Touches no platform tree. |
 | `node .harness/loom/sync.ts --provider <list>` | Deploy canonical `.harness/loom/` into platform trees (`.claude/`, `.codex/`, `.gemini/`). One-way; never writes back into `.harness/loom/`. Provider selection is explicit: a bare invocation with no provider flags is an error. |
-| `/harness-pair-dev --add <slug> "<purpose>" [--reviewer <slug> ...]` | Author a new producer-reviewer pair anchored to the current codebase. `<purpose>` is a positional second argument. Default is 1:1; repeat `--reviewer` for 1:N reviewer topology. Every pair carries at least one reviewer — cycle-end reviewer-less work belongs in the singleton `harness-finalizer`, not in the pair roster. Authoring writes only into `.harness/loom/`; re-run `node .harness/loom/sync.ts --provider <list>` afterward. |
-| `/harness-pair-dev --improve <slug> [--hint "<text>"]` | Re-audit an existing pair against the rubric and current codebase, then improve it. Re-run sync afterward to refresh platform trees. |
-| `/harness-pair-dev --split <slug>` | Split an overloaded pair into two narrower pairs. Re-run sync afterward. |
+| `/harness-pair-dev --add <slug> "<purpose>" [--from <existing-pair>] [--reviewer <slug> ...] [--before <slug> \| --after <slug>]` | Author a new producer-reviewer pair anchored to the current codebase. `<purpose>` is required. `--from` accepts only a currently registered pair as a template-first overlay source: current harness shape stays fixed while compatible source domain guidance is preserved. It is not a snapshot, filesystem path, or provider-tree import. Default is 1:1; repeat `--reviewer` for 1:N reviewer topology. Authoring writes only into `.harness/loom/`; re-run `node .harness/loom/sync.ts --provider <list>` afterward. |
+| `/harness-pair-dev --improve <slug> "<purpose>" [--before <slug> \| --after <slug>]` | Improve an existing registered pair with positional `<purpose>` as the primary revision axis, then fold in rubric hygiene and current repo evidence. If a pair has become two different jobs, use explicit add/improve/remove steps. Re-run sync afterward to refresh platform trees. |
+| `/harness-pair-dev --remove <slug>` | Safely unregister a pair and delete only pair-owned `.harness/loom/` files. Removal refuses foundation/singleton targets and active-cycle references in `## Next` or live EPIC roster/current fields before mutating, preserves `.harness/cycle/` task/review history, and touches no provider tree; re-run sync afterward. |
 | `/harness-orchestrate <goal.md>` | Target-side runtime entry point. Reads the goal and runs a four-state DFA (`Planner | Pair | Finalizer | Halt`) dispatching exactly one producer per response; hook re-entry advances the cycle. When every EPIC reaches terminal, the orchestrator enters the Finalizer state and dispatches the singleton `harness-finalizer` before halting. |
 
 ## Factory And Runtime
@@ -264,6 +283,8 @@ factory (this repo)                            target project
 plugins/harness-loom/skills/harness-init/          installs ->      .harness/loom/{skills,agents,hook.sh,sync.ts}
 plugins/harness-loom/skills/harness-init/                            .harness/cycle/{state.md,events.md,epics/}
 plugins/harness-loom/skills/harness-init/references/runtime/ seeds -> .harness/loom/skills/<slug>/SKILL.md
+plugins/harness-loom/skills/harness-auto-setup/    converges ->     .harness/_snapshots/auto-setup/<timestamp>/
+                                                                    .harness/loom/ + .harness/cycle/ refreshed
 plugins/harness-loom/skills/harness-pair-dev/      authors  ->      .harness/loom/agents/<slug>-producer.md
                                                                     .harness/loom/agents/<reviewer>.md
                                                                     .harness/loom/skills/<slug>/SKILL.md

--- a/README.md
+++ b/README.md
@@ -57,13 +57,15 @@ target project
     ├── cycle/                   # runtime state (orchestrator owns)
     │   ├── state.md
     │   ├── events.md
-    │   └── epics/
+    │   ├── epics/
+    │   └── finalizer/
+    │       └── tasks/
     ├── _snapshots/              # auto-setup provenance, when convergence runs
     │   └── auto-setup/
     └── _archive/                # past cycles, created on goal-different reset
 ```
 
-Project documentation (target-root `*.md` files, `docs/`) is authored **directly in the target**, not inside `.harness/`. You then derive at least one platform tree with `node .harness/loom/sync.ts --provider claude` (and add `codex,gemini` for multi-platform), then add domain-specific pairs with `/harness-pair-dev`. The orchestrator runs as a four-state DFA — `Planner | Pair | Finalizer | Halt`. When every EPIC reaches terminal and the planner is done, it enters the **Finalizer state** and dispatches the singleton `harness-finalizer` agent before halting. The seeded `harness-finalizer` agent is a generic skeleton; you replace its body with the concrete cycle-end work this project needs — documentation refresh (`CLAUDE.md`, `AGENTS.md`, `docs/`), goal-coverage inspection against `events.md`, release prep, audit output, etc. You do not invoke the finalizer directly; the orchestrator dispatches it as the cycle-end turn before halting.
+Project documentation (target-root `*.md` files, `docs/`) is authored **directly in the target**, not inside `.harness/`. You then derive at least one platform tree with `node .harness/loom/sync.ts --provider claude` (and add `codex,gemini` for multi-platform), then add domain-specific pairs with `/harness-pair-dev`. The install scaffold does not create request snapshots. On direct `/harness-orchestrate <file.md>` entry, the orchestrator preserves the full request body in `.harness/cycle/user-request-snapshot.md` and keeps `state.md`'s `Goal` header as a compact summary. The orchestrator runs as a four-state DFA — `Planner | Pair | Finalizer | Halt`. When every EPIC reaches terminal and no planner continuation remains, it enters the **Finalizer state** and dispatches the singleton `harness-finalizer` agent before halting. The seeded `harness-finalizer` agent is a generic skeleton; you replace its body with the concrete cycle-end work this project needs — documentation refresh (`CLAUDE.md`, `AGENTS.md`, `docs/`), request-coverage inspection against `events.md` and the user request snapshot, release prep, audit output, etc. You do not invoke the finalizer directly; the orchestrator dispatches it as the cycle-end turn before halting.
 
 `/harness-auto-setup` is the safer entry point for first setup or refresh. On a fresh target it seeds the foundation and emits repo-grounded pair/finalizer recommendations. On an existing target it snapshots live `.harness/loom/` and `.harness/cycle/` state under `.harness/_snapshots/auto-setup/<timestamp>/`, warns when the cycle looks active or unknown, refreshes the foundation, reconstructs valid registered pairs and customized finalizer intent on current templates, and stops with an explicit sync command. It never writes `.claude/`, `.codex/`, or `.gemini/` itself.
 
@@ -149,7 +151,7 @@ Once the factory is installed in your assistant, the usual target-repo flow is:
 2. Deploy at least one assistant runtime tree with `sync.ts`.
 3. Add the first producer-reviewer pairs for your repo.
 4. Optionally customize the cycle-end finalizer.
-5. Run `/harness-orchestrate <goal.md>`.
+5. Run `/harness-orchestrate <file.md>`.
 
 ### 1. Setup Or Refresh The Target Repository
 
@@ -173,7 +175,7 @@ If you only want a foundation reset with no convergence, run:
 /harness-init
 ```
 
-This writes the canonical staging tree under `.harness/loom/` and the runtime state scaffold under `.harness/cycle/`. It does not create `.claude/`, `.codex/`, or `.gemini/` yet.
+This writes the canonical staging tree under `.harness/loom/` and the runtime state scaffold under `.harness/cycle/`. It seeds `state.md`, `events.md`, `epics/`, and `finalizer/tasks/`; it does not create goal/request snapshot placeholders, `.claude/`, `.codex/`, or `.gemini/`.
 
 If you rerun `/harness-init` later, treat it as a reset of the target-side harness scaffolding: pair-authored `.harness/loom/` content and the current `.harness/cycle/` state are reseeded rather than preserved. Use `/harness-auto-setup` for existing targets when you want snapshot-first refresh and current-contract reconstruction.
 
@@ -221,7 +223,7 @@ After editing the finalizer body, run `sync.ts` again to deploy the updated agen
 
 ### 5. Run The First Cycle
 
-Create a goal file and start the orchestrator:
+Create a request file and start the orchestrator:
 
 ```bash
 cat > goal.md <<'EOF'
@@ -231,7 +233,7 @@ EOF
 /harness-orchestrate goal.md
 ```
 
-Artifacts land under `.harness/cycle/epics/EP-N--<slug>/{tasks,reviews}/`. Runtime state lives in `.harness/cycle/state.md`, and the append-only event log lives in `.harness/cycle/events.md`. When every live EPIC reaches terminal, the orchestrator enters the **Finalizer state**, runs the singleton `harness-finalizer`, and halts.
+Artifacts land under `.harness/cycle/epics/EP-N--<slug>/{tasks,reviews}/`. Runtime state lives in `.harness/cycle/state.md`, the full original request lives in `.harness/cycle/user-request-snapshot.md`, and the append-only event log lives in `.harness/cycle/events.md`. When every live EPIC reaches terminal and no planner continuation remains, the orchestrator enters the **Finalizer state**, runs the singleton `harness-finalizer`, and halts.
 
 ## What You Usually Customize
 
@@ -239,7 +241,7 @@ Most users only need to customize three things:
 
 - **Pairs** — add, improve, and remove producer-reviewer pairs until they reflect your repo's actual work decomposition and review axes. If one pair has become two different jobs, add or improve the replacements explicitly, then remove the old pair.
 - **Finalizer body** — replace the default no-op only if your project needs cycle-end work at the target root.
-- **Goal files** — each cycle starts from a user-authored goal, usually `goal.md`.
+- **Cycle request files** — each cycle starts from a user-authored request file, often named `goal.md`. The orchestrator preserves the full body in `.harness/cycle/user-request-snapshot.md` and passes that path through dispatch envelopes as `User request snapshot`; `Goal` remains a compact summary.
 
 Most users do **not** need to edit these by hand:
 
@@ -257,23 +259,23 @@ A few terms recur across commands, files, and state. Knowing these is enough to 
 
 - **Harness** — the persistent layer around the assistant: state files, hooks, subagents, contracts. `harness-loom` shapes this layer to fit your repo.
 - **Pair** — one **producer** plus one or more **reviewers**, sharing a single `SKILL.md`. The authoring unit of domain work.
-- **Producer** — the subagent that performs work for a task (writes code, specs, analysis) and proposes the next action.
-- **Reviewer** — a subagent that grades the producer's output on a specific axis (code quality, spec fit, security, etc.). A pair can fan out to many reviewers, each graded independently.
+- **Producer** — the subagent that performs work for a task (writes code, specs, analysis) and returns the task artifact. Its `Status` is self-report only; reviewers decide the Pair verdict.
+- **Reviewer** — a subagent that grades the producer's output on a specific axis (code quality, spec fit, security, etc.). A pair can fan out to many reviewers, each graded independently; their `Verdict` values are the Pair turn's load-bearing verdict source.
 - **EPIC / Task** — an EPIC is a unit of outcome emitted by the planner; a Task is a single producer-reviewer round inside that EPIC. Artifacts land under `.harness/cycle/epics/EP-N--<slug>/{tasks,reviews}/`.
 - **Orchestrator vs Planner** — the **orchestrator** owns `.harness/cycle/state.md` and runs as a four-state DFA (`Planner | Pair | Finalizer | Halt`), dispatching exactly one producer per response (Pair turns run a producer plus 1 or M reviewers in parallel; Finalizer turns run a single cycle-end agent with no reviewer). The **planner** runs inside that loop to decompose the goal into EPICs, choose each EPIC's applicable slice of the fixed global roster, and declare same-stage upstream gates across EPICs.
-- **Finalizer** — the cycle-end hook. The runtime ships one singleton `harness-finalizer` agent that runs when every EPIC is terminal. It has no paired reviewer; verdict is the finalizer's own `Status` plus mechanical `Self-verification` evidence. The default seeded `harness-finalizer` is a generic skeleton; the project replaces its body with the concrete cycle-end work it needs.
+- **Finalizer** — the cycle-end hook. The runtime ships one singleton `harness-finalizer` agent that runs when every EPIC is terminal and no planner continuation remains. It has no paired reviewer; verdict is the finalizer's own `Status` plus mechanical `Self-verification` evidence. The default seeded `harness-finalizer` is a generic skeleton; the project replaces its body with the concrete cycle-end work it needs.
 
 ## Commands
 
 | Command | Purpose |
 |---------|---------|
-| `/harness-init [<target>]` | Scaffold the canonical `.harness/loom/` staging tree plus the `.harness/cycle/` runtime state into a target project. Writes runtime skills, the `harness-planner` agent, the generic `harness-finalizer` cycle-end skeleton, and the `hook.sh` + `sync.ts` self-contained copies under `.harness/loom/`. Rerunning install reseeds both namespaces. Touches no platform tree. |
+| `/harness-init [<target>]` | Scaffold the canonical `.harness/loom/` staging tree plus the `.harness/cycle/` runtime state into a target project. Writes runtime skills, the `harness-planner` agent, the generic `harness-finalizer` cycle-end skeleton, and the `hook.sh` + `sync.ts` self-contained copies under `.harness/loom/`. Seeds `state.md`, `events.md`, `epics/`, and `finalizer/tasks/`, but no goal or request snapshot placeholder. Rerunning install reseeds both namespaces. Touches no platform tree. |
 | `/harness-auto-setup [<target>] [--provider <list>]` | Safely set up or refresh a target harness. Fresh targets receive the foundation plus repo-grounded pair/finalizer recommendations. Existing targets are snapshotted under `.harness/_snapshots/auto-setup/`, active or unknown cycles are warned and preserved in the snapshot before discard/reseed, registered pairs and customized finalizer intent are reconstructed on current templates, and the command stops with an explicit sync handoff. Touches no platform tree. |
 | `node .harness/loom/sync.ts --provider <list>` | Deploy canonical `.harness/loom/` into platform trees (`.claude/`, `.codex/`, `.gemini/`). One-way; never writes back into `.harness/loom/`. Provider selection is explicit: a bare invocation with no provider flags is an error. |
 | `/harness-pair-dev --add <slug> "<purpose>" [--from <existing-pair>] [--reviewer <slug> ...] [--before <slug> \| --after <slug>]` | Author a new producer-reviewer pair anchored to the current codebase. `<purpose>` is required. `--from` accepts only a currently registered pair as a template-first overlay source: current harness shape stays fixed while compatible source domain guidance is preserved. It is not a snapshot, filesystem path, or provider-tree import. Default is 1:1; repeat `--reviewer` for 1:N reviewer topology. Authoring writes only into `.harness/loom/`; re-run `node .harness/loom/sync.ts --provider <list>` afterward. |
 | `/harness-pair-dev --improve <slug> "<purpose>" [--before <slug> \| --after <slug>]` | Improve an existing registered pair with positional `<purpose>` as the primary revision axis, then fold in rubric hygiene and current repo evidence. If a pair has become two different jobs, use explicit add/improve/remove steps. Re-run sync afterward to refresh platform trees. |
 | `/harness-pair-dev --remove <slug>` | Safely unregister a pair and delete only pair-owned `.harness/loom/` files. Removal refuses foundation/singleton targets and active-cycle references in `## Next` or live EPIC roster/current fields before mutating, preserves `.harness/cycle/` task/review history, and touches no provider tree; re-run sync afterward. |
-| `/harness-orchestrate <goal.md>` | Target-side runtime entry point. Reads the goal and runs a four-state DFA (`Planner | Pair | Finalizer | Halt`) dispatching exactly one producer per response; hook re-entry advances the cycle. When every EPIC reaches terminal, the orchestrator enters the Finalizer state and dispatches the singleton `harness-finalizer` before halting. |
+| `/harness-orchestrate <file.md>` | Target-side runtime entry point. Reads the request file, preserves its full body in `.harness/cycle/user-request-snapshot.md`, and runs a four-state DFA (`Planner | Pair | Finalizer | Halt`) dispatching exactly one producer per response; hook re-entry advances the cycle from `state.md` and the existing snapshot path. When every EPIC reaches terminal and planner continuation is clear, the orchestrator enters the Finalizer state and dispatches the singleton `harness-finalizer` before halting. |
 
 ## Factory And Runtime
 
@@ -281,7 +283,7 @@ A few terms recur across commands, files, and state. Knowing these is enough to 
 factory (this repo)                            target project
 -----------------------------------------      ----------------------------------
 plugins/harness-loom/skills/harness-init/          installs ->      .harness/loom/{skills,agents,hook.sh,sync.ts}
-plugins/harness-loom/skills/harness-init/                            .harness/cycle/{state.md,events.md,epics/}
+plugins/harness-loom/skills/harness-init/                            .harness/cycle/{state.md,events.md,epics/,finalizer/tasks/}
 plugins/harness-loom/skills/harness-init/references/runtime/ seeds -> .harness/loom/skills/<slug>/SKILL.md
 plugins/harness-loom/skills/harness-auto-setup/    converges ->     .harness/_snapshots/auto-setup/<timestamp>/
                                                                     .harness/loom/ + .harness/cycle/ refreshed

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -36,7 +36,7 @@
   Mejora un pair registrado usando el purpose posicional como eje principal.
 - `/harness-pair-dev --remove <slug>`
   Rechaza la eliminación si el ciclo activo referencia ese pair, conserva el historial de `.harness/cycle/` y elimina sólo archivos loom propios del pair.
-- `/harness-orchestrate <goal.md>`
+- `/harness-orchestrate <file.md>`
   Ejecuta el orchestrator de runtime en el proyecto objetivo.
 
 Los cambios de `/harness-pair-dev` escriben sólo en `.harness/loom/`. Después de add/improve/remove, vuelve a ejecutar `node .harness/loom/sync.ts --provider <list>` para refrescar los árboles de plataforma.

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -4,7 +4,7 @@
 
 [English](../README.md) | [한국어](README.ko.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md) | [Español](README.es.md)
 
-[![Version](https://img.shields.io/badge/version-0.2.2-blue.svg)](../CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.3.0-blue.svg)](../CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](../LICENSE)
 [![Platforms](https://img.shields.io/badge/platforms-Claude%20Code%20%7C%20Codex%20%7C%20Gemini-purple.svg)](../README.md#multi-platform)
 
@@ -12,7 +12,7 @@
 
 <br clear="left" />
 
-> **Estado:** 0.2.2
+> **Estado:** 0.3.0
 
 ## Resumen actual
 
@@ -24,18 +24,22 @@
 
 ## Comandos principales
 
+- `/harness-auto-setup [<target>] [--provider <list>]`
+  Configura por primera vez el proyecto objetivo o actualiza un harness existente después de tomar un snapshot.
 - `/harness-init [<target>]`
-  Instala el runtime basado en `.harness/loom/` y `.harness/cycle/` dentro del proyecto objetivo.
+  Instala o reinicia el runtime base de `.harness/loom/` y `.harness/cycle/` dentro del proyecto objetivo.
 - `node .harness/loom/sync.ts --provider claude,codex,gemini`
   Despliega el canonical staging hacia los árboles de plataforma necesarios.
-- `/harness-pair-dev --add <slug> "<purpose>" [--reviewer <slug> ...]`
-  Crea un nuevo pair producer-reviewer basado en el código actual.
-- `/harness-pair-dev --improve <slug> [--hint "<text>"]`
-  Mejora un pair existente apoyándose en evidencia real del repositorio.
-- `/harness-pair-dev --split <slug>`
-  Divide un pair demasiado amplio en dos pairs más estrechos.
+- `/harness-pair-dev --add <slug> "<purpose>" [--from <existing-pair>] [--reviewer <slug> ...]`
+  Usa sólo un pair actualmente registrado como overlay source de `--from` y crea el nuevo pair en `.harness/loom/` preservando el conocimiento compatible sobre el template actual.
+- `/harness-pair-dev --improve <slug> "<purpose>"`
+  Mejora un pair registrado usando el purpose posicional como eje principal.
+- `/harness-pair-dev --remove <slug>`
+  Rechaza la eliminación si el ciclo activo referencia ese pair, conserva el historial de `.harness/cycle/` y elimina sólo archivos loom propios del pair.
 - `/harness-orchestrate <goal.md>`
   Ejecuta el orchestrator de runtime en el proyecto objetivo.
+
+Los cambios de `/harness-pair-dev` escriben sólo en `.harness/loom/`. Después de add/improve/remove, vuelve a ejecutar `node .harness/loom/sync.ts --provider <list>` para refrescar los árboles de plataforma.
 
 ## Dónde seguir leyendo
 

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -4,7 +4,7 @@
 
 [English](../README.md) | [한국어](README.ko.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md) | [Español](README.es.md)
 
-[![Version](https://img.shields.io/badge/version-0.2.2-blue.svg)](../CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.3.0-blue.svg)](../CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](../LICENSE)
 [![Platforms](https://img.shields.io/badge/platforms-Claude%20Code%20%7C%20Codex%20%7C%20Gemini-purple.svg)](../README.md#multi-platform)
 
@@ -12,7 +12,7 @@
 
 <br clear="left" />
 
-> **ステータス:** 0.2.2
+> **ステータス:** 0.3.0
 
 ## 現在の要点
 
@@ -24,18 +24,22 @@
 
 ## 主なコマンド
 
+- `/harness-auto-setup [<target>] [--provider <list>]`
+  対象プロジェクトを初期セットアップするか、既存 harness をスナップショットしてから現在の契約に合わせて更新します。
 - `/harness-init [<target>]`
-  対象プロジェクトに `.harness/loom/` と `.harness/cycle/` ベースのランタイムを導入します。
+  対象プロジェクトに `.harness/loom/` と `.harness/cycle/` ベースの基盤ランタイムを導入または再初期化します。
 - `node .harness/loom/sync.ts --provider claude,codex,gemini`
   canonical staging を必要なプラットフォームツリーへ配備します。
-- `/harness-pair-dev --add <slug> "<purpose>" [--reviewer <slug> ...]`
-  現在のコードベースに合わせて新しい producer-reviewer pair を作成します。
-- `/harness-pair-dev --improve <slug> [--hint "<text>"]`
-  既存 pair をリポジトリ根拠に基づいて改善します。
-- `/harness-pair-dev --split <slug>`
-  肥大化した pair を、より狭い 2 つの pair に分割します。
+- `/harness-pair-dev --add <slug> "<purpose>" [--from <existing-pair>] [--reviewer <slug> ...]`
+  現在登録されている pair だけを `--from` の overlay source として受け取り、最新 template 上で互換性のある元の知識を保ちながら `.harness/loom/` に作成します。
+- `/harness-pair-dev --improve <slug> "<purpose>"`
+  positional purpose を主軸にして、既存の登録済み pair を改善します。
+- `/harness-pair-dev --remove <slug>`
+  active cycle がその pair を参照している場合は拒否し、`.harness/cycle/` history を残したまま pair-owned loom ファイルだけを安全に削除します。
 - `/harness-orchestrate <goal.md>`
   対象側ランタイムの orchestrator を起動します。
+
+`/harness-pair-dev` の変更は `.harness/loom/` にだけ書き込まれます。add/improve/remove の後は `node .harness/loom/sync.ts --provider <list>` を再実行してプラットフォームツリーを更新します。
 
 ## 参照先
 

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -36,7 +36,7 @@
   positional purpose を主軸にして、既存の登録済み pair を改善します。
 - `/harness-pair-dev --remove <slug>`
   active cycle がその pair を参照している場合は拒否し、`.harness/cycle/` history を残したまま pair-owned loom ファイルだけを安全に削除します。
-- `/harness-orchestrate <goal.md>`
+- `/harness-orchestrate <file.md>`
   対象側ランタイムの orchestrator を起動します。
 
 `/harness-pair-dev` の変更は `.harness/loom/` にだけ書き込まれます。add/improve/remove の後は `node .harness/loom/sync.ts --provider <list>` を再実行してプラットフォームツリーを更新します。

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -4,7 +4,7 @@
 
 [English](../README.md) | [한국어](README.ko.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md) | [Español](README.es.md)
 
-[![Version](https://img.shields.io/badge/version-0.2.2-blue.svg)](../CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.3.0-blue.svg)](../CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](../LICENSE)
 [![Platforms](https://img.shields.io/badge/platforms-Claude%20Code%20%7C%20Codex%20%7C%20Gemini-purple.svg)](../README.md#multi-platform)
 
@@ -12,7 +12,7 @@
 
 <br clear="left" />
 
-> **상태:** 0.2.2
+> **상태:** 0.3.0
 
 ## 현재 기준 요약
 
@@ -24,18 +24,22 @@
 
 ## 핵심 명령
 
+- `/harness-auto-setup [<target>] [--provider <list>]`
+  타깃 프로젝트를 처음 설정하거나, 기존 하네스를 스냅샷한 뒤 현재 계약에 맞게 갱신합니다.
 - `/harness-init [<target>]`
-  타깃 프로젝트에 `.harness/loom/` 과 `.harness/cycle/` 기반 런타임을 설치합니다.
+  타깃 프로젝트에 `.harness/loom/` 과 `.harness/cycle/` 기반 foundation runtime을 설치하거나 재설정합니다.
 - `node .harness/loom/sync.ts --provider claude,codex,gemini`
   canonical staging을 원하는 플랫폼 트리로 배포합니다.
-- `/harness-pair-dev --add <slug> "<purpose>" [--reviewer <slug> ...]`
-  현재 코드베이스에 맞는 새 producer-reviewer pair를 작성합니다.
-- `/harness-pair-dev --improve <slug> [--hint "<text>"]`
-  기존 pair를 리포지토리 근거 기준으로 개선합니다.
-- `/harness-pair-dev --split <slug>`
-  과도하게 넓어진 pair를 두 개의 더 좁은 pair로 분할합니다.
+- `/harness-pair-dev --add <slug> "<purpose>" [--from <existing-pair>] [--reviewer <slug> ...]`
+  현재 등록된 pair만 `--from` overlay source로 받아 최신 template 위에 호환되는 원본 지식을 보존해 `.harness/loom/`에 작성합니다.
+- `/harness-pair-dev --improve <slug> "<purpose>"`
+  positional purpose를 기준으로 기존 등록 pair를 개선합니다.
+- `/harness-pair-dev --remove <slug>`
+  active cycle이 해당 pair를 참조하면 거부하고, `.harness/cycle/` history를 보존한 채 pair-owned loom 파일만 안전하게 제거합니다.
 - `/harness-orchestrate <goal.md>`
   타깃 측 런타임 오케스트레이터를 실행합니다.
+
+`/harness-pair-dev` 변경은 `.harness/loom/`에만 기록됩니다. add/improve/remove 뒤에는 `node .harness/loom/sync.ts --provider <list>`를 다시 실행해 플랫폼 트리를 갱신합니다.
 
 ## 어디를 보면 되나
 

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -36,7 +36,7 @@
   positional purpose를 기준으로 기존 등록 pair를 개선합니다.
 - `/harness-pair-dev --remove <slug>`
   active cycle이 해당 pair를 참조하면 거부하고, `.harness/cycle/` history를 보존한 채 pair-owned loom 파일만 안전하게 제거합니다.
-- `/harness-orchestrate <goal.md>`
+- `/harness-orchestrate <file.md>`
   타깃 측 런타임 오케스트레이터를 실행합니다.
 
 `/harness-pair-dev` 변경은 `.harness/loom/`에만 기록됩니다. add/improve/remove 뒤에는 `node .harness/loom/sync.ts --provider <list>`를 다시 실행해 플랫폼 트리를 갱신합니다.

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -4,7 +4,7 @@
 
 [English](../README.md) | [한국어](README.ko.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md) | [Español](README.es.md)
 
-[![Version](https://img.shields.io/badge/version-0.2.2-blue.svg)](../CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.3.0-blue.svg)](../CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](../LICENSE)
 [![Platforms](https://img.shields.io/badge/platforms-Claude%20Code%20%7C%20Codex%20%7C%20Gemini-purple.svg)](../README.md#multi-platform)
 
@@ -12,7 +12,7 @@
 
 <br clear="left" />
 
-> **状态：** 0.2.2
+> **状态：** 0.3.0
 
 ## 当前要点
 
@@ -24,18 +24,22 @@
 
 ## 关键命令
 
+- `/harness-auto-setup [<target>] [--provider <list>]`
+  对目标项目做首次设置，或先快照已有 harness 再按当前契约刷新。
 - `/harness-init [<target>]`
-  在目标项目中安装基于 `.harness/loom/` 与 `.harness/cycle/` 的运行时。
+  在目标项目中安装或重置基于 `.harness/loom/` 与 `.harness/cycle/` 的基础运行时。
 - `node .harness/loom/sync.ts --provider claude,codex,gemini`
   将 canonical staging 部署到所需的平台树。
-- `/harness-pair-dev --add <slug> "<purpose>" [--reviewer <slug> ...]`
-  基于当前代码库创建新的 producer-reviewer pair。
-- `/harness-pair-dev --improve <slug> [--hint "<text>"]`
-  按照仓库证据改进已有 pair。
-- `/harness-pair-dev --split <slug>`
-  将过于宽泛的 pair 拆成两个更窄的 pair。
+- `/harness-pair-dev --add <slug> "<purpose>" [--from <existing-pair>] [--reviewer <slug> ...]`
+  只接受当前已注册的 pair 作为 `--from` overlay source，在最新 template 上保留兼容的原始知识并写入 `.harness/loom/`。
+- `/harness-pair-dev --improve <slug> "<purpose>"`
+  以 positional purpose 为主轴改进已注册的 pair。
+- `/harness-pair-dev --remove <slug>`
+  如果 active cycle 正在引用该 pair 就拒绝删除，保留 `.harness/cycle/` history，只安全移除 pair-owned loom 文件。
 - `/harness-orchestrate <goal.md>`
   运行目标侧的 runtime orchestrator。
+
+`/harness-pair-dev` 的变更只写入 `.harness/loom/`。add/improve/remove 后，请重新运行 `node .harness/loom/sync.ts --provider <list>` 刷新平台树。
 
 ## 继续阅读
 

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -36,7 +36,7 @@
   以 positional purpose 为主轴改进已注册的 pair。
 - `/harness-pair-dev --remove <slug>`
   如果 active cycle 正在引用该 pair 就拒绝删除，保留 `.harness/cycle/` history，只安全移除 pair-owned loom 文件。
-- `/harness-orchestrate <goal.md>`
+- `/harness-orchestrate <file.md>`
   运行目标侧的 runtime orchestrator。
 
 `/harness-pair-dev` 的变更只写入 `.harness/loom/`。add/improve/remove 后，请重新运行 `node .harness/loom/sync.ts --provider <list>` 刷新平台树。

--- a/plugins/harness-loom/.claude-plugin/plugin.json
+++ b/plugins/harness-loom/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "harness-loom",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Seed a planner + producer-reviewer pair harness into any repository, then grow it pair by pair.",
   "author": {
     "name": "KingGyuSuh",

--- a/plugins/harness-loom/.codex-plugin/plugin.json
+++ b/plugins/harness-loom/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "harness-loom",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Install and grow producer-reviewer harnesses for repository work.",
   "author": {
     "name": "KingGyuSuh",
@@ -22,7 +22,7 @@
   "interface": {
     "displayName": "Harness Loom",
     "shortDescription": "Install and grow producer-reviewer harnesses in repos",
-    "longDescription": "Harness Loom seeds a planning and orchestration harness into a target repository, then helps you add, improve, and split project-specific producer-reviewer pairs.",
+    "longDescription": "Harness Loom seeds or refreshes a planning and orchestration harness in a target repository, then helps you add, improve, and remove project-specific producer-reviewer pairs as the codebase evolves.",
     "developerName": "KingGyuSuh",
     "category": "Coding",
     "capabilities": [
@@ -33,9 +33,9 @@
     "privacyPolicyURL": "https://github.com/KingGyuSuh/harness-loom/blob/main/PRIVACY.md",
     "termsOfServiceURL": "https://github.com/KingGyuSuh/harness-loom/blob/main/TERMS.md",
     "defaultPrompt": [
-      "Install the harness foundation into this repository.",
+      "Set up or refresh the harness in this repository with /harness-auto-setup.",
       "Add a producer-reviewer pair for a new project workflow.",
-      "Improve or split an overloaded harness pair."
+      "Improve or remove harness pairs as the codebase evolves."
     ],
     "brandColor": "#0F766E",
     "composerIcon": "./assets/harness-loom-small.png",

--- a/plugins/harness-loom/skills/harness-auto-setup/SKILL.md
+++ b/plugins/harness-loom/skills/harness-auto-setup/SKILL.md
@@ -1,0 +1,190 @@
+---
+name: harness-auto-setup
+description: "Use when `/harness-auto-setup [<target>]` is invoked to safely install, refresh, or converge a target harness by snapshotting live `.harness/` state, preserving pair/finalizer intent as evidence, reseeding the foundation, and handing off explicit platform sync."
+argument-hint: "[target-path] [--provider claude,codex,gemini]"
+user-invocable: true
+---
+
+# harness-auto-setup
+
+## Design Thinking
+
+`harness-auto-setup` is the factory-side convergence workflow for a target harness. It exists because rerunning `/harness-init` is intentionally simple and destructive: it reseeds the foundation, but it does not preserve project-specific pairs, finalizer work, or active cycle state.
+
+This workflow does not introduce a second human-authored setup source of truth. The durable truth remains the target's live harness files:
+
+- `.harness/loom/registry.md` — pair roster, order, and reviewer topology
+- `.harness/loom/skills/<pair>/` — pair skill bodies
+- `.harness/loom/agents/<producer-or-reviewer>.md` — pair agents
+- `.harness/loom/agents/harness-finalizer.md` — singleton cycle-end role
+
+Snapshots are machine provenance and convergence input, not restore sources. Old files may explain intent, but current output must be regenerated against the current templates, authoring rubric, and target repo evidence.
+
+## Methodology
+
+### 1. Arguments
+
+`/harness-auto-setup [<target>]`
+
+- `<target>` — target project root path. If omitted, `process.cwd()` is the target.
+
+### 2. Authority boundaries
+
+- `/harness-init` remains the foundation installer. Auto-setup may invoke it, but must not move pair/finalizer authoring into `harness-init`.
+- `/harness-pair-dev` remains the pair-authoring layer. Auto-setup may use existing pair files as evidence, but must author current pair outputs through the current templates, authoring rubric, and registry contract.
+- `/harness-pair-dev --add ... --from <existing-pair-slug>` is only for evidence from a pair already registered in the current target registry. Snapshot paths, agent/skill paths, and derived platform paths remain auto-setup convergence inputs, not pair-dev inputs.
+- `.harness/loom/registry.md` remains the pair roster SSOT. The planner and finalizer are never registry entries.
+- `harness-finalizer` remains a singleton cycle-end role. Reviewer-less cycle-end work belongs in `.harness/loom/agents/harness-finalizer.md`, not in `## Registered pairs`.
+- `node .harness/loom/sync.ts --provider <list>` remains an explicit user handoff after convergence. Auto-setup must not derive `.claude/`, `.codex/`, or `.gemini/` automatically.
+- Auto-setup may reseed `.harness/cycle/` only as setup-time discard/reseed through the foundation install path. It must not fabricate pair task or review history.
+
+### 3. Snapshot and provenance contract
+
+Before any destructive refresh on a target with existing harness runtime state (`.harness/loom/` or `.harness/cycle/`), create a machine snapshot under:
+
+```text
+.harness/_snapshots/auto-setup/<YYYYMMDDTHHMMSSZ>/
+```
+
+Use the UTC run-start timestamp for the id; if a directory already exists for the same second, append `-NN` with a zero-padded monotonic counter. The snapshot directory contains:
+
+- `manifest.json` — deterministic JSON summary with stable key order
+- `loom/` — copy of pre-refresh `.harness/loom/` when present
+- `cycle/` — copy of pre-refresh `.harness/cycle/` when present
+
+`manifest.json` must include at least:
+
+- `schemaVersion`
+- `tool`
+- `targetPath`
+- `createdAt`
+- `snapshotPath`
+- `copiedNamespaces`
+- `activeCycle`
+- `registrySummary`
+- `finalizerSummary`
+- `nextAction`
+
+Keep `copiedNamespaces` sorted and use target-relative namespace names such as `.harness/loom` and `.harness/cycle`. `activeCycle` must record the classification plus the parse reason. Do not snapshot derived platform trees by default; they are deployment outputs and are refreshed only by explicit sync.
+
+If snapshot creation fails, stop before running install or deleting anything.
+
+### 4. Active cycle policy
+
+Inspect `.harness/cycle/` before refresh. Apply the classifications in the order below so the pristine scaffold is not treated as active only because its initial planner `Next` block is non-empty.
+
+Classify the cycle as:
+
+- `absent` — no `.harness/cycle/`
+- `pristine` — fresh scaffold with `Goal (from <none yet>)`, `Phase: planner`, `loop: false`, no emitted EPICs, and the initial planner `Next`
+- `active` — `loop: true`, a non-empty runnable `Next` outside the pristine scaffold, any live EPIC whose `current` is not `done` or `superseded`, or any ambiguous state that may still need runtime dispatch
+- `halted` — `loop: false`, no runnable `Next`, and every EPIC is terminal or no EPIC exists
+- `unknown` — state cannot be parsed safely
+
+For `active` or `unknown`, silent deletion is forbidden. The default policy is:
+
+1. emit a warning that the current cycle will be discarded after snapshot
+2. include `.harness/cycle/` in the snapshot
+3. run foundation refresh so `.harness/cycle/` is reseeded fresh
+4. report that old cycle state is preserved only in the snapshot, not restored
+
+This policy forbids silent destruction, not destruction itself.
+
+### 5. Existing target flow
+
+When `.harness/loom/` exists, or `.harness/cycle/` exists without `.harness/loom/`:
+
+1. Snapshot `.harness/loom/` when present and `.harness/cycle/` when present per the snapshot contract.
+2. If the snapshot contains `loom/registry.md`, parse it for registered pair order, producer slug, reviewer slug(s), and skill slug.
+3. Inspect pair agent/skill bodies when present and target repo evidence to infer current intent.
+4. Inspect snapshot `harness-finalizer.md` when present and decide whether it is missing, default no-op, or customized.
+5. Run `/harness-init` or its installer implementation to reseed the foundation.
+6. Reconstruct each known pair against the current pair templates and authoring rubric. Preserve topology and order from the old registry when valid.
+7. Preserve customized finalizer intent by rewriting it on the current finalizer skeleton and Output Format contract.
+8. Leave split/reorder decisions as recommendations unless the old registry already proves the intended topology.
+9. End with the exact sync handoff command the user should run from the target root.
+
+Old pair and finalizer files are evidence only. Do not blind-copy them over the refreshed foundation.
+
+If `.harness/cycle/` existed without `.harness/loom/`, there is no pair/finalizer source to converge; snapshot the cycle, reseed the foundation, then follow the fresh target repo-inspection rules.
+
+### 6. Fresh target flow
+
+When both `.harness/loom/` and `.harness/cycle/` are absent:
+
+1. Run `/harness-init` or its installer implementation to seed the foundation.
+2. Inspect the target repo before proposing project-specific harness work.
+3. Recommend or author an initial pair roster grounded in real repo surfaces.
+4. Recommend or author a concrete finalizer body when the repo has obvious cycle-end duties.
+5. Leave the finalizer as the safe no-op only when no concrete cycle-end duty is justified yet.
+6. End with the exact sync handoff command the user should run from the target root.
+
+Do not create generic stock pairs just to fill the registry. If repo evidence is insufficient, emit recommended `/harness-pair-dev --add` commands and leave the roster empty.
+
+### 7. Pair convergence rules
+
+- Treat snapshot `registry.md` as a strong topology/order hint, not as immutable truth.
+- Registered producer, reviewer, and skill slugs should be preserved when they remain coherent with the target repo and current namespace rules.
+- Each pair must have at least one reviewer.
+- Missing or unparsable pair files do not block the whole workflow when registry intent plus repo evidence is enough to reconstruct the pair; record the gap in `manifest.json` and the user summary.
+- If a pair has clearly become two jobs, recommend a split instead of silently changing the roster.
+- If a pair belongs in a different global roster position, recommend a reorder instead of silently moving it unless the user supplied an explicit roster instruction.
+- Use `/harness-pair-dev --add ... --from <existing-pair-slug>` only after the source pair exists in the refreshed current registry. Use snapshot pair files directly as auto-setup evidence; do not pass snapshot or file paths through `--from`.
+- Re-registration must preserve duplicate-free `## Registered pairs` order and use the registry helper rather than hand-editing the section.
+
+### 8. Finalizer convergence rules
+
+- The finalizer is customized when its body declares concrete cycle-end duties beyond the default no-op summary, writes out-of-cycle artifacts, performs coverage/release/docs/audit work, or changes the default Task section materially.
+- A customized finalizer's intent should be preserved, but its body must be rewritten against the current `harness-finalizer` skeleton, principles, Structural Issue shape, and Output Format.
+- A missing or no-op finalizer should trigger repo-grounded recommendations for concrete cycle-end work. Author it only when the target repo evidence makes the duty clear.
+- Do not turn finalizer work into a pair, and do not add a finalizer line to `## Registered pairs`.
+
+### 9. Sync handoff
+
+Auto-setup must stop before platform derivation. The final user-facing summary must include a target-local command such as:
+
+```bash
+node .harness/loom/sync.ts --provider claude,codex,gemini
+```
+
+Use any subset the user requested or that the workflow recommends, but never execute sync automatically.
+
+### 10. Execution
+
+Run the script-owned execution path:
+
+```bash
+node plugins/harness-loom/skills/harness-auto-setup/scripts/auto-setup.ts [<target>] [--provider claude,codex,gemini]
+```
+
+The script snapshots existing `.harness/loom/` / `.harness/cycle/`, classifies active-cycle risk, calls the `harness-init` installer for foundation refresh, reconstructs valid registered pairs and customized finalizer intent on current templates, and returns JSON. `--provider` only shapes the printed sync handoff; it never runs sync.
+
+## Evaluation Criteria
+
+- Existing targets are snapshotted before any destructive refresh.
+- Active or unparsable `.harness/cycle/` state is warned about and copied before discard/reseed.
+- Snapshot data is machine provenance with deterministic path and manifest shape, not a human-authored setup SSOT.
+- `/harness-init` remains foundation-only.
+- Pair convergence uses old files only as evidence and regenerates current pair outputs against current templates, rubric, and repo evidence.
+- `registry.md` remains the sole pair roster source of truth and contains only executable producer-reviewer pairs.
+- Customized finalizer intent is preserved in the singleton finalizer body, not converted into a pair.
+- Fresh targets receive repo-grounded pair/finalizer recommendations or authored outputs, not stock generic harness content.
+- Derived platform trees are not modified; the result ends with an explicit `node .harness/loom/sync.ts --provider <list>` handoff.
+
+## Taboos
+
+- Create a persistent human-edited `setup.md` or equivalent setup SSOT.
+- Restore stale pair or finalizer files by blind copy after foundation refresh.
+- Delete an active or unparsable cycle silently.
+- Treat snapshot content as canonical after convergence.
+- Register the planner or finalizer as a pair.
+- Author reviewer-less pair stages.
+- Move pair/finalizer authoring into `/harness-init`.
+- Run `sync.ts` automatically or write `.claude/`, `.codex/`, or `.gemini/` directly.
+
+## References
+
+- `../harness-init/SKILL.md` — foundation installer boundary
+- `../harness-pair-dev/SKILL.md` — pair authoring and registry mutation boundary
+- `../harness-init/references/runtime/registry.md` — target-side pair roster contract
+- `../harness-init/references/runtime/harness-finalizer.template.md` — singleton finalizer skeleton and Output Format

--- a/plugins/harness-loom/skills/harness-auto-setup/scripts/auto-setup.ts
+++ b/plugins/harness-loom/skills/harness-auto-setup/scripts/auto-setup.ts
@@ -128,6 +128,11 @@ interface PairReconstruction {
   evidenceLines: string[];
 }
 
+interface ArtifactUsage {
+  agents: Map<string, string[]>;
+  skills: Map<string, string[]>;
+}
+
 interface FinalizerReconstruction {
   status: "reconstructed" | "default-noop" | "missing" | "skipped";
   reason: string;
@@ -765,8 +770,39 @@ function finalizerRecommendation(finalizer: FinalizerSummary, signals: RepoSigna
   return finalizer.recommendation;
 }
 
-function validatePair(pair: RegistryPair, seen: Set<string>): string | null {
+function addUsage(map: Map<string, string[]>, slug: string, owner: string): void {
+  const current = map.get(slug) ?? [];
+  current.push(owner);
+  map.set(slug, current);
+}
+
+function collectArtifactUsage(pairs: RegistryPair[]): ArtifactUsage {
+  const usage: ArtifactUsage = {
+    agents: new Map(),
+    skills: new Map(),
+  };
+  for (const pair of pairs) {
+    addUsage(usage.skills, pair.skill, pair.pair);
+    addUsage(usage.agents, pair.producer, `${pair.pair}:producer`);
+    for (const reviewer of pair.reviewers) addUsage(usage.agents, reviewer, `${pair.pair}:reviewer`);
+  }
+  return usage;
+}
+
+function uniqueOwners(owners: string[]): string[] {
+  return [...new Set(owners)];
+}
+
+function sharedArtifactReason(kind: "agent" | "skill", slug: string, owners: string[]): string | null {
+  const unique = uniqueOwners(owners);
+  if (unique.length <= 1) return null;
+  const scope = kind === "agent" ? "pair roles" : "pair entries";
+  return `${kind} slug is shared by multiple ${scope} and cannot be safely reconstructed: ${slug} (${unique.join(", ")})`;
+}
+
+function validatePairBasics(pair: RegistryPair, seen: Set<string>): string | null {
   if (seen.has(pair.pair)) return `duplicate pair slug in snapshot registry: ${pair.pair}`;
+  seen.add(pair.pair);
   for (const [label, value] of [
     ["pair", pair.pair],
     ["producer", pair.producer],
@@ -780,8 +816,21 @@ function validatePair(pair: RegistryPair, seen: Set<string>): string | null {
   for (const reviewer of pair.reviewers) {
     if (!HARNESS_SLUG_RE.test(reviewer)) return `reviewer slug is outside current harness namespace: ${reviewer}`;
     if (FOUNDATION_SLUGS.has(reviewer)) return `reviewer slug is reserved for a foundation or singleton role: ${reviewer}`;
+    if (reviewer === pair.producer) return `producer and reviewer share the same agent slug: ${reviewer}`;
     if (reviewerSeen.has(reviewer)) return `duplicate reviewer slug: ${reviewer}`;
     reviewerSeen.add(reviewer);
+  }
+  return null;
+}
+
+function validatePairArtifacts(pair: RegistryPair, usage: ArtifactUsage): string | null {
+  const skillReason = sharedArtifactReason("skill", pair.skill, usage.skills.get(pair.skill) ?? []);
+  if (skillReason) return skillReason;
+  const producerReason = sharedArtifactReason("agent", pair.producer, usage.agents.get(pair.producer) ?? []);
+  if (producerReason) return producerReason;
+  for (const reviewer of pair.reviewers) {
+    const reviewerReason = sharedArtifactReason("agent", reviewer, usage.agents.get(reviewer) ?? []);
+    if (reviewerReason) return reviewerReason;
   }
   return null;
 }
@@ -992,8 +1041,11 @@ async function reconstructPairs(
   if (!snapshotPath || registry.pairCount === 0) return [];
   const out: PairReconstruction[] = [];
   const seen = new Set<string>();
-  for (const pair of registry.pairs) {
-    const invalidReason = validatePair(pair, seen);
+  const basicInvalidReasons = registry.pairs.map((pair) => validatePairBasics(pair, seen));
+  const artifactUsage = collectArtifactUsage(registry.pairs.filter((_, index) => !basicInvalidReasons[index]));
+
+  for (const [index, pair] of registry.pairs.entries()) {
+    const invalidReason = basicInvalidReasons[index] ?? validatePairArtifacts(pair, artifactUsage);
     if (invalidReason) {
       out.push({
         pair: pair.pair,
@@ -1008,7 +1060,6 @@ async function reconstructPairs(
       });
       continue;
     }
-    seen.add(pair.pair);
     const intent = await collectPairIntent(target, snapshotPath, pair);
     const filesWritten: string[] = [];
     const skillDir = join(target, ".harness", "loom", "skills", pair.skill);

--- a/plugins/harness-loom/skills/harness-auto-setup/scripts/auto-setup.ts
+++ b/plugins/harness-loom/skills/harness-auto-setup/scripts/auto-setup.ts
@@ -1,0 +1,1285 @@
+#!/usr/bin/env node
+// Purpose: Snapshot existing target harness state, classify cycle risk, then
+//          delegate foundation refresh to harness-init's installer. Valid
+//          registered pairs and customized finalizer intent are reconstructed
+//          from snapshot evidence on top of current templates; stale harness
+//          files are never blind-copied and platform sync is never run.
+
+import { spawnSync } from "node:child_process";
+import { constants as FS, readFileSync } from "node:fs";
+import { access, cp, mkdir, readFile, stat, writeFile } from "node:fs/promises";
+import { dirname, isAbsolute, join, relative, resolve } from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const INSTALL_SCRIPT = resolve(SCRIPT_DIR, "../../harness-init/scripts/install.ts");
+const FINALIZER_TEMPLATE = resolve(
+  SCRIPT_DIR,
+  "../../harness-init/references/runtime/harness-finalizer.template.md",
+);
+const PAIR_DEV_DIR = resolve(SCRIPT_DIR, "../../harness-pair-dev");
+const REGISTER_PAIR_SCRIPT = resolve(PAIR_DEV_DIR, "scripts/register-pair.ts");
+const PRODUCER_TEMPLATE = resolve(PAIR_DEV_DIR, "templates/producer-agent.md");
+const REVIEWER_TEMPLATE = resolve(PAIR_DEV_DIR, "templates/reviewer-agent.md");
+const PAIR_SKILL_TEMPLATE = resolve(PAIR_DEV_DIR, "templates/pair-skill.md");
+const ALLOWED_PROVIDERS = new Set(["claude", "codex", "gemini"]);
+const HARNESS_SLUG_RE = /^harness-[a-z0-9]+(-[a-z0-9]+)*$/;
+
+type CycleClassification = "absent" | "pristine" | "active" | "halted" | "unknown";
+type RegistryStatus = "absent" | "present" | "unparsable";
+type FinalizerStatus = "absent" | "default-noop" | "customized" | "unreadable";
+
+interface Args {
+  target: string;
+  providers: string[];
+}
+
+interface ActiveCycleSummary {
+  classification: CycleClassification;
+  reason: string;
+  path: string | null;
+  phase: string | null;
+  loop: boolean | null;
+  runnableNext: boolean | null;
+  epicCount: number;
+  liveEpicCount: number;
+}
+
+interface RegistryPair {
+  pair: string;
+  producer: string;
+  reviewers: string[];
+  skill: string;
+  sourceLine: string;
+  evidence: {
+    skillPresent: boolean;
+    producerPresent: boolean;
+    reviewersPresent: string[];
+    missing: string[];
+  };
+}
+
+interface RegistrySummary {
+  status: RegistryStatus;
+  path: string | null;
+  pairCount: number;
+  pairs: RegistryPair[];
+  unparsedLines: string[];
+}
+
+interface FinalizerSummary {
+  status: FinalizerStatus;
+  path: string | null;
+  customized: boolean;
+  signals: string[];
+  taskPreview: string | null;
+  recommendation: string;
+}
+
+interface RepoSignals {
+  files: string[];
+  directories: string[];
+  evidence: string[];
+}
+
+interface Manifest {
+  schemaVersion: number;
+  tool: string;
+  targetPath: string;
+  createdAt: string;
+  snapshotPath: string;
+  copiedNamespaces: string[];
+  activeCycle: ActiveCycleSummary;
+  registrySummary: RegistrySummary;
+  finalizerSummary: FinalizerSummary;
+  nextAction: string;
+  recommendations: {
+    mode: string;
+    pairs: string[];
+    finalizer: string;
+    sync: string;
+  };
+}
+
+interface PairIntent {
+  skillPath: string | null;
+  producerPath: string | null;
+  reviewerPaths: Record<string, string | null>;
+  evidenceLines: string[];
+}
+
+interface PairReconstruction {
+  pair: string;
+  status: "reconstructed" | "skipped";
+  reason: string;
+  producer: string;
+  reviewers: string[];
+  skill: string;
+  filesWritten: string[];
+  registry: unknown;
+  evidenceLines: string[];
+}
+
+interface FinalizerReconstruction {
+  status: "reconstructed" | "default-noop" | "missing" | "skipped";
+  reason: string;
+  path: string | null;
+  filesWritten: string[];
+  evidenceLines: string[];
+}
+
+function die(message: string, code = 1): never {
+  process.stderr.write(`harness-auto-setup: ${message}\n`);
+  process.exit(code);
+}
+
+function parseProviders(raw: string): string[] {
+  const providers = raw
+    .split(",")
+    .map((p) => p.trim())
+    .filter(Boolean);
+  if (providers.length === 0) die("--provider requires at least one provider");
+  for (const provider of providers) {
+    if (!ALLOWED_PROVIDERS.has(provider)) {
+      die(`unknown provider: ${provider} (expected claude,codex,gemini)`);
+    }
+  }
+  return providers;
+}
+
+function parseArgs(argv: string[]): Args {
+  const rest = argv.slice(2);
+  const positional: string[] = [];
+  let providers = ["claude", "codex", "gemini"];
+  for (let i = 0; i < rest.length; i++) {
+    const arg = rest[i];
+    if (arg === "--help" || arg === "-h") {
+      process.stdout.write(
+        "Usage: node skills/harness-auto-setup/scripts/auto-setup.ts [<target-project-path>] [--provider <claude,codex,gemini>]\n" +
+          "  Target defaults to process.cwd() when omitted.\n" +
+          "  The provider list is only used to print the explicit sync handoff; sync is not run.\n",
+      );
+      process.exit(0);
+    } else if (arg === "--provider") {
+      const value = rest[++i];
+      if (value === undefined || value.startsWith("--")) die("--provider requires a comma-separated list");
+      providers = parseProviders(value);
+    } else if (arg.startsWith("--")) {
+      die(`unknown flag: ${arg}`);
+    } else {
+      positional.push(arg);
+    }
+  }
+  if (positional.length > 1) die("at most one <target-project-path> accepted");
+  const targetArg = positional[0] ?? process.cwd();
+  const target = isAbsolute(targetArg) ? targetArg : resolve(process.cwd(), targetArg);
+  return { target, providers };
+}
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await access(path, FS.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function normalize(body: string): string {
+  return body.replace(/\r\n/g, "\n").trim();
+}
+
+function rel(target: string, path: string): string {
+  return relative(target, path).split("\\").join("/");
+}
+
+function syncCommand(providers: string[]): string {
+  return `node .harness/loom/sync.ts --provider ${providers.join(",")}`;
+}
+
+function snapshotStamp(date: Date): string {
+  return date
+    .toISOString()
+    .replace(/[-:]/g, "")
+    .replace(/\.\d{3}Z$/, "Z");
+}
+
+async function allocateSnapshotDir(target: string, createdAt: string): Promise<string> {
+  const root = join(target, ".harness", "_snapshots", "auto-setup");
+  await mkdir(root, { recursive: true });
+  const stamp = snapshotStamp(new Date(createdAt));
+  for (let i = 0; i < 100; i++) {
+    const id = i === 0 ? stamp : `${stamp}-${String(i).padStart(2, "0")}`;
+    const candidate = join(root, id);
+    try {
+      await mkdir(candidate);
+      return candidate;
+    } catch (err) {
+      const code = err && typeof err === "object" && "code" in err ? (err as { code?: string }).code : "";
+      if (code === "EEXIST") continue;
+      throw err;
+    }
+  }
+  die(`could not allocate snapshot directory under ${root}`);
+}
+
+function section(body: string, heading: string): string | null {
+  const normalized = body.replace(/\r\n/g, "\n");
+  const headingLine = `## ${heading}`;
+  const headingIdxLineStart = normalized.indexOf(`\n${headingLine}\n`);
+  const headingIdx =
+    headingIdxLineStart !== -1
+      ? headingIdxLineStart + 1
+      : normalized.startsWith(`${headingLine}\n`)
+      ? 0
+      : -1;
+  if (headingIdx === -1) return null;
+  const bodyStart = normalized.indexOf("\n", headingIdx) + 1;
+  const nextHeading = normalized.indexOf("\n## ", bodyStart);
+  const bodyEnd = nextHeading === -1 ? normalized.length : nextHeading;
+  return normalized.slice(bodyStart, bodyEnd);
+}
+
+function subsection(body: string, headingLine: string): string | null {
+  const normalized = body.replace(/\r\n/g, "\n");
+  const headingIdxLineStart = normalized.indexOf(`\n${headingLine}\n`);
+  const headingIdx =
+    headingIdxLineStart !== -1
+      ? headingIdxLineStart + 1
+      : normalized.startsWith(`${headingLine}\n`)
+      ? 0
+      : -1;
+  if (headingIdx === -1) return null;
+  const bodyStart = normalized.indexOf("\n", headingIdx) + 1;
+  const tail = normalized.slice(bodyStart);
+  const nextHeadingMatch = tail.match(/\n#{2,3}\s+/);
+  const bodyEnd = nextHeadingMatch?.index === undefined ? normalized.length : bodyStart + nextHeadingMatch.index;
+  return normalized.slice(bodyStart, bodyEnd);
+}
+
+function replaceSection(body: string, heading: string, replacement: string): string {
+  const normalized = body.replace(/\r\n/g, "\n");
+  const headingLine = `## ${heading}`;
+  const headingIdxLineStart = normalized.indexOf(`\n${headingLine}\n`);
+  const headingIdx =
+    headingIdxLineStart !== -1
+      ? headingIdxLineStart + 1
+      : normalized.startsWith(`${headingLine}\n`)
+      ? 0
+      : -1;
+  const sectionBody = replacement.trimEnd() + "\n";
+  if (headingIdx === -1) {
+    const sep = normalized.endsWith("\n") ? "" : "\n";
+    return `${normalized}${sep}\n${headingLine}\n\n${sectionBody}`;
+  }
+  const bodyStart = normalized.indexOf("\n", headingIdx) + 1;
+  const nextHeading = normalized.indexOf("\n## ", bodyStart);
+  const bodyEnd = nextHeading === -1 ? normalized.length : nextHeading;
+  return normalized.slice(0, bodyStart) + sectionBody + normalized.slice(bodyEnd);
+}
+
+function field(body: string, name: string): string | null {
+  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = body.match(new RegExp(`^${escaped}:\\s*(.*)$`, "m"));
+  return match ? match[1].trim() : null;
+}
+
+function renderTemplate(raw: string, vars: Record<string, string>): string {
+  let out = raw;
+  for (const [key, value] of Object.entries(vars)) {
+    out = out.split(`{{${key}}}`).join(value);
+  }
+  return out;
+}
+
+function titleFromSlug(slug: string): string {
+  return slug
+    .split("-")
+    .filter(Boolean)
+    .map((part) => part.slice(0, 1).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function frontmatterDescription(body: string): string | null {
+  const normalized = body.replace(/\r\n/g, "\n");
+  const match = normalized.match(/^---\n[\s\S]*?\ndescription:\s*"?([^"\n]+)"?[\s\S]*?\n---/);
+  return match ? match[1].trim() : null;
+}
+
+function cleanEvidenceLine(line: string): string | null {
+  const cleaned = line
+    .replace(/^[-*]\s+/, "")
+    .replace(/^#+\s+/, "")
+    .replace(/\s+/g, " ")
+    .trim();
+  if (!cleaned) return null;
+  if (/^```/.test(cleaned)) return null;
+  if (/^Status: PASS \/ FAIL$/.test(cleaned)) return null;
+  return cleaned.length > 220 ? `${cleaned.slice(0, 217)}...` : cleaned;
+}
+
+function uniqueCapped(lines: string[], limit: number): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const line of lines) {
+    const cleaned = cleanEvidenceLine(line);
+    if (!cleaned || seen.has(cleaned)) continue;
+    seen.add(cleaned);
+    out.push(cleaned);
+    if (out.length >= limit) break;
+  }
+  return out;
+}
+
+function markedEvidence(body: string): string[] | null {
+  const marked =
+    subsection(body, "### Preserved Snapshot Intent") ?? subsection(body, "### Preserved Intent Evidence");
+  if (!marked) return null;
+  const lines = marked
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith("- "));
+  return uniqueCapped(lines, 8);
+}
+
+function evidenceFromMarkdown(body: string, preferredSections: string[], fallbackLabel: string): string[] {
+  const marked = markedEvidence(body);
+  if (marked && marked.length > 0) return marked;
+
+  const out: string[] = [];
+  const description = frontmatterDescription(body);
+  if (description) out.push(`${fallbackLabel} description: ${description}`);
+  for (const heading of preferredSections) {
+    const sectionBody = section(body, heading);
+    if (!sectionBody) continue;
+    const lines = sectionBody
+      .split("\n")
+      .map((line) => line.trim())
+      .filter((line) => line && !line.startsWith("```"))
+      .slice(0, 4);
+    for (const line of lines) out.push(`${fallbackLabel} ${heading}: ${line}`);
+  }
+  if (out.length === 0) {
+    const lines = body
+      .replace(/^---\n[\s\S]*?\n---\n?/, "")
+      .split("\n")
+      .map((line) => line.trim())
+      .filter((line) => line && !line.startsWith("#") && !line.startsWith("```"))
+      .slice(0, 4);
+    for (const line of lines) out.push(`${fallbackLabel} body: ${line}`);
+  }
+  return uniqueCapped(out, 8);
+}
+
+async function classifyCycle(target: string, cycleDir: string): Promise<ActiveCycleSummary> {
+  if (!(await exists(cycleDir))) {
+    return {
+      classification: "absent",
+      reason: ".harness/cycle is absent",
+      path: null,
+      phase: null,
+      loop: null,
+      runnableNext: null,
+      epicCount: 0,
+      liveEpicCount: 0,
+    };
+  }
+
+  const statePath = join(cycleDir, "state.md");
+  if (!(await exists(statePath))) {
+    return {
+      classification: "unknown",
+      reason: ".harness/cycle exists but state.md is missing",
+      path: rel(target, statePath),
+      phase: null,
+      loop: null,
+      runnableNext: null,
+      epicCount: 0,
+      liveEpicCount: 0,
+    };
+  }
+
+  let state: string;
+  try {
+    state = normalize(await readFile(statePath, "utf8"));
+  } catch {
+    return {
+      classification: "unknown",
+      reason: "state.md could not be read",
+      path: rel(target, statePath),
+      phase: null,
+      loop: null,
+      runnableNext: null,
+      epicCount: 0,
+      liveEpicCount: 0,
+    };
+  }
+
+  const phase = field(state, "Phase");
+  const loopRaw = field(state, "loop");
+  const plannerContinuation = field(state, "planner-continuation");
+  const next = section(state, "Next");
+  const nextTo = next ? field(next, "To") : null;
+  const nextEpic = next ? field(next, "EPIC") : null;
+  const nextTask = next ? field(next, "Task path") : null;
+
+  if (!phase || (loopRaw !== "true" && loopRaw !== "false") || !plannerContinuation || !next || !nextTo) {
+    return {
+      classification: "unknown",
+      reason: "state.md is missing required header or Next fields",
+      path: rel(target, statePath),
+      phase,
+      loop: loopRaw === "true" ? true : loopRaw === "false" ? false : null,
+      runnableNext: null,
+      epicCount: 0,
+      liveEpicCount: 0,
+    };
+  }
+
+  const loop = loopRaw === "true";
+  const epicSummaryBody = section(state, "EPIC summaries") ?? "";
+  const liveEpicSummaryBody = epicSummaryBody.split(/\nExample:\n/)[0];
+  const epicHeadings = [...liveEpicSummaryBody.matchAll(/^###\s+(EP-\d+--[^\n]+)$/gm)].map((m) => m[1]);
+  const epicCurrents = [...liveEpicSummaryBody.matchAll(/^current:\s*(.+)$/gm)].map((m) => m[1].trim());
+  const terminal = new Set(["done", "superseded"]);
+  const liveEpicCount = epicCurrents.filter((current) => !terminal.has(current)).length;
+  const ambiguousEpic = epicHeadings.length !== epicCurrents.length;
+  const runnableNext = !["", "(none)", "none", "halt", "halted"].includes(nextTo.toLowerCase());
+  const pristine =
+    /^Goal \(from <none yet>\):/m.test(state) &&
+    phase === "planner" &&
+    !loop &&
+    plannerContinuation === "none" &&
+    epicHeadings.length === 0 &&
+    nextTo === "planner" &&
+    nextEpic === "(none)" &&
+    nextTask === "(none)";
+
+  if (pristine) {
+    return {
+      classification: "pristine",
+      reason: "fresh scaffold with initial planner Next and no emitted EPICs",
+      path: rel(target, statePath),
+      phase,
+      loop,
+      runnableNext,
+      epicCount: 0,
+      liveEpicCount: 0,
+    };
+  }
+
+  if (loop) {
+    return {
+      classification: "active",
+      reason: "loop is true",
+      path: rel(target, statePath),
+      phase,
+      loop,
+      runnableNext,
+      epicCount: epicHeadings.length,
+      liveEpicCount,
+    };
+  }
+  if (ambiguousEpic) {
+    return {
+      classification: "active",
+      reason: "EPIC headings and current fields do not line up",
+      path: rel(target, statePath),
+      phase,
+      loop,
+      runnableNext,
+      epicCount: epicHeadings.length,
+      liveEpicCount,
+    };
+  }
+  if (liveEpicCount > 0) {
+    return {
+      classification: "active",
+      reason: "at least one EPIC current field is not terminal",
+      path: rel(target, statePath),
+      phase,
+      loop,
+      runnableNext,
+      epicCount: epicHeadings.length,
+      liveEpicCount,
+    };
+  }
+  if (runnableNext) {
+    return {
+      classification: "active",
+      reason: "runnable Next block outside pristine scaffold",
+      path: rel(target, statePath),
+      phase,
+      loop,
+      runnableNext,
+      epicCount: epicHeadings.length,
+      liveEpicCount,
+    };
+  }
+  return {
+    classification: "halted",
+    reason: "loop is false, no runnable Next remains, and every EPIC is terminal",
+    path: rel(target, statePath),
+    phase,
+    loop,
+    runnableNext,
+    epicCount: epicHeadings.length,
+    liveEpicCount,
+  };
+}
+
+function parseRegistryLine(line: string): Omit<RegistryPair, "evidence"> | null {
+  const match = line.match(
+    /^-\s+([a-z0-9][a-z0-9-]*)\s*:\s*producer\s+`([^`]+)`\s*↔\s*(?:reviewer\s+`([^`]+)`|reviewers\s+\[([^\]]*)\])\s*,\s*skill\s+`([^`]+)`/,
+  );
+  if (!match) return null;
+  const reviewers = match[3]
+    ? [match[3]]
+    : [...(match[4] ?? "").matchAll(/`([^`]+)`/g)].map((m) => m[1]);
+  return {
+    pair: match[1],
+    producer: match[2],
+    reviewers,
+    skill: match[5],
+    sourceLine: line,
+  };
+}
+
+async function pairEvidence(target: string, loomDir: string, pair: Omit<RegistryPair, "evidence">): Promise<RegistryPair["evidence"]> {
+  const skillPath = join(loomDir, "skills", pair.skill);
+  const producerPath = join(loomDir, "agents", `${pair.producer}.md`);
+  const reviewerPaths = pair.reviewers.map((reviewer) => join(loomDir, "agents", `${reviewer}.md`));
+  const skillPresent = await exists(skillPath);
+  const producerPresent = await exists(producerPath);
+  const reviewersPresent: string[] = [];
+  const missing: string[] = [];
+  if (!skillPresent) missing.push(rel(target, skillPath));
+  if (!producerPresent) missing.push(rel(target, producerPath));
+  for (let i = 0; i < pair.reviewers.length; i++) {
+    if (await exists(reviewerPaths[i])) reviewersPresent.push(pair.reviewers[i]);
+    else missing.push(rel(target, reviewerPaths[i]));
+  }
+  return { skillPresent, producerPresent, reviewersPresent, missing };
+}
+
+async function summarizeRegistry(target: string, loomDir: string): Promise<RegistrySummary> {
+  const registryPath = join(loomDir, "registry.md");
+  if (!(await exists(registryPath))) {
+    return { status: "absent", path: null, pairCount: 0, pairs: [], unparsedLines: [] };
+  }
+  const body = await readFile(registryPath, "utf8");
+  const registered = section(body, "Registered pairs");
+  if (registered === null) {
+    return {
+      status: "unparsable",
+      path: rel(target, registryPath),
+      pairCount: 0,
+      pairs: [],
+      unparsedLines: ["missing ## Registered pairs section"],
+    };
+  }
+  const pairs: RegistryPair[] = [];
+  const unparsedLines: string[] = [];
+  for (const rawLine of registered.split("\n")) {
+    const line = rawLine.trim();
+    if (!line.startsWith("- ")) continue;
+    const parsed = parseRegistryLine(line);
+    if (!parsed || parsed.reviewers.length === 0) {
+      unparsedLines.push(line);
+      continue;
+    }
+    pairs.push({ ...parsed, evidence: await pairEvidence(target, loomDir, parsed) });
+  }
+  return {
+    status: unparsedLines.length > 0 ? "unparsable" : "present",
+    path: rel(target, registryPath),
+    pairCount: pairs.length,
+    pairs,
+    unparsedLines,
+  };
+}
+
+function taskPreview(body: string): string | null {
+  const task = section(body, "Task");
+  if (!task) return null;
+  const lines = task
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .slice(0, 4);
+  return lines.length > 0 ? lines.join(" ") : null;
+}
+
+async function summarizeFinalizer(target: string, loomDir: string): Promise<FinalizerSummary> {
+  const finalizerPath = join(loomDir, "agents", "harness-finalizer.md");
+  if (!(await exists(finalizerPath))) {
+    return {
+      status: "absent",
+      path: null,
+      customized: false,
+      signals: [],
+      taskPreview: null,
+      recommendation: "No finalizer was found; keep the installed safe no-op unless repo evidence justifies concrete cycle-end work.",
+    };
+  }
+  let body: string;
+  try {
+    body = await readFile(finalizerPath, "utf8");
+  } catch {
+    return {
+      status: "unreadable",
+      path: rel(target, finalizerPath),
+      customized: false,
+      signals: ["read-failed"],
+      taskPreview: null,
+      recommendation: "Finalizer could not be read; inspect the snapshot before authoring cycle-end work.",
+    };
+  }
+
+  let template = "";
+  try {
+    template = await readFile(FINALIZER_TEMPLATE, "utf8");
+  } catch {
+    template = "";
+  }
+  if (normalize(body) === normalize(template)) {
+    return {
+      status: "default-noop",
+      path: rel(target, finalizerPath),
+      customized: false,
+      signals: ["safe-no-op"],
+      taskPreview: taskPreview(body),
+      recommendation: "Finalizer is the default safe no-op; add concrete cycle-end work only when repo evidence supports it.",
+    };
+  }
+
+  const signals: string[] = [];
+  for (const [label, re] of [
+    ["docs", /\bdocs?\b|README|CHANGELOG/i],
+    ["release", /\brelease\b|version|tag/i],
+    ["verification", /\btest\b|verify|coverage|audit/i],
+    ["out-of-cycle-writes", /Files created|Files modified|write|update/i],
+  ] as const) {
+    if (re.test(body)) signals.push(label);
+  }
+  if (signals.length === 0) signals.push("material-body-differs-from-default");
+  return {
+    status: "customized",
+    path: rel(target, finalizerPath),
+    customized: true,
+    signals,
+    taskPreview: taskPreview(body),
+    recommendation: "Use the snapshot finalizer as intent evidence and rewrite it on the current harness-finalizer skeleton before running cycles.",
+  };
+}
+
+async function repoSignals(target: string): Promise<RepoSignals> {
+  const fileCandidates = [
+    "README.md",
+    "CHANGELOG.md",
+    "package.json",
+    "pnpm-workspace.yaml",
+    "pyproject.toml",
+    "go.mod",
+    "Cargo.toml",
+    "pubspec.yaml",
+  ];
+  const dirCandidates = ["src", "app", "lib", "tests", "test", "docs", ".github/workflows"];
+  const files: string[] = [];
+  const directories: string[] = [];
+  for (const file of fileCandidates) {
+    const path = join(target, file);
+    if ((await exists(path)) && (await stat(path)).isFile()) files.push(file);
+  }
+  for (const dir of dirCandidates) {
+    const path = join(target, dir);
+    if ((await exists(path)) && (await stat(path)).isDirectory()) directories.push(dir);
+  }
+
+  const evidence: string[] = [];
+  if (files.includes("README.md") || directories.includes("docs")) evidence.push("documentation surface");
+  if (directories.includes("tests") || directories.includes("test")) evidence.push("test surface");
+  if (files.includes("package.json") || files.includes("pnpm-workspace.yaml")) evidence.push("node workspace");
+  if (files.includes("pyproject.toml")) evidence.push("python workspace");
+  if (files.includes("go.mod")) evidence.push("go workspace");
+  if (files.includes("Cargo.toml")) evidence.push("rust workspace");
+  if (files.includes("pubspec.yaml")) evidence.push("dart/flutter workspace");
+  if (directories.includes(".github/workflows")) evidence.push("ci workflow surface");
+  if (directories.some((dir) => ["src", "app", "lib"].includes(dir))) evidence.push("implementation surface");
+  return { files, directories, evidence };
+}
+
+function pairRecommendations(registry: RegistrySummary, signals: RepoSignals): string[] {
+  if (registry.pairCount > 0) {
+    return registry.pairs.map((pair) => {
+      const reviewers = pair.reviewers.map((reviewer) => ` --reviewer ${reviewer}`).join("");
+      const missing =
+        pair.evidence.missing.length > 0
+          ? ` Missing evidence: ${pair.evidence.missing.join(", ")}.`
+          : "";
+      return `Re-author ${pair.pair} from snapshot evidence with current templates: /harness-pair-dev --add ${pair.pair} "Refresh ${pair.pair} against current repo evidence and contracts"${reviewers}.${missing}`;
+    });
+  }
+
+  const out: string[] = [];
+  if (signals.evidence.includes("documentation surface")) {
+    out.push(
+      'Repo has documentation evidence; consider /harness-pair-dev --add harness-document "Maintain user-facing docs and pointer-doc alignment" --reviewer harness-document-reviewer.',
+    );
+  }
+  if (signals.evidence.includes("test surface") || signals.evidence.includes("ci workflow surface")) {
+    out.push(
+      'Repo has verification evidence; consider /harness-pair-dev --add harness-verification "Maintain regression tests and smoke checks" --reviewer harness-verification-reviewer.',
+    );
+  }
+  if (signals.evidence.includes("implementation surface")) {
+    out.push(
+      'Repo has implementation surfaces; inspect ownership boundaries before adding a producer-reviewer implementation pair.',
+    );
+  }
+  if (out.length === 0) {
+    out.push("No strong repo-grounded pair recommendation found; leave registry empty until concrete workstreams are identified.");
+  }
+  return out;
+}
+
+function finalizerRecommendation(finalizer: FinalizerSummary, signals: RepoSignals): string {
+  if (finalizer.customized) return finalizer.recommendation;
+  if (signals.evidence.includes("documentation surface") && signals.evidence.includes("test surface")) {
+    return "Consider a finalizer that checks goal coverage, summarizes verification, and refreshes release/docs notes at cycle end.";
+  }
+  if (signals.evidence.includes("documentation surface")) {
+    return "Consider a finalizer that refreshes docs or changelog notes only when the cycle goal declares that duty.";
+  }
+  if (signals.evidence.includes("test surface") || signals.evidence.includes("ci workflow surface")) {
+    return "Consider a finalizer that performs a cycle-end verification summary only when the goal requires it.";
+  }
+  return finalizer.recommendation;
+}
+
+function validatePair(pair: RegistryPair, seen: Set<string>): string | null {
+  if (seen.has(pair.pair)) return `duplicate pair slug in snapshot registry: ${pair.pair}`;
+  for (const [label, value] of [
+    ["pair", pair.pair],
+    ["producer", pair.producer],
+    ["skill", pair.skill],
+  ] as const) {
+    if (!HARNESS_SLUG_RE.test(value)) return `${label} slug is outside current harness namespace: ${value}`;
+  }
+  if (pair.reviewers.length === 0) return "pair has no reviewer";
+  const reviewerSeen = new Set<string>();
+  for (const reviewer of pair.reviewers) {
+    if (!HARNESS_SLUG_RE.test(reviewer)) return `reviewer slug is outside current harness namespace: ${reviewer}`;
+    if (reviewerSeen.has(reviewer)) return `duplicate reviewer slug: ${reviewer}`;
+    reviewerSeen.add(reviewer);
+  }
+  return null;
+}
+
+async function readOptional(path: string): Promise<string | null> {
+  if (!(await exists(path))) return null;
+  try {
+    return await readFile(path, "utf8");
+  } catch {
+    return null;
+  }
+}
+
+async function collectPairIntent(target: string, snapshotPath: string, pair: RegistryPair): Promise<PairIntent> {
+  const snapshotLoom = join(snapshotPath, "loom");
+  const skillPath = join(snapshotLoom, "skills", pair.skill, "SKILL.md");
+  const producerPath = join(snapshotLoom, "agents", `${pair.producer}.md`);
+  const reviewerPaths: Record<string, string | null> = {};
+  const evidenceLines: string[] = [];
+
+  const skillBody = await readOptional(skillPath);
+  const skillMarkedEvidence = skillBody ? markedEvidence(skillBody) : null;
+  if (skillMarkedEvidence && skillMarkedEvidence.length > 0) {
+    for (const reviewer of pair.reviewers) {
+      const reviewerPath = join(snapshotLoom, "agents", `${reviewer}.md`);
+      reviewerPaths[reviewer] = (await exists(reviewerPath)) ? reviewerPath : null;
+    }
+    return {
+      skillPath,
+      producerPath: (await exists(producerPath)) ? producerPath : null,
+      reviewerPaths,
+      evidenceLines: skillMarkedEvidence,
+    };
+  }
+  if (skillBody) {
+    evidenceLines.push(...evidenceFromMarkdown(skillBody, ["Design Thinking", "Methodology", "Task"], "Prior skill"));
+  } else {
+    evidenceLines.push(`Prior skill missing: ${rel(target, skillPath)}`);
+  }
+
+  const producerBody = await readOptional(producerPath);
+  if (producerBody) {
+    evidenceLines.push(...evidenceFromMarkdown(producerBody, ["Task", "Principles"], "Prior producer"));
+  } else {
+    evidenceLines.push(`Prior producer missing: ${rel(target, producerPath)}`);
+  }
+
+  for (const reviewer of pair.reviewers) {
+    const reviewerPath = join(snapshotLoom, "agents", `${reviewer}.md`);
+    reviewerPaths[reviewer] = (await exists(reviewerPath)) ? reviewerPath : null;
+    const reviewerBody = await readOptional(reviewerPath);
+    if (reviewerBody) {
+      evidenceLines.push(
+        ...evidenceFromMarkdown(reviewerBody, ["Task", "Principles"], `Prior reviewer ${reviewer}`),
+      );
+    } else {
+      evidenceLines.push(`Prior reviewer missing: ${rel(target, reviewerPath)}`);
+    }
+  }
+
+  return {
+    skillPath: skillBody ? skillPath : null,
+    producerPath: producerBody ? producerPath : null,
+    reviewerPaths,
+    evidenceLines: uniqueCapped(evidenceLines, 10),
+  };
+}
+
+function evidenceBulletBlock(lines: string[]): string {
+  const body = lines.length > 0 ? lines : ["No readable prior body evidence; preserve only registry topology."];
+  return body.map((line) => `- ${line}`).join("\n");
+}
+
+function renderPairSkill(pair: RegistryPair, intent: PairIntent, signals: RepoSignals): string {
+  const evidence = evidenceBulletBlock(intent.evidenceLines);
+  const signalLine =
+    signals.evidence.length > 0
+      ? signals.evidence.join(", ")
+      : "no strong repo surface signal beyond the preserved harness registry";
+  return renderTemplate(
+    // The current pair-dev template owns section order and frontmatter shape.
+    // Auto-setup only fills it with conservative convergence prose.
+    loadTemplateSync(PAIR_SKILL_TEMPLATE).replace("name: {{PAIR_SLUG}}", "name: {{SKILL_SLUG}}"),
+    {
+      PAIR_SLUG: pair.pair,
+      SKILL_SLUG: pair.skill,
+      PAIR_TITLE: titleFromSlug(pair.pair),
+      DESIGN_THINKING_PARAGRAPH:
+        `${titleFromSlug(pair.pair)} preserves the target's registered producer-reviewer responsibility while refreshing the body against the current harness contract. The snapshot evidence below is intent input, not restored runtime law.`,
+      METHODOLOGY_BODY:
+        `### Preserved Snapshot Intent\n\n${evidence}\n\n` +
+        `### Repo Evidence\n\n- Detected surfaces: ${signalLine}.\n\n` +
+        "### Convergence Workflow\n\n" +
+        "1. Read the orchestrator envelope and the shared `harness-context` law before touching files.\n" +
+        "2. Use the preserved snapshot intent to identify the workstream this pair owns.\n" +
+        "3. Inspect current project files instead of assuming the snapshot body is still correct.\n" +
+        "4. Keep writes inside the envelope `Scope` and report every changed path.\n" +
+        "5. Treat split, reorder, or ownership ambiguity as a structural issue for planning.",
+      EVAL_CRITERIA_BULLETS:
+        "- The producer output satisfies the envelope goal and stays inside the declared scope.\n" +
+        "- Snapshot intent is used as evidence, not as a copied contract.\n" +
+        "- Current project files and tests are cited when behavior changes.\n" +
+        "- The reviewer can verify filesystem effects and regression evidence.\n" +
+        "- Structural ambiguity is surfaced instead of hidden in a PASS.",
+      TABOO_BULLETS:
+        "- Do not restore stale snapshot files by copying them over current templates.\n" +
+        "- Do not edit `.harness/cycle/`; only the orchestrator owns runtime state.\n" +
+        "- Do not write derived provider trees; use explicit sync after convergence.\n" +
+        "- Do not broaden this pair into unrelated repository ownership.",
+    },
+  );
+}
+
+function renderProducerAgent(pair: RegistryPair): string {
+  const raw = loadTemplateSync(PRODUCER_TEMPLATE).replace(
+    "name: {{PAIR_SLUG}}-producer",
+    "name: {{PRODUCER_SLUG}}",
+  );
+  return renderTemplate(raw, {
+    PAIR_SLUG: pair.pair,
+    PRODUCER_SLUG: pair.producer,
+    SKILL_SLUG: pair.skill,
+    PRODUCER_ROLE_NAME: titleFromSlug(pair.producer),
+    IDENTITY_PARAGRAPH:
+      `${titleFromSlug(pair.producer)} is the producer for the registered \`${pair.pair}\` harness pair. It turns the orchestrator envelope, the shared pair skill, and current project evidence into one reviewed work artifact.`,
+    PRINCIPLE_1: "Ground work in the envelope. Reason: the orchestrator owns task boundaries and runtime state.",
+    PRINCIPLE_2: "Use snapshot intent carefully. Reason: old files explain responsibility but do not define the current contract.",
+    PRINCIPLE_3: "Prefer narrow filesystem changes. Reason: convergence should not expand this pair's authority by accident.",
+    PRINCIPLE_4: "Verify concrete effects. Reason: reviewers need paths, diffs, and command evidence rather than intent claims.",
+    PRINCIPLE_5: "Surface structural uncertainty. Reason: split, ownership, or contract gaps belong in planner-visible escalation.",
+    TASK_STEPS:
+      "1. Read the dispatch envelope and the `harness-context` authority rules.\n" +
+      `2. Load the shared \`${pair.skill}\` skill and identify the pair responsibility.\n` +
+      "3. Inspect current project files named by the task scope.\n" +
+      "4. Produce the requested artifact or code change inside scope.\n" +
+      "5. Run the smallest relevant verification command available.\n" +
+      "6. Report changed files, verification, and remaining work in the Producer Output Format.",
+  });
+}
+
+function renderReviewerAgent(pair: RegistryPair, reviewer: string): string {
+  const raw = loadTemplateSync(REVIEWER_TEMPLATE).replace(
+    "name: {{PAIR_SLUG}}-reviewer",
+    "name: {{REVIEWER_SLUG}}",
+  );
+  return renderTemplate(raw, {
+    PAIR_SLUG: pair.pair,
+    REVIEWER_SLUG: reviewer,
+    SKILL_SLUG: pair.skill,
+    REVIEWER_ROLE_NAME: titleFromSlug(reviewer),
+    IDENTITY_PARAGRAPH:
+      `${titleFromSlug(reviewer)} is a reviewer for the registered \`${pair.pair}\` harness pair. It grades the paired producer artifact against the shared skill, current contracts, and concrete filesystem evidence.`,
+    PRINCIPLE_1: "Review by evidence. Reason: verdicts must cite concrete files, lines, diffs, or command results.",
+    PRINCIPLE_2: "Preserve the pair boundary. Reason: this reviewer grades its registered workstream, not adjacent ownership.",
+    PRINCIPLE_3: "Check contract freshness. Reason: reconstructed pairs must follow current templates and harness-context law.",
+    PRINCIPLE_4: "Treat missing tests honestly. Reason: a PASS without regression evidence can hide broken convergence.",
+    PRINCIPLE_5: "Escalate structural gaps. Reason: invalid planning or ownership cannot be repaired by reviewer optimism.",
+    TASK_STEPS:
+      "1. Read the producer task artifact and linked diff evidence.\n" +
+      `2. Load the shared \`${pair.skill}\` skill and evaluate its criteria.\n` +
+      "3. Check that changed files stay inside the envelope scope.\n" +
+      "4. Verify the producer used current contracts rather than stale snapshot copies.\n" +
+      "5. Inspect stated tests or explain why regression evidence is insufficient.\n" +
+      "6. Emit the Reviewer Output Format with PASS or FAIL.",
+  });
+}
+
+function loadTemplateSync(path: string): string {
+  try {
+    return readFileSync(path, "utf8");
+  } catch {
+    die(`missing template: ${path}`);
+  }
+}
+
+function runRegisterPair(target: string, pair: RegistryPair): unknown {
+  const args = [
+    REGISTER_PAIR_SCRIPT,
+    "--target",
+    target,
+    "--pair",
+    pair.pair,
+    "--producer",
+    pair.producer,
+    "--skill",
+    pair.skill,
+  ];
+  for (const reviewer of pair.reviewers) args.push("--reviewer", reviewer);
+  const result = spawnSync(process.execPath, args, { encoding: "utf8" });
+  if (result.stderr) process.stderr.write(result.stderr);
+  if (result.status !== 0) {
+    const detail = result.stderr.trim() || result.stdout.trim() || "registration failed";
+    die(`pair reconstruction failed for ${pair.pair}: ${detail}`);
+  }
+  try {
+    return JSON.parse(result.stdout);
+  } catch {
+    return result.stdout.trim();
+  }
+}
+
+async function reconstructPairs(
+  target: string,
+  snapshotPath: string | null,
+  registry: RegistrySummary,
+  signals: RepoSignals,
+): Promise<PairReconstruction[]> {
+  if (!snapshotPath || registry.pairCount === 0) return [];
+  const out: PairReconstruction[] = [];
+  const seen = new Set<string>();
+  for (const pair of registry.pairs) {
+    const invalidReason = validatePair(pair, seen);
+    if (invalidReason) {
+      out.push({
+        pair: pair.pair,
+        status: "skipped",
+        reason: invalidReason,
+        producer: pair.producer,
+        reviewers: pair.reviewers,
+        skill: pair.skill,
+        filesWritten: [],
+        registry: null,
+        evidenceLines: [],
+      });
+      continue;
+    }
+    seen.add(pair.pair);
+    const intent = await collectPairIntent(target, snapshotPath, pair);
+    const filesWritten: string[] = [];
+    const skillDir = join(target, ".harness", "loom", "skills", pair.skill);
+    const agentsDir = join(target, ".harness", "loom", "agents");
+    await mkdir(skillDir, { recursive: true });
+    await mkdir(agentsDir, { recursive: true });
+
+    const skillFile = join(skillDir, "SKILL.md");
+    await writeFile(skillFile, renderPairSkill(pair, intent, signals));
+    filesWritten.push(rel(target, skillFile));
+
+    const producerFile = join(agentsDir, `${pair.producer}.md`);
+    await writeFile(producerFile, renderProducerAgent(pair));
+    filesWritten.push(rel(target, producerFile));
+
+    for (const reviewer of pair.reviewers) {
+      const reviewerFile = join(agentsDir, `${reviewer}.md`);
+      await writeFile(reviewerFile, renderReviewerAgent(pair, reviewer));
+      filesWritten.push(rel(target, reviewerFile));
+    }
+
+    const registration = runRegisterPair(target, pair);
+    out.push({
+      pair: pair.pair,
+      status: "reconstructed",
+      reason: "current pair-dev templates rendered from snapshot evidence",
+      producer: pair.producer,
+      reviewers: pair.reviewers,
+      skill: pair.skill,
+      filesWritten,
+      registry: registration,
+      evidenceLines: intent.evidenceLines,
+    });
+  }
+  return out;
+}
+
+function finalizerEvidence(body: string, summary: FinalizerSummary): string[] {
+  const marked = markedEvidence(body);
+  if (marked && marked.length > 0) return marked;
+  const out: string[] = [];
+  if (summary.signals.length > 0) out.push(`Signals: ${summary.signals.join(", ")}`);
+  const preview = taskPreview(body);
+  if (preview) out.push(`Prior task: ${preview}`);
+  out.push(...evidenceFromMarkdown(body, ["Task", "Principles"], "Prior finalizer"));
+  return uniqueCapped(out, 10);
+}
+
+function renderFinalizerFromTemplate(template: string, evidenceLines: string[]): string {
+  const evidence = evidenceBulletBlock(evidenceLines);
+  const task =
+    "\n" +
+    "This finalizer was reconstructed by `/harness-auto-setup` from snapshot evidence. The preserved intent below is evidence, not restored contract text.\n\n" +
+    "### Preserved Intent Evidence\n\n" +
+    `${evidence}\n\n` +
+    "### Current Contract Task\n\n" +
+    "1. Read the envelope and confirm the concrete cycle-end scope.\n" +
+    "2. Use preserved intent evidence to decide which cycle-end duty applies.\n" +
+    "3. Inspect project files and cycle artifacts named by the envelope.\n" +
+    "4. Perform only writes justified by scope, current contracts, and project evidence.\n" +
+    "5. Run the smallest relevant verification for the cycle-end duty.\n" +
+    "6. Emit the Output Format block with concrete paths, verification, and remaining items.\n\n" +
+    "If the preserved intent no longer matches the current goal or project contract, emit the Structural Issue block and return `Status: FAIL`.\n";
+  return replaceSection(template, "Task", task);
+}
+
+async function reconstructFinalizer(
+  target: string,
+  snapshotPath: string | null,
+  summary: FinalizerSummary,
+): Promise<FinalizerReconstruction> {
+  const finalizerPath = join(target, ".harness", "loom", "agents", "harness-finalizer.md");
+  if (summary.status === "absent") {
+    return {
+      status: "missing",
+      reason: "no prior finalizer existed; installed default skeleton left unchanged",
+      path: rel(target, finalizerPath),
+      filesWritten: [],
+      evidenceLines: [],
+    };
+  }
+  if (summary.status !== "customized") {
+    return {
+      status: summary.status === "default-noop" ? "default-noop" : "skipped",
+      reason: `${summary.status} finalizer does not require reconstruction`,
+      path: rel(target, finalizerPath),
+      filesWritten: [],
+      evidenceLines: [],
+    };
+  }
+  if (!snapshotPath) {
+    return {
+      status: "skipped",
+      reason: "customized finalizer was detected but no snapshot path is available",
+      path: rel(target, finalizerPath),
+      filesWritten: [],
+      evidenceLines: [],
+    };
+  }
+  const snapshotFinalizer = join(snapshotPath, "loom", "agents", "harness-finalizer.md");
+  const body = await readOptional(snapshotFinalizer);
+  if (!body) {
+    return {
+      status: "skipped",
+      reason: "customized finalizer evidence was not readable from snapshot",
+      path: rel(target, finalizerPath),
+      filesWritten: [],
+      evidenceLines: [],
+    };
+  }
+  const template = await readFile(FINALIZER_TEMPLATE, "utf8");
+  const evidenceLines = finalizerEvidence(body, summary);
+  await writeFile(finalizerPath, renderFinalizerFromTemplate(template, evidenceLines));
+  return {
+    status: "reconstructed",
+    reason: "current finalizer skeleton rendered with preserved intent evidence",
+    path: rel(target, finalizerPath),
+    filesWritten: [rel(target, finalizerPath)],
+    evidenceLines,
+  };
+}
+
+async function createSnapshot(
+  target: string,
+  createdAt: string,
+  activeCycle: ActiveCycleSummary,
+  registrySummary: RegistrySummary,
+  finalizerSummary: FinalizerSummary,
+  recommendations: { pairs: string[]; finalizer: string; sync: string },
+): Promise<{ created: boolean; path: string; manifestPath: string; copiedNamespaces: string[] }> {
+  const snapshotPath = await allocateSnapshotDir(target, createdAt);
+  const harnessDir = join(target, ".harness");
+  const copiedNamespaces: string[] = [];
+  const copies = [
+    { ns: ".harness/cycle", src: join(harnessDir, "cycle"), dst: join(snapshotPath, "cycle") },
+    { ns: ".harness/loom", src: join(harnessDir, "loom"), dst: join(snapshotPath, "loom") },
+  ];
+  for (const copySpec of copies) {
+    if (await exists(copySpec.src)) {
+      await cp(copySpec.src, copySpec.dst, { recursive: true });
+      copiedNamespaces.push(copySpec.ns);
+    }
+  }
+  copiedNamespaces.sort();
+
+  const manifest: Manifest = {
+    schemaVersion: 1,
+    tool: "harness-auto-setup",
+    targetPath: target,
+    createdAt,
+    snapshotPath,
+    copiedNamespaces,
+    activeCycle,
+    registrySummary,
+    finalizerSummary,
+    nextAction: "Foundation refresh will reseed .harness/loom and .harness/cycle; valid registered pairs and customized finalizer intent will be reconstructed after refresh, then explicit sync remains a user handoff.",
+    recommendations: {
+      mode: "reconstruct-after-refresh",
+      pairs: recommendations.pairs,
+      finalizer: recommendations.finalizer,
+      sync: recommendations.sync,
+    },
+  };
+  const manifestPath = join(snapshotPath, "manifest.json");
+  await writeFile(manifestPath, JSON.stringify(manifest, null, 2) + "\n");
+  return { created: true, path: snapshotPath, manifestPath, copiedNamespaces };
+}
+
+function runInstall(target: string): { status: number | null; stdout: string; stderr: string; summary: unknown } {
+  const result = spawnSync(process.execPath, [INSTALL_SCRIPT, target], { encoding: "utf8" });
+  let summary: unknown = null;
+  if (result.stdout.trim()) {
+    try {
+      summary = JSON.parse(result.stdout);
+    } catch {
+      summary = null;
+    }
+  }
+  return {
+    status: result.status,
+    stdout: result.stdout,
+    stderr: result.stderr,
+    summary,
+  };
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  if (!(await exists(args.target))) die(`target does not exist: ${args.target}`);
+  const targetStat = await stat(args.target);
+  if (!targetStat.isDirectory()) die(`target is not a directory: ${args.target}`);
+
+  const createdAt = new Date().toISOString();
+  const harnessDir = join(args.target, ".harness");
+  const loomDir = join(harnessDir, "loom");
+  const cycleDir = join(harnessDir, "cycle");
+  const loomExists = await exists(loomDir);
+  const cycleExists = await exists(cycleDir);
+  const mode = loomExists || cycleExists ? "existing" : "fresh";
+  const command = syncCommand(args.providers);
+
+  const activeCycle = await classifyCycle(args.target, cycleDir);
+  const registrySummary: RegistrySummary = loomExists
+    ? await summarizeRegistry(args.target, loomDir)
+    : { status: "absent", path: null, pairCount: 0, pairs: [], unparsedLines: [] };
+  const finalizerSummary: FinalizerSummary = loomExists
+    ? await summarizeFinalizer(args.target, loomDir)
+    : {
+        status: "absent",
+        path: null,
+        customized: false,
+        signals: [],
+        taskPreview: null,
+        recommendation: "No prior finalizer exists; keep the installed safe no-op unless repo evidence justifies concrete cycle-end work.",
+      };
+  const signals = await repoSignals(args.target);
+  const recommendations = {
+    pairs: pairRecommendations(registrySummary, signals),
+    finalizer: finalizerRecommendation(finalizerSummary, signals),
+    sync: command,
+  };
+
+  const snapshot =
+    mode === "existing"
+      ? await createSnapshot(args.target, createdAt, activeCycle, registrySummary, finalizerSummary, recommendations)
+      : { created: false, path: null, manifestPath: null, copiedNamespaces: [] };
+
+  const warnings: string[] = [];
+  if (activeCycle.classification === "active" || activeCycle.classification === "unknown") {
+    warnings.push(
+      `Existing cycle classified as ${activeCycle.classification}; it was copied to ${snapshot.path} and will be discarded/reseeded by foundation refresh.`,
+    );
+  }
+  for (const warning of warnings) {
+    process.stderr.write(`harness-auto-setup: warning - ${warning}\n`);
+  }
+
+  const install = runInstall(args.target);
+  if (install.stderr) process.stderr.write(install.stderr);
+  if (install.status !== 0) {
+    const detail = install.stderr.trim() || install.stdout.trim() || "install failed";
+    die(`foundation refresh failed: ${detail}`);
+  }
+
+  const pairReconstructions = await reconstructPairs(args.target, snapshot.path, registrySummary, signals);
+  const finalizerReconstruction = await reconstructFinalizer(args.target, snapshot.path, finalizerSummary);
+
+  const summary = {
+    schemaVersion: 1,
+    tool: "harness-auto-setup",
+    targetPath: args.target,
+    createdAt,
+    mode,
+    snapshot,
+    activeCycle,
+    registrySummary,
+    finalizerSummary,
+    repoSignals: signals,
+    convergence: {
+      mode: "current-contract-reconstruction",
+      note:
+        "Pair/finalizer files were not blind-copied. Valid registered pairs and customized finalizer intent were regenerated against current templates from snapshot evidence.",
+      pairReconstructions,
+      finalizerReconstruction,
+      pairRecommendations: recommendations.pairs,
+      finalizerRecommendation: recommendations.finalizer,
+    },
+    install: {
+      status: install.status,
+      summary: install.summary,
+    },
+    warnings,
+    providerTreesWritten: [],
+    syncCommand: command,
+    nextAction: `From the target root, run \`${command}\` for any platform trees you want to refresh.`,
+  };
+  process.stdout.write(JSON.stringify(summary, null, 2) + "\n");
+}
+
+main().catch((err) => {
+  const msg = err instanceof Error ? err.message : String(err);
+  die(msg);
+});

--- a/plugins/harness-loom/skills/harness-auto-setup/scripts/auto-setup.ts
+++ b/plugins/harness-loom/skills/harness-auto-setup/scripts/auto-setup.ts
@@ -25,6 +25,13 @@ const REVIEWER_TEMPLATE = resolve(PAIR_DEV_DIR, "templates/reviewer-agent.md");
 const PAIR_SKILL_TEMPLATE = resolve(PAIR_DEV_DIR, "templates/pair-skill.md");
 const ALLOWED_PROVIDERS = new Set(["claude", "codex", "gemini"]);
 const HARNESS_SLUG_RE = /^harness-[a-z0-9]+(-[a-z0-9]+)*$/;
+const FOUNDATION_SLUGS = new Set([
+  "harness-context",
+  "harness-orchestrate",
+  "harness-planning",
+  "harness-planner",
+  "harness-finalizer",
+]);
 
 type CycleClassification = "absent" | "pristine" | "active" | "halted" | "unknown";
 type RegistryStatus = "absent" | "present" | "unparsable";
@@ -766,11 +773,13 @@ function validatePair(pair: RegistryPair, seen: Set<string>): string | null {
     ["skill", pair.skill],
   ] as const) {
     if (!HARNESS_SLUG_RE.test(value)) return `${label} slug is outside current harness namespace: ${value}`;
+    if (FOUNDATION_SLUGS.has(value)) return `${label} slug is reserved for a foundation or singleton role: ${value}`;
   }
   if (pair.reviewers.length === 0) return "pair has no reviewer";
   const reviewerSeen = new Set<string>();
   for (const reviewer of pair.reviewers) {
     if (!HARNESS_SLUG_RE.test(reviewer)) return `reviewer slug is outside current harness namespace: ${reviewer}`;
+    if (FOUNDATION_SLUGS.has(reviewer)) return `reviewer slug is reserved for a foundation or singleton role: ${reviewer}`;
     if (reviewerSeen.has(reviewer)) return `duplicate reviewer slug: ${reviewer}`;
     reviewerSeen.add(reviewer);
   }

--- a/plugins/harness-loom/skills/harness-init/SKILL.md
+++ b/plugins/harness-loom/skills/harness-init/SKILL.md
@@ -40,14 +40,14 @@ Then summarize the script result for the user. Trust the script's own output rat
 Install seeds two namespaces:
 
 - `.harness/loom/` — canonical staging for target-side skills, agents, `hook.sh`, and `sync.ts`
-- `.harness/cycle/` — runtime state for `state.md`, `events.md`, and `epics/`
+- `.harness/cycle/` — runtime scaffold for `state.md`, `events.md`, `epics/`, and `finalizer/tasks/`
 
 On a fresh install, the target receives at least:
 
 - `.harness/loom/skills/{harness-orchestrate,harness-planning,harness-context}/`
 - `.harness/loom/agents/{harness-planner,harness-finalizer}.md` — `harness-finalizer.md` is a generic skeleton; the project fills in the concrete cycle-end work (documentation refresh, goal-coverage inspection, release prep, etc.) before running the first real cycle
 - `.harness/loom/{hook.sh,sync.ts}`
-- `.harness/cycle/{state.md,events.md,epics/}`
+- `.harness/cycle/{state.md,events.md,epics/,finalizer/tasks/}`
 
 Install does **not** create `.claude/`, `.codex/`, or `.gemini/`. Those are derived later from `.harness/loom/`.
 
@@ -89,6 +89,7 @@ node .harness/loom/sync.ts --provider claude,codex,gemini
 ## Evaluation Criteria
 
 - Install writes `.harness/loom/` and `.harness/cycle/` in the target project.
+- Install does not create `.harness/cycle/goal.md` or `.harness/cycle/user-request-snapshot.md`; direct runtime goal entry owns cycle-local request snapshots.
 - Install copies target-local `hook.sh` and `sync.ts` into `.harness/loom/`.
 - Install does not create `.claude/`, `.codex/`, or `.gemini/`.
 - Rerun reseeds both `.harness/loom/` and `.harness/cycle/`.

--- a/plugins/harness-loom/skills/harness-init/SKILL.md
+++ b/plugins/harness-loom/skills/harness-init/SKILL.md
@@ -56,6 +56,7 @@ Install does **not** create `.claude/`, `.codex/`, or `.gemini/`. Those are deri
 - Every rerun reseeds both `.harness/loom/` and `.harness/cycle/`.
 - Pair-authored content under `.harness/loom/` is wipe-on-rerun and must be re-authored afterward.
 - Runtime state under `.harness/cycle/` is also reseeded. Finished-cycle preservation belongs to the orchestrator's goal-different archive path, not to `harness-init`.
+- Existing target refresh with pair/finalizer convergence belongs to `/harness-auto-setup`. `harness-init` does not snapshot live harness state, parse old registry intent, or preserve customized finalizer work.
 
 If the script reports that pair-authored content inside `.harness/loom/` was removed during a rerun, surface that clearly to the user so they can re-author those pairs afterward.
 

--- a/plugins/harness-loom/skills/harness-init/references/runtime/harness-context/SKILL.template.md
+++ b/plugins/harness-loom/skills/harness-init/references/runtime/harness-context/SKILL.template.md
@@ -21,21 +21,18 @@ This document is written for the currently dispatched subagent. Your agent body 
 
 ### 2. Read the envelope
 
-At dispatch time the orchestrator supplies the fields below in the prompt. Use them as the authority for this turn's scope, target artifact, and immediate objective. Do not read `state.md` to infer routing for yourself.
+At dispatch time the orchestrator supplies a role-specific envelope. Use it as the authority for this turn's scope, artifact, and immediate objective. Do not read `state.md` to infer routing for yourself, and do not invent omitted placeholder fields.
 
-- **Goal** — one paragraph with the top-level goal of this cycle.
-- **Focus EPIC** — `EP-N--slug` plus the one-line outcome for that EPIC. If the planner is being called, this is `(none)` or the existing EPIC list.
-- **Task path** — the path this turn's artifact is attached to. Pair and finalizer turns receive a real artifact path; planner turns set this to `(none)`.
-- **Scope** — one sentence defining which files or paths are allowed this turn. Do not modify anything outside it.
-- **Current phase** — the natural-language instruction for what must happen now. This field settles "what do I do in this turn?"
-- **Prior tasks / Prior reviews** — arrays of previous artifact paths. On rework they provide the baseline; on retreat they provide the target to repair; on forward progress they provide upstream evidence relevant to this turn.
-- **Axis** — reviewer-only field. In a 1:M pair it names the grading axis owned by this reviewer. In 1:1 it is omitted or set to `(entire pair)`.
-- **Existing EPICs / Recent events / Registered roster** — planner-only additions. They provide the current EPIC list, recent state changes, and the project's current roster for this turn.
+- **Common fields** — `Goal`, `User request snapshot`, `Turn intent`, and `Scope`. `Goal` is a compact summary; `User request snapshot` is the full request path; `Turn intent` is what this turn must do now.
+- **Pair additions** — `Focus EPIC`, `Task path`, `Prior tasks`, `Prior reviews`, pair `rubric`, and reviewer-only `Axis` when supplied.
+- **Planner additions** — `Existing EPICs`, `Recent events`, `Registered roster`, and prior artifacts only when the recall needs them. Planner envelopes do not need a task-path placeholder.
+- **Finalizer additions** — `Task path`, `Prior tasks`, and `Prior reviews`. Finalizer envelopes do not need an EPIC placeholder, pair rubric, or reviewer axis.
 
 ### 3. If you are a pair producer
 
 - Produce the task artifact by following the pair skill's rubric.
-- Your artifact is the content that will be written to `Task path`. Include the role's required output block plus the evidence and body required by the pair skill, but do not write any control-plane fields. A paired reviewer decides the verdict; your own `Status` is self-report only.
+- Your artifact is the content that will be written to `Task path`. Include the role's reduced producer output block (`Status`, `Summary`, `Files created`, `Files modified`, `Diff summary`, `Self-verification`, `Remaining items`) plus any evidence/body required by the pair skill. A paired reviewer decides the verdict; your own `Status` is self-report only.
+- Read `User request snapshot` before narrowing the work if it contains constraints beyond `Turn intent`.
 - Do not modify files outside `Scope`.
 - Task ids and task-file history are orchestrator-owned. Return the artifact content; the orchestrator records it on disk.
 - If you detect an upstream contract failure you cannot resolve inside this turn, report it with `## Structural Issue` instead of flattening it into a generic FAIL. The paired reviewer will restate and judge it in the review.
@@ -46,18 +43,22 @@ At dispatch time the orchestrator supplies the fields below in the prompt. Use t
 - Apply the pair skill's Evaluation Criteria and return PASS or FAIL.
 - If `Axis` is present, focus on criteria tagged for that axis. Untagged shared criteria still apply.
 - Use the task artifact and concrete disk evidence from the files it changed or cited. Do not use producer transcript, tool trace, or another reviewer's decision as evidence.
+- Use `User request snapshot` and `Prior reviews` as grading context. A producer can fail even when the local task is implemented if it ignores required original-request constraints or unresolved prior-review findings.
+- End with the reduced reviewer output block: `Verdict`, `Criteria`, `FAIL items`, and `Feedback`. Put domain-specific regression notes in the body or `Feedback` when useful; do not add advisory routing fields.
 - Do not pull FAIL items from another axis into your own verdict. Cross-review synthesis belongs to the orchestrator.
 
 ### 5. If you are the planner
 
 - You are a meta-role with no paired reviewer. You do not leave task or review files.
 - Follow `harness-planning` for the planner-specific field set, roster rules, and re-plan behavior.
+- Prefer `User request snapshot` over the short `Goal` summary when extracting line-cited request evidence.
 - The orchestrator owns runtime fields such as `current`, `note`, and `Next`; do not emit them from planner output, and do not include task file paths.
 
 ### 6. If you are a finalizer
 
 - You run only in a cycle-end finalizer turn. There is no paired reviewer, and the concrete rubric for the turn lives inside your agent body.
-- Your `Status: PASS | FAIL` plus `Self-verification` block is the verdict source. Cite concrete mechanical evidence — file paths, diff summaries, exit codes, coverage tallies — not narrative.
+- Your reduced finalizer output block keeps `Status`, `Summary`, `Files created`, `Files modified`, `Self-verification`, and `Remaining items`; an optional `Files left alone (intentionally)` line is allowed only when useful. `Status: PASS | FAIL` plus `Self-verification` is the verdict source. Cite concrete mechanical evidence — file paths, diff summaries, exit codes, coverage tallies — not narrative.
+- Read `User request snapshot` when cycle-end work checks request coverage or release readiness.
 - Do not request reviewer dispatch and do not emit reviewer-shape fields. Finalizer turns leave 0 review files.
 - If an upstream contract is invalid (for example, the cycle claims to have shipped a result with no source evidence), emit the `## Structural Issue` block inside your artifact with `Suspected upstream stage: planner`. The orchestrator will recall the planner rather than redispatching the finalizer in place.
 
@@ -87,7 +88,8 @@ Assume only the skills explicitly attached to your role plus the dispatch envelo
 ## Evaluation Criteria
 
 - Your output follows the correct role-specific return shape for pair producer, pair reviewer, planner, or finalizer.
-- You actually use the envelope fields `Goal`, `Current phase`, `Scope`, and `Task path` when your role has one.
+- You actually use the envelope fields `Goal`, `Turn intent`, `Scope`, and `Task path` when your role has one.
+- When supplied, `User request snapshot` is read or explicitly judged irrelevant to the current narrow task.
 - You do not modify anything outside `Scope`.
 - Your output contains no control-plane fields such as `Next`, `current`, or `loop`.
 - Reviewer evidence stays anchored to one task artifact.
@@ -100,6 +102,8 @@ Assume only the skills explicitly attached to your role plus the dispatch envelo
 - Write directly under `.harness/cycle/` or `.harness/loom/`; return content only.
 - Modify files outside the envelope scope.
 - Replace orchestrator routing by emitting `Next`, `current`, or `loop` in your output.
+- Add advisory or escalation routing fields; use `Remaining items`, `Feedback`, or `## Structural Issue` according to role.
+- Treat `Turn intent` as permission to ignore the full user request snapshot.
 - Use producer transcript or tool trace as reviewer evidence.
 - Try to manage task ids or on-disk history yourself.
 - Flatten a structural issue into a generic FAIL and force endless same-pair rework.

--- a/plugins/harness-loom/skills/harness-init/references/runtime/harness-finalizer.template.md
+++ b/plugins/harness-loom/skills/harness-init/references/runtime/harness-finalizer.template.md
@@ -13,7 +13,7 @@ The default body below is a safe no-op: it returns `Status: PASS` with `Summary:
 
 ## Principles
 
-1. Read before writing. Start from the envelope (`Goal`, `Scope`, `Current phase`, `Prior tasks`) and derive output from project evidence rather than from a fixed template, because the finalizer runs in arbitrary target projects.
+1. Read before writing. Start from the envelope (`Goal`, `User request snapshot`, `Scope`, `Turn intent`, `Prior tasks`) and derive output from project evidence rather than from a fixed template, because the finalizer runs in arbitrary target projects.
 2. Stay inside the declared scope. Do exactly one cycle-end job and keep writes inside the envelope `Scope`; the default no-op body writes nothing.
 3. Evolve, don't overwrite. When cycle-end outputs already exist, preserve hand-authored content outside clearly-managed regions; append or extend rather than replace.
 4. Self-verification is the verdict. Cite concrete mechanical evidence — file paths, diff summaries, exit codes, coverage tallies — because the orchestrator reads `Status` + `Self-verification` as the entire verdict source. The no-op body cites that no cycle-end work was performed.
@@ -36,11 +36,11 @@ Status: PASS / FAIL
 Summary: {what was performed in one line; default no-op uses "no cycle-end work registered for this project"}
 Files created: [{file path}]
 Files modified: [{file path}]
-Files left alone (intentionally): [{file path — one-line reason}]
 Self-verification: {concrete mechanical evidence — file paths, diff summaries, exit codes, coverage tallies; default no-op cites "no cycle-end work required; no files touched"}
 Remaining items: [{items not yet done}]
-Escalation: {none | structural-retreat-to-planner, reason}
 ```
+
+Optional line: inside the fenced block, include `Files left alone (intentionally): [{file path — one-line reason}]` before `Self-verification` only when it carries useful cycle-end evidence. Omit it for the default no-op or empty lists.
 
 If a structural issue is detected, include this block immediately before the Output Format block:
 

--- a/plugins/harness-loom/skills/harness-init/references/runtime/harness-orchestrate/SKILL.template.md
+++ b/plugins/harness-loom/skills/harness-init/references/runtime/harness-orchestrate/SKILL.template.md
@@ -16,16 +16,7 @@ Every response executes exactly one of three runtime turn kinds:
 
 The orchestrator does not do domain work itself. It reads the saved `Next`, dispatches exactly one turn, persists that turn's artifacts, computes the next `Next`, and yields. Hook is only the re-entry trigger. The orchestrator's job is to keep the cycle deterministic, auditable, and moving.
 
-### Quick Map
-
-Read the runtime in this order:
-
-1. On direct `/harness-orchestrate <file.md>` entry, run Goal-anchored entry first; on Hook re-entry, resume from saved state.
-2. Consume the saved `Next` and dispatch exactly one turn: Planner, Pair, or Finalizer.
-3. Persist that turn's artifacts and verdict.
-4. Synthesize the next `Next`, or halt with `loop: false`.
-
-For a compact DFA diagram and transition table, see `references/state-machine.md`. For the exact dispatch-envelope payload, see `references/dispatch-envelope.md`.
+For a compact DFA diagram, see `references/state-machine.md`. For the exact dispatch-envelope payload, see `references/dispatch-envelope.md`.
 
 ## Methodology
 
@@ -40,13 +31,14 @@ Read the canonical runtime references at the start of every turn before editing 
 
 - `references/state-md-schema.md` — header, `## Next`, and `## EPIC summaries`
 - `references/events-md-format.md` — append-only events line format
+- `references/dispatch-envelope.md` — role-specific subagent payloads
 
 #### Authority Rules
 
 - Only the orchestrator writes under `.harness/cycle/`. `.harness/loom/` is read-only for the orchestrator. `.harness/_archive/` is touched only by goal reset under §Entry, reset, and halt paths.
 - Out-of-cycle write scope (target root `*.md`, `docs/`, release artifacts, audit output, etc.) is reserved for the finalizer turn and declared in that agent's own `Scope`.
 - Subagents may return supporting body or evidence before their concluding Output Format block. The orchestrator parses the turn result from that concluding block plus any top-level `## Structural Issue` block.
-- `Suggested next-work`, `Advisory-next`, and `Escalation` are advisory only. The orchestrator synthesizes the real `Next`.
+- Advisory or escalation routing fields are not part of the runtime output contract. If a legacy artifact includes them, ignore them; the orchestrator synthesizes the real `Next` from reviewer verdicts, planner `next-action`, finalizer `Status`, and `## Structural Issue`.
 - Subagents run with `fork_context=false`. Reviewers judge the disk artifact plus concrete disk evidence; they never see producer transcript, tool trace, or another reviewer's verdict.
 
 #### Pair turn contract
@@ -56,7 +48,7 @@ One Pair turn always follows the same artifact law, regardless of which register
 - **Task** (exactly 1) — `.harness/cycle/epics/EP-N--{slug}/tasks/T{id}--{task-slug}.md`
 - **Review** (1 or M files) — `.harness/cycle/epics/EP-N--{slug}/reviews/T{id}--{task-slug}--{reviewer-name}.md`
 
-Producer artifacts may include domain body and evidence, but must end with the producer Output Format block. Reviewer artifacts may include supporting rationale, but must end with the reviewer Output Format block. A `## Structural Issue` block belongs in the review artifact when the reviewer judges the issue as structural.
+Producer artifacts may include domain body and evidence, but must end with the reduced producer Output Format block. Reviewer artifacts may include supporting rationale, but must end with the reduced reviewer Output Format block. No advisory routing field is parsed. A `## Structural Issue` block belongs in the review artifact when the reviewer judges the issue as structural.
 
 Rework never overwrites the same task id. The orchestrator allocates a fresh `T<id>` so the previous task and reviews remain on disk. Structural retreat follows the same rule.
 
@@ -67,38 +59,28 @@ The finalizer is a singleton cycle-end turn, not a registered pair.
 - **Task** (exactly 1) — `.harness/cycle/finalizer/tasks/T{id}--cycle-end.md`
 - **Review** — none
 
-The finalizer artifact may include supporting body and evidence, but must end with the finalizer's concluding producer-shaped block. Verdict source is the finalizer's own `Status: PASS|FAIL` line plus its `Self-verification` block; a top-level `## Structural Issue` block signals RETREAT. FAIL or RETREAT routes to planner recall, not in-place rework.
+The finalizer artifact may include supporting body and evidence, but must end with the finalizer Output Format block. Verdict source is the finalizer's own `Status: PASS|FAIL` line plus its `Self-verification` block; a top-level `## Structural Issue` block signals RETREAT. FAIL or RETREAT routes to planner recall, not in-place rework.
 
 The finalizer is dispatched only when every live EPIC is terminal and `planner-continuation: none`.
 
 #### Registry contract
 
-`.harness/loom/registry.md` is the sole source of truth for the pair roster. It contains only Pair stages, never the planner or finalizer. Two line shapes exist:
-
-- 1:1 — `` - <pair>: producer `<p>` ↔ reviewer `<r>`, skill `<s>` ``
-- 1:M — `` - <pair>: producer `<p>` ↔ reviewers [`<r1>`, `<r2>`], skill `<s>` ``
-
-The `↔` arrow is load-bearing. When `Next.To` resolves to a pair producer slug, the orchestrator finds the matching registry line and uses that line's position as the producer's global stage index.
-
-The planner and finalizer are singleton turns:
-
-- `Next.To = planner` dispatches `.harness/loom/agents/harness-planner.md`
-- `Next.To = harness-finalizer` dispatches `.harness/loom/agents/harness-finalizer.md`
+`.harness/loom/registry.md` is the sole source of truth for executable Pair stages. It contains only lines shaped as `` - <pair>: producer `<p>` ↔ reviewer(s) ..., skill `<s>` ``. The `↔` segment binds a producer to its reviewer set, and the line position is the producer's global stage index. The planner and finalizer are singleton dispatches (`planner`, `harness-finalizer`), never registry entries.
 
 ### 2. One-turn algorithm
 
-On direct `/harness-orchestrate <file.md>` invocation, apply §Goal-anchored entry before consuming `Next`. On Hook re-entry, skip that gate and continue from the saved control plane.
+On direct `/harness-orchestrate <file.md>` invocation, apply §Request-anchored entry before consuming `Next`. On Hook re-entry, skip that gate and continue from the saved control plane.
 
 #### Turn rhythm (one response = consume `Next`, produce the next `Next`)
 
-1. Read `references/state-md-schema.md` and `references/events-md-format.md` first so the read/write shape is locked.
+1. Read `references/state-md-schema.md`, `references/events-md-format.md`, and `references/dispatch-envelope.md` first so the read/write shape is locked.
 2. Write `loop: false` into `state.md` first to lock out re-entry. Codex and Gemini hooks may fire on subagent completion, so this lock is the first write of every turn whether or not `Next` exists.
 3. Read `state.md` and inspect `## Next`. If empty or absent, branch to Cold start / Halt under §Entry, reset, and halt paths.
 4. Classify `Next.To`:
    - `planner` → Planner turn
    - `harness-finalizer` → Finalizer turn
    - anything else → Pair turn via registry lookup in `## Registered pairs` (missing slug is an error)
-5. Assemble the dispatch envelope and run the turn with `fork_context=false`.
+5. Assemble the role-specific dispatch envelope from `references/dispatch-envelope.md` and run the turn with `fork_context=false`.
 6. Persist artifacts by turn kind:
    - **Planner** — no task/review files. Absorb the planner output into `## EPIC summaries` and append one planner result line into `events.md`. If `Additional pairs required` is non-empty, append a separate orchestrator note so the request survives into future planner recalls through `Recent events`.
    - **Pair** — write the producer artifact into `Next.Task path`, then dispatch the paired reviewer(s) in parallel within the same response. Write each reviewer artifact into its review path.
@@ -133,7 +115,7 @@ After a planner turn:
    - `Next.Intent = (gate condition: ready set empty; repair upstream or roster slices against current state)`
 9. If every live EPIC is terminal, apply Terminal resolution below.
 
-#### Phase advance — Pair rules
+#### Pair verdict branch
 
 The verdict source is the aggregated reviewer set.
 
@@ -152,7 +134,7 @@ Apply this rule whenever a Planner or Pair turn leaves every live EPIC terminal 
 - `planner-continuation: pending` — planner continuation recall: `Next.To = planner`, `Next.EPIC = (none)`, `Next.Task path = (none)`, `Next.Intent = (planner continuation: planning deferred until all live EPICs reached terminal — re-plan against execution evidence in events.md)`
 - `planner-continuation: none` or absent — finalizer entry: `Next.To = harness-finalizer`, `Next.EPIC = (none)`, `Next.Task path = .harness/cycle/finalizer/tasks/T{id}--cycle-end.md`, `Next.Intent = (cycle-end finalizer)`
 
-#### Phase advance — Finalizer rules
+#### Finalizer verdict branch
 
 1. **PASS** — cycle complete. Clear `Next`, keep `loop: false`, stop. Hook does not re-enter.
 2. **FAIL or RETREAT** — planner recall:
@@ -169,11 +151,9 @@ Do not touch `planner-continuation` in this branch. The recovery loop is bounded
 
 #### Dispatch envelope
 
-Subagents run with `fork_context=false`, so the envelope is the only runtime payload they should trust for this turn.
+Subagents run with `fork_context=false`, so the envelope is the only runtime payload they should trust for this turn. The envelope-facing field for `Next.Intent` is `Turn intent`; do not emit legacy phase wording for that field.
 
-Every envelope includes `Goal`, `Focus EPIC`, `Task path`, `Scope`, `Current phase`, `Prior tasks`, and `Prior reviews`. Reviewers may also receive `Axis`. Pair turns include the rubric path. Planner turns add `Existing EPICs`, `Recent events`, and `Registered roster`. Finalizer turns omit reviewer-only and pair-only fields.
-
-The exact block descriptions and per-turn envelope shape live in `references/dispatch-envelope.md`.
+`references/dispatch-envelope.md` owns the role-specific minimum field set. Every executable Planner, Pair, and Finalizer dispatch must carry `Goal`, `User request snapshot`, `Turn intent`, and `Scope`; placeholder fields for unrelated roles are omitted.
 
 #### Context propagation
 
@@ -183,95 +163,66 @@ The exact block descriptions and per-turn envelope shape live in `references/dis
 
 No branch should rely on hidden side references or unstated runtime context.
 
+#### User request snapshot propagation
+
+The `Goal` header in `state.md` is only a compact summary. `.harness/cycle/user-request-snapshot.md` is the full original-request artifact and must be passed as read-only request evidence in every Planner, Pair, and Finalizer envelope after direct entry initializes the cycle.
+
+Keep prior artifacts in `Prior tasks` / `Prior reviews`; do not invent a broader context bundle. If an executable dispatch needs original request detail but the snapshot is missing outside the empty/bootstrap direct-entry path, treat that as a runtime contract defect rather than synthesizing a placeholder.
+
 #### Structural Issue handling
 
-When a Pair reviewer or the Finalizer detects an upstream contract failure that cannot be resolved inside the current turn, the artifact reports it in this shape:
-
-```markdown
-## Structural Issue
-
-- Suspected upstream stage: {producer name | planner}
-- Blocked contract: {what cannot be satisfied}
-- Why this role cannot resolve it: {reason}
-- Evidence: {concrete task or review evidence}
-- Suggested repair focus: {what the upstream stage should revisit}
-```
-
-Use when: (a) an upstream artifact is invalid, (b) the pair contract itself is wrong, (c) an agent-skill mismatch makes downstream work impossible, or (d) a finalizer's cycle-end check fails against the planned outcome. `Suspected upstream stage: planner` is correct when the fault is in the plan.
-
-Do **not** use when ordinary same-role rework is enough.
+`## Structural Issue` is the only structural escalation surface. Pair reviewers and the Finalizer emit the report shape defined in `harness-context`; the orchestrator consumes `Suspected upstream stage` to choose planner recall or producer rewind. Use it only when ordinary same-role rework cannot repair the upstream contract.
 
 ### 4. Entry, reset, and halt paths
 
 #### Cold start / Halt
 
-- **Cold start** — `state.md` has no `Next` block and no EPIC summaries. `loop: false` is already written. Synthesize the initial planner dispatch with `To: planner`, `EPIC: (none)`, `Task path: (none)`, `Intent: read the full goal and decompose it into EPICs`, then execute it in the same response.
+- **Cold start** — `state.md` has no `Next` block and no EPIC summaries. `loop: false` is already written. Synthesize the initial planner dispatch with `To: planner`, `EPIC: (none)`, `Task path: (none)`, `Intent: read the user request snapshot and decompose it into EPICs`, then execute it in the same response.
 - **Manual / terminal halt** — if the user manually clears `Next`, halt immediately. Automatic halt follows Terminal resolution and Finalizer rule 1. All halt paths keep `loop: false`.
 
-#### Goal-anchored entry
+#### Request-anchored entry
 
 When `/harness-orchestrate <filename.md>` is invoked:
 
-1. Read `<filename.md>` and treat the entire trimmed body as the Goal. Do not require load-bearing headers such as `# Goal`.
-2. Compare it to the existing `Goal (from X):` in `state.md` and choose the lightest honest action:
+1. Read `<filename.md>` and treat the entire trimmed body as the original user request. Derive the `Goal` header as a compact summary. Do not require load-bearing headers such as `# Goal`.
+2. If `.harness/cycle/user-request-snapshot.md` is missing on an empty/bootstrap cycle, write the full trimmed body there, update the compact `Goal` summary in `state.md`, and continue Cold start in the same response.
+3. Otherwise compare the trimmed body to the existing `.harness/cycle/user-request-snapshot.md` body and choose the lightest honest action:
    - matching or empty -> no-op, continue from current `Next`
    - clearly different intent or domain -> reset
-   - same intent with expanded scope or new detail -> planner recall
-3. **Reset procedure — all in the current response**:
+   - same intent with expanded scope or new detail -> update `.harness/cycle/user-request-snapshot.md` with the expanded body, update the compact `Goal` summary, then planner recall
+4. **Reset procedure — all in the current response**:
    - create `.harness/_archive/<ISO-timestamp>/` (append `--<kebab-slug>` only if two resets collide within the same second)
-   - move `.harness/cycle/state.md`, `.harness/cycle/events.md`, `.harness/cycle/epics/`, and `.harness/cycle/finalizer/` into that archive
+   - move `.harness/cycle/state.md`, `.harness/cycle/events.md`, `.harness/cycle/user-request-snapshot.md`, `.harness/cycle/epics/`, and `.harness/cycle/finalizer/` into that archive when present
    - leave `.harness/loom/` untouched; finalizer out-of-cycle output at the target root is not part of the cycle trace and must not be archived
-   - write a fresh `.harness/cycle/state.md` per `references/state-md-schema.md` with the new goal body, `Phase: planner`, `loop: false`, `planner-continuation: none`, and a Cold-start `## Next` block whose `Task path` is `(none)`
-   - write a fresh `.harness/cycle/events.md` whose first line is `<ISO-timestamp> T0 orchestrator archive — reset to new goal (from <filename.md>)`
+   - write the full trimmed request body to `.harness/cycle/user-request-snapshot.md`; this artifact, not the inline state header, is the canonical original-request source for subagent envelopes
+   - write a fresh `.harness/cycle/state.md` per `references/state-md-schema.md` with the new compact `Goal` summary, `Phase: planner`, `loop: false`, `planner-continuation: none`, and a Cold-start `## Next` block whose `Task path` is `(none)`
+   - write a fresh `.harness/cycle/events.md` whose first line is `<ISO-timestamp> T0 orchestrator archive — reset to new request (from <filename.md>)`
    - re-enter Cold start in the same response: dispatch the planner, synthesize the follow-up `Next`, and raise `loop: true` at turn end
-4. This classification is the orchestrator's semantic judgment. The Hook re-entry environment has no interactive channel, so do not ask the user for confirmation.
+5. This classification is the orchestrator's semantic judgment. The Hook re-entry environment has no interactive channel, so do not ask the user for confirmation.
 
 #### Hook re-entry
 
-`.harness/loom/hook.sh` checks whether `state.md` has `loop: true` and, if so, emits the platform-appropriate orchestrator invocation (`/harness-orchestrate` or `$harness-orchestrate`) for the next turn. Hook is a re-entry mechanism, not a cadence driver. Every response ends with `state.md` write-back and then yield.
-
-## Evaluation Criteria
-
-- Description surfaces both `/harness-orchestrate <file.md>` and Hook re-entry trigger vocabulary in active form.
-- The body clearly separates the three runtime turn kinds: singleton Planner, registry Pair, singleton Finalizer.
-- `references/state-md-schema.md` and `references/events-md-format.md` remain the canonical storage specs instead of being duplicated inline.
-- `upstream` is preserved as an explicit stored EPIC field and is used in ready-set computation.
-- `Task path` rules are explicit for all three turn kinds: planner `(none)`, pair canonical pair task path, finalizer canonical finalizer task path.
-- Pair and finalizer artifact contracts explicitly allow supporting body plus a concluding parseable block.
-- The Phase advance rules fill the `Next` block (`To / EPIC / Task path / Intent / Prior tasks / Prior reviews`) deterministically for every outcome.
-- Finalizer entry (`all live EPICs terminal + planner-continuation: none`) and FAIL/RETREAT recovery back to planner are both explicit.
-- Cold start, goal-entry branches, and Hook re-entry are easy to find under Entry, reset, and halt paths.
+`.harness/loom/hook.sh` checks whether `state.md` has `loop: true` and, if so, emits the platform-appropriate orchestrator invocation (`/harness-orchestrate` or `$harness-orchestrate`) for the next turn. Hook re-entry never re-reads the original input file; it advances from `state.md` and passes the existing `User request snapshot` path through dispatch envelopes. Hook is a re-entry mechanism, not a cadence driver. Every response ends with `state.md` write-back and then yield.
 
 ## Taboos
 
-- Put pipe tables or row-oriented formatting into `state.md`.
-- Collapse `## EPIC summaries` into one prose blob that hides per-EPIC identity.
-- Use numeric phase slugs. `Phase: planner` or `Phase: skill-writer` is correct; `Phase: 1` is wrong.
-- Dispatch more than one runtime turn in a single response.
-- Let a subagent write the `Next` block directly.
-- Leave `Next` empty or ambiguous when a deterministic next dispatch exists.
-- Reuse a `T<id>` and erase the trace of rework.
-- Re-explain setup, sync, or Hook implementation internals inside this skill body.
-- Ask the user for confirmation while classifying a goal change, or require marker headers in the goal markdown.
-- Record planner output as task files.
+- Dispatch more than one runtime turn in a single response, or raise `loop: true` without a committed valid `Next`.
+- Let a subagent write control-plane fields (`Next`, `current`, `loop`, registry, or EPIC summaries) directly.
+- Reuse a `T<id>` and erase the trace of rework or retreat.
+- Collapse full original-request propagation into a longer `Goal` summary; direct entry owns `.harness/cycle/user-request-snapshot.md`.
+- Record planner output as task files, synthesize finalizer review files, or rework a failed finalizer in place.
 - Mutate an existing EPIC's `outcome`, `upstream`, or `roster` in place. Mark it `superseded` and append a new EPIC.
-- Compare EPIC progress by local roster slot number instead of project-global roster order.
-- Treat `upstream` as a whole-EPIC completion gate instead of a same-stage gate.
-- Move directly gradeable contract blocks (`Authority Rules`, Pair turn contract, Finalizer turn contract, Phase advance, Structural Issue handling) out into references and leave only citations.
-- Copy phase advance, state schema, or Hook re-entry law into the subagent-facing `harness-context`.
-- Synthesize a reviewer dispatch for a finalizer turn, or write a zero-byte review file to preserve symmetry.
-- Skip dispatching the finalizer when every live EPIC is terminal and `planner-continuation: none`.
-- Rework a finalizer in place on FAIL. FAIL and RETREAT always route to planner recall.
-- Write into `.harness/loom/` from the orchestrator.
-- Embed the pair roster inside this SKILL body. It lives in `.harness/loom/registry.md`.
-- Turn the finalizer into a list of agents. Multi-step cycle-end work belongs inside the finalizer body as sequential Task steps.
+- Compare EPIC progress by local roster slot number, or treat `upstream` as a whole-EPIC completion gate.
+- Embed the pair roster in this skill body, register the planner/finalizer as pairs, or dispatch an unregistered pair slug.
+- Copy phase advance, state schema, or Hook re-entry law into `harness-context`.
+- Ask for interactive confirmation while classifying a direct-entry request change; Hook re-entry has no such channel.
 
 ## References
 
 - `references/state-md-schema.md` — canonical fields for the state header, `Next` block, and EPIC summaries
 - `references/events-md-format.md` — canonical one-line events format and invariants
 - `references/state-machine.md` — quick DFA diagram and transition table for scan-first reading
-- `references/dispatch-envelope.md` — exact envelope payload by turn kind
+- `references/dispatch-envelope.md` — exact envelope payload by turn kind, including `User request snapshot` and `Turn intent`
 - `../harness-planning/SKILL.md` — planner rubric for EPIC decomposition and roster writing
 - `../harness-context/SKILL.md` — reduced subagent-facing context skill for envelope reading, output shape, and taboos
 - `.harness/loom/registry.md` — sole source of truth for the pair roster

--- a/plugins/harness-loom/skills/harness-init/references/runtime/harness-orchestrate/references/dispatch-envelope.md
+++ b/plugins/harness-loom/skills/harness-init/references/runtime/harness-orchestrate/references/dispatch-envelope.md
@@ -2,25 +2,29 @@
 
 Quick reference for the runtime payload the orchestrator sends to subagents. This file is a supporting reference; the canonical orchestrator law stays in `../SKILL.template.md`, and the subagent-side read contract stays in `../../harness-context/SKILL.template.md`.
 
-## Shared fields
+## Common fields
 
-Every turn receives these fields:
+Every executable turn receives these fields:
 
-- `Goal` — the `Goal (from X):` paragraph from `state.md`
-- `Focus EPIC` — the selected `EP-N--slug` plus one-line outcome, or `(none)` / existing EPIC list for planner turns
-- `Task path` — copied from `Next.Task path`; planner turns use `(none)`
+- `Goal` — the compact `Goal (from X):` summary from `state.md`; this is a cycle-level quality bar, not the full original request
+- `User request snapshot` — the cycle-local full original request path, normally `.harness/cycle/user-request-snapshot.md`; planner, pair producers/reviewers, and the finalizer read it for original request detail
+- `Turn intent` — the subagent-facing copy of `Next.Intent`
 - `Scope` — one sentence defining writable surfaces for the turn
-- `Current phase` — copied from `Next.Intent`
-- `Prior tasks` — prior task artifact paths attached for context
-- `Prior reviews` — prior review artifact paths attached for context
+
+Omit placeholder fields that do not apply to the role. The state `## Next` block may still carry `Task path: (none)` or `EPIC: (none)` for orchestrator bookkeeping; those placeholders do not need to be forwarded to subagents.
 
 ## Pair envelope
 
 Pair producers and reviewers receive:
 
-- all shared fields
+- all common fields
+- `Focus EPIC` — the selected `EP-N--slug` plus one-line outcome/note context
+- `Task path` — copied from `Next.Task path`
+- `Prior tasks` — prior task artifact paths attached for rework, retreat, or upstream evidence
+- `Prior reviews` — prior review artifact paths attached for rework, retreat, or upstream evidence
 - `rubric: skills/<slug>/SKILL.md`
 - reviewer-only `Axis` when the pair is 1:M
+- `User request snapshot` is read-only request evidence. It does not authorize routing or state mutation, but reviewers may fail work that ignores required original-request constraints.
 
 The orchestrator resolves the reviewer set from `.harness/loom/registry.md`.
 
@@ -28,19 +32,23 @@ The orchestrator resolves the reviewer set from `.harness/loom/registry.md`.
 
 The planner receives:
 
-- all shared fields, with `Focus EPIC: (none)` when dispatch is not EPIC-local
+- all common fields
 - `Existing EPICs` — the full `## EPIC summaries` block from `state.md`
 - `Recent events` — the last five lines of `events.md`
 - `Registered roster` — the full `## Registered pairs` block from `.harness/loom/registry.md`
+- `Prior tasks` / `Prior reviews` only on structural recall, finalizer recall, or another recall where prior artifacts are evidence
 
-Planner turns never receive a task artifact path and never write task or review files.
+Planner envelopes do not include `Task path: (none)` or `Focus EPIC: (none)` placeholders. Planner turns never write task or review files. On initial planning, `User request snapshot` is the best source for line-cited request evidence.
 
 ## Finalizer envelope
 
 The finalizer receives:
 
-- all shared fields
-- no reviewer-only fields
-- no pair rubric line
+- all common fields
+- `Task path` — copied from `Next.Task path`
+- `Prior tasks` — completed task artifacts available for cycle-end work
+- `Prior reviews` — completed review artifacts available for cycle-end work
+
+Finalizer envelopes do not include `Focus EPIC: (none)`, a pair rubric line, or reviewer-only `Axis`.
 
 Its verdict is read from the finalizer artifact's `Status` plus `Self-verification`.

--- a/plugins/harness-loom/skills/harness-init/references/runtime/harness-orchestrate/references/state-md-schema.md
+++ b/plugins/harness-loom/skills/harness-init/references/runtime/harness-orchestrate/references/state-md-schema.md
@@ -1,13 +1,13 @@
 # state.md narrative schema
 
-`.harness/cycle/state.md` is the readable runtime summary that the orchestrator reads and writes every turn. Its structure is a four-line header plus a `## Next` block plus an ordered `## EPIC summaries` list. `harness-orchestrate/SKILL.md` cites this file as the canonical schema when editing state, advancing phases, and deciding Cold start vs Halt.
+`.harness/cycle/state.md` is the readable runtime summary that the orchestrator reads and writes every turn. Its structure is a four-line header plus a `## Next` block plus an ordered `## EPIC summaries` list. The full original request is preserved separately in `.harness/cycle/user-request-snapshot.md`; the `Goal` header is a compact human summary, not the full request. `harness-orchestrate/SKILL.md` cites this file as the canonical schema when editing state, advancing phases, and deciding Cold start vs Halt.
 
 ## Canonical shape
 
 ```text
 # Runtime State
 
-Goal (from <filename.md>): <one-paragraph trimmed body>
+Goal (from <filename.md>): <one-paragraph compact summary; full request lives in .harness/cycle/user-request-snapshot.md>
 Phase: <planner | pair-producer-slug | harness-finalizer>
 loop: <true|false>
 planner-continuation: <pending|none>
@@ -29,7 +29,7 @@ outcome: <one-sentence completion condition>
 upstream: <EP-M--slug, ...> | none
 roster: <producer1> → <producer3> → <producer5>
 current: <producer-slug | done | superseded>
-note: <progress state + evidence + goal.md:Lxx citation>
+note: <progress state + evidence + .harness/cycle/user-request-snapshot.md:Lxx citation>
 
 ### EP-2--<slug>
 outcome: ...
@@ -41,7 +41,7 @@ note: ...
 
 ## Field semantics
 
-- **Goal** header — one paragraph containing the trimmed goal markdown body loaded through `/harness-orchestrate <file.md>`. Do not require load-bearing headers such as `# Goal`.
+- **Goal** header — one paragraph summarizing the request markdown loaded through `/harness-orchestrate <file.md>`. Do not require load-bearing headers such as `# Goal`. The full trimmed body is written to `.harness/cycle/user-request-snapshot.md` and is propagated in dispatch envelopes as `User request snapshot`.
 - **Phase** header — an echo of `Next.To`, used only to keep the current turn readable to humans. Numeric slugs are forbidden.
 - **loop** header — Hook re-entry switch. The orchestrator writes `false` first at the start of every turn, and raises it to `true` only at the end of a turn that has committed a valid next dispatch.
 - **planner-continuation** header — planner-owned defer-to-end flag. Written only from planner `next-action` (`continue` -> `pending`, `done` or absent -> `none`). Consumed when every live EPIC reaches terminal: `pending` recalls the planner, `none` enters the finalizer turn.
@@ -49,7 +49,7 @@ note: ...
   - `To` — the next runtime turn target
   - `EPIC` — `EP-N--slug`, or `(none)` for planner and finalizer turns
   - `Task path` — `(none)` for planner turns; canonical pair task path for Pair turns; canonical finalizer task path for Finalizer turns
-  - `Intent` — one or two natural-language sentences. On retreat, prefix with `(retreat reason: ...)`. On a defer-to-end planner recall, prefix with `(planner continuation: ...)`.
+  - `Intent` — one or two natural-language sentences. Dispatch envelopes expose this value as `Turn intent`. On retreat, prefix with `(retreat reason: ...)`. On a defer-to-end planner recall, prefix with `(planner continuation: ...)`.
   - `Prior tasks` / `Prior reviews` — arrays of previous artifact paths that will be attached into the next envelope
 - **`## EPIC summaries` block** — one EPIC = one `### EP-N--slug` heading plus five fields: `outcome`, `upstream`, `roster`, `current`, and `note`. Pipe tables and prose blobs are forbidden.
   - `outcome` — one-sentence completion condition
@@ -61,6 +61,7 @@ note: ...
 ## Mutation rules
 
 - All writes are orchestrator-exclusive. Subagents do not write the `Next` block or EPIC summary fields directly.
+- `.harness/cycle/user-request-snapshot.md` is orchestrator-owned. `harness-init` must not seed a placeholder snapshot. On direct goal entry, reset, or same-intent expansion, write the full trimmed request body there before dispatching the planner, a pair, or the finalizer.
 - The orchestrator writes `loop: false` first at turn start, and writes `loop: true` only at the end of a turn with a committed valid `Next`.
 - EPIC mutation is append-only. Add new EPICs or mark old ones `superseded`, but never edit existing `outcome`, `upstream`, or `roster` fields in place.
 - EPICs whose `current` is terminal (`done` or `superseded`) are excluded from dispatch.

--- a/plugins/harness-loom/skills/harness-init/references/runtime/harness-planner.template.md
+++ b/plugins/harness-loom/skills/harness-init/references/runtime/harness-planner.template.md
@@ -20,36 +20,32 @@ The producer responsible for decomposing the current goal into outcome EPICs and
 
 ## Task
 
-1. Determine the turn mode from the envelope before planning: initial plan, structural recall (`Current phase` starts with `(retreat reason: ...)`), or defer-to-end continuation recall (`Current phase` starts with `(planner continuation: ...)`).
-2. Read `Goal`, `Existing EPICs`, `Current phase`, `Prior tasks`, `Prior reviews`, `Recent events`, and `Registered roster` from the envelope. Treat `Registered roster` as the authoritative pair list for this turn; do not consult any SKILL file to discover roster state.
+1. Determine the turn mode from the envelope before planning: initial plan, structural recall (`Turn intent` starts with `(retreat reason: ...)`), or defer-to-end continuation recall (`Turn intent` starts with `(planner continuation: ...)`).
+2. Read `Goal`, `User request snapshot`, `Existing EPICs`, `Turn intent`, `Prior tasks`, `Prior reviews`, `Recent events`, and `Registered roster` from the envelope. Treat `Registered roster` as the authoritative pair list for this turn; do not consult any SKILL file to discover roster state.
 3. Scan this project's README, root docs, and major directories for domain signals.
-4. Turn the goal markdown into citation-ready notes. Prefer `goal.md:Lxx "quoted phrase"` when line numbering is available; otherwise cite the quoted goal phrase from `Goal`.
+4. Turn the request snapshot into citation-ready notes. Prefer `User request snapshot` line citations such as `.harness/cycle/user-request-snapshot.md:Lxx "quoted phrase"` when line numbering is available; otherwise cite the quoted goal phrase from `Goal`.
 5. Name downstream EPIC slugs starting at `EP-1--{outcome-slug}`; on re-plan turns, continue numbering after the last existing EPIC.
 6. For each EPIC, emit `outcome`, `upstream`, `why`, and `roster`.
 7. Treat `upstream` as a same-stage gate across EPICs.
 8. Keep the turn small. Describe unplanned work informationally under `Remaining`, and use the load-bearing `next-action` grammar (`continue — <reason>` vs `done`) to actually trigger or end re-dispatch.
 9. If an unregistered pair is required, list it under `Additional pairs required` and do not emit that blocked EPIC as executable work.
-10. End with the Output Format block below. Do not write files under `.harness/` yourself.
+10. End with the load-bearing planner Output Format block below. Do not write files under `.harness/` yourself.
 
 ## Output Format
 
 End your response with this fenced block:
 
 ```text
-Status: PASS
-Summary: <one-line gist of what this planning turn produced>
-
 EPICs (this turn):
 EP-N--<slug>
 - outcome: ...
 - upstream: <EP-M--slug, ...> | none
-- why: goal.md:L<line> "<quoted phrase>" | Goal: "<quoted phrase>"
+- why: .harness/cycle/user-request-snapshot.md:L<line> "<quoted phrase>" | Goal: "<quoted phrase>"
 - roster: <pair1-producer> → <pair3-producer> [→ <pair5-producer> ...]
 
 Remaining: <"More EPICs still need to be emitted" | "none">
 next-action: <"done" | "continue — <one-sentence reason>">
 Additional pairs required: <"<desired-slug>: <purpose>" lines | "none">
-Escalation: none
 ```
 
-`next-action` is load-bearing: the orchestrator's prefix matcher reads it verbatim. A line starting with `continue` writes `planner-continuation: pending` into `state.md`, which recalls the planner **after all currently-live EPICs reach terminal** (defer-to-end, not next-turn). Any other value (canonically `done`) clears the flag and lets execution enter the cycle-end **Finalizer** state at terminal (dispatching the singleton `harness-finalizer` agent). Do not invent phrasing such as `maybe` or `further analysis needed` — those degrade silently to `done`. A zero-emit safety forces `done` if a continuation-recalled planner turn produces no new executable EPICs, so the cycle cannot stall at halt. `Escalation` stays `none`: planner turns repair the plan by emitting replacement EPICs or by resolving with zero EPICs plus `next-action: done`; they do not emit structural-issue blocks themselves.
+`next-action` is load-bearing: the orchestrator's prefix matcher reads it verbatim. A line starting with `continue` writes `planner-continuation: pending` into `state.md`, which recalls the planner **after all currently-live EPICs reach terminal** (defer-to-end, not next-turn). Any other value (canonically `done`) clears the flag and lets execution enter the cycle-end **Finalizer** state at terminal (dispatching the singleton `harness-finalizer` agent). Do not invent phrasing such as `maybe` or `further analysis needed` — those degrade silently to `done`. A zero-emit safety forces `done` if a continuation-recalled planner turn produces no new executable EPICs, so the cycle cannot stall at halt. Planner turns do not emit `Status`, `Escalation`, or structural-issue blocks; they repair the plan by emitting replacement EPICs or by resolving with zero EPICs plus `next-action: done`.

--- a/plugins/harness-loom/skills/harness-init/references/runtime/harness-planning/SKILL.template.md
+++ b/plugins/harness-loom/skills/harness-init/references/runtime/harness-planning/SKILL.template.md
@@ -25,8 +25,8 @@ A simple test for whether two items are one outcome or two: would a user say "sh
 Before naming EPICs, classify the current planner turn from the envelope:
 
 - **Initial plan** — first entry from a new or reset goal
-- **Structural recall** — `Current phase` carries `(retreat reason: ...)`; inspect `Prior tasks` / `Prior reviews` to see what failed upstream
-- **Defer-to-end continuation recall** — `Current phase` carries `(planner continuation: ...)`; inspect `Recent events` to see what the earlier batch actually produced
+- **Structural recall** — `Turn intent` carries `(retreat reason: ...)`; inspect `Prior tasks` / `Prior reviews` to see what failed upstream
+- **Defer-to-end continuation recall** — `Turn intent` carries `(planner continuation: ...)`; inspect `Recent events` to see what the earlier batch actually produced
 
 This distinction is load-bearing. Structural recall repairs the plan; continuation recall extends the plan from execution evidence.
 
@@ -34,11 +34,12 @@ This distinction is load-bearing. Structural recall repairs the plan; continuati
 
 Collect only the signals needed to name good EPICs:
 
-- the `Goal` text from the envelope
-- `Existing EPICs`, `Current phase`, `Prior tasks`, `Prior reviews`, and `Recent events` from the envelope when re-planning
+- the compact `Goal` summary from the envelope
+- `User request snapshot` from the envelope; prefer the full snapshot for line-cited requirements and product-quality constraints
+- `Existing EPICs`, `Turn intent`, `Prior tasks`, `Prior reviews`, and `Recent events` from the envelope when re-planning
 - this project's README, root docs, and major directories
 
-Treat the goal as plain markdown text. Do not depend on special headers such as `# Goal`. Prefer the orchestrator-supplied envelope over reading control-plane files directly.
+Treat the request snapshot as plain markdown text. Do not depend on special headers such as `# Goal`. Prefer `User request snapshot` over the short `Goal` summary when it exists, and prefer the orchestrator-supplied envelope over reading control-plane files directly.
 
 ### 3. Emit EPICs directly
 
@@ -59,7 +60,7 @@ Treat `continue` as **learned replanning**, not split-the-batch convenience. Con
 
 Concrete signals that `done` is the right call even when more work exists:
 
-- All EPICs are already decidable from the goal markdown — emit them all this turn.
+- All EPICs are already decidable from the request snapshot — emit them all this turn.
 - You want more thinking time, but no execution outcome would change later EPICs. That is padding, not learned replanning.
 
 When recalled at defer-to-end (see §6), `Recent events` in the envelope is your evidence base — base the next batch of EPICs on what actually shipped, not on what you originally predicted.
@@ -70,7 +71,7 @@ Each EPIC has four planner-owned fields:
 
 - `outcome` — one sentence describing what will be true when the EPIC is done
 - `upstream` — EPIC slugs that must stay ahead of this EPIC at the same stage gate, or `none`
-- `why` — the goal evidence that justified this EPIC. Prefer `goal.md:L12 "quoted phrase"` when line numbering is available; otherwise cite the quoted goal phrase directly.
+- `why` — the request evidence that justified this EPIC. Prefer `.harness/cycle/user-request-snapshot.md:L12 "quoted phrase"` when line numbering is available; otherwise cite the quoted goal phrase directly.
 - `roster` — the stage slice for this EPIC
 
 `current` and `note` are runtime fields owned by the orchestrator. Do not emit them from the planner.
@@ -94,8 +95,8 @@ If an EPIC cannot be expressed with currently registered pairs, do not emit it a
 
 The planner is recalled in two distinct modes — read the envelope signals to tell which mode you are in, then follow the mode-specific expectations:
 
-- **Structural-issue recall.** Triggered when a Pair reviewer or a Finalizer raised a `## Structural Issue` block whose `Suspected upstream stage` resolved to `planner`. The envelope's `Current phase` will carry `(retreat reason: ...)`. Treat the cited upstream contract as the thing to fix — append replacement EPICs that address the reported gap instead of rewriting prior EPICs in place. A **Finalizer-retreat recall** (Intent prefix `(retreat reason: finalizer <slug> ...)`) means the just-finished cycle failed its cycle-end check against the plan; expect to revise the roster or EPIC coverage before Finalizer re-enters. If you cannot find a fix, emit **zero EPICs with `next-action: done`** — the orchestrator's Finalizer-retreat blocked-halt rule will halt the cycle and ask the user to intervene, which is preferable to padding with placeholder EPICs.
-- **Defer-to-end continuation recall.** Triggered when every currently-live EPIC reached terminal while `planner-continuation: pending` was on state. The envelope's `Current phase` will carry `(planner continuation: ...)`. Treat `Recent events` as your evidence base: the five most recent events.md lines summarize what the last batch actually produced. Plan the next batch against that evidence, not against a pre-cycle prediction.
+- **Structural-issue recall.** Triggered when a Pair reviewer or a Finalizer raised a `## Structural Issue` block whose `Suspected upstream stage` resolved to `planner`. The envelope's `Turn intent` will carry `(retreat reason: ...)`. Treat the cited upstream contract as the thing to fix — append replacement EPICs that address the reported gap instead of rewriting prior EPICs in place. A **Finalizer-retreat recall** (`Turn intent` prefix `(retreat reason: finalizer <slug> ...)`) means the just-finished cycle failed its cycle-end check against the plan; expect to revise the roster or EPIC coverage before Finalizer re-enters. If you cannot find a fix, emit **zero EPICs with `next-action: done`** — the orchestrator's Finalizer-retreat blocked-halt rule will halt the cycle and ask the user to intervene, which is preferable to padding with placeholder EPICs.
+- **Defer-to-end continuation recall.** Triggered when every currently-live EPIC reached terminal while `planner-continuation: pending` was on state. The envelope's `Turn intent` will carry `(planner continuation: ...)`. Treat `Recent events` as your evidence base: the five most recent events.md lines summarize what the last batch actually produced. Plan the next batch against that evidence, not against a pre-cycle prediction.
 
 Either mode is **append-only**: continue numbering after the last existing EPIC, never mutate existing `outcome`, `roster`, or `upstream` fields in place. If a recalled turn has nothing new to plan (goal is now fully covered, or the structural gap is already repaired by prior EPICs), emit zero EPICs with `next-action: done`. On defer-to-end continuation recall the zero-emit safety will force `done` anyway; on Finalizer-retreat recall the orchestrator will blocked-halt; on pair-driven structural recall the orchestrator simply resumes the rewound stage. None of these paths require placeholder EPICs.
 
@@ -111,7 +112,7 @@ outcome: Author the skill set for the OAuth login flow.
 upstream: EP-1--domain-agent-design
 roster: skill-dev-producer → test-writer-producer
 current: skill-dev-producer
-note: upstream EP-1--domain-agent-design must stay ahead at the same stage gates. Derived from goal.md:L18 "Login must use a third-party OAuth2 flow."
+note: upstream EP-1--domain-agent-design must stay ahead at the same stage gates. Derived from .harness/cycle/user-request-snapshot.md:L18 "Login must use a third-party OAuth2 flow."
 ```
 
 `current` and `note` are shown here only to illustrate how the orchestrator stores the summary. The planner itself emits `outcome / upstream / why / roster`.
@@ -127,7 +128,8 @@ note: upstream EP-1--domain-agent-design must stay ahead at the same stage gates
 - Re-planning is append-only.
 - `next-action: continue` is used only for learned replanning (later EPIC shape truly depends on earlier execution); padding-style continuation is treated as a grading failure.
 - On a defer-to-end continuation recall, `Recent events` from the envelope is cited as evidence for at least one newly emitted EPIC (or the turn cleanly resolves with zero new EPICs and `next-action: done`).
-- Planner output contains no task file paths and no control-plane fields.
+- On initial planning or same-intent expansion, emitted `why` lines cite `User request snapshot` line numbers when available, or quote the short `Goal` only when no full snapshot is supplied.
+- Planner output contains no task file paths, no `Status`, no `Escalation`, and no control-plane fields other than the load-bearing `next-action`.
 
 ## Taboos
 
@@ -184,19 +186,18 @@ EPICs (this turn):
 EP-1--user-profile-page
 - outcome: Ship the `/profile` page so a logged-in user can view and edit their display name, handle, and bio end-to-end.
 - upstream: none
-- why: goal.md:L12 "Users need a profile page to manage personal info."
+- why: .harness/cycle/user-request-snapshot.md:L12 "Users need a profile page to manage personal info."
 - roster: db-migration-producer → backend-api-producer → frontend-ui-producer → e2e-test-producer → doc-producer → git-producer
 
 EP-2--profile-avatar-upload
 - outcome: Let users upload an avatar image and render it on the profile page, using the S3 direct-upload pattern.
 - upstream: EP-1--user-profile-page
-- why: goal.md:L18 "Avatar upload must use S3 direct-upload."
+- why: .harness/cycle/user-request-snapshot.md:L18 "Avatar upload must use S3 direct-upload."
 - roster: backend-api-producer → frontend-ui-producer → e2e-test-producer → doc-producer → git-producer
 
 Remaining: none
 next-action: done
 Additional pairs required: none
-Escalation: none
 ```
 
 Each EPIC is **one shippable outcome traversing many stages**. EP-2 skips `db-migration-producer` (no schema change) — stages may be skipped, their relative order never changes. `upstream: EP-1--user-profile-page` is a **same-stage gate**: EP-2's `backend-api-producer` turn waits for EP-1's `backend-api-producer` turn, not for all of EP-1 to finish. EP-1 and EP-2 are two EPICs because they pass the "ship it alone?" test independently — the profile page is useful without avatar upload.

--- a/plugins/harness-loom/skills/harness-init/references/runtime/state.template.md
+++ b/plugins/harness-loom/skills/harness-init/references/runtime/state.template.md
@@ -9,7 +9,7 @@ planner-continuation: none
 To: planner
 EPIC: (none)
 Task path: (none)
-Intent: Read the full goal, emit an initial EPIC batch, and provide the applicable global-roster slice for each EPIC.
+Intent: Read the user request snapshot, emit an initial EPIC batch, and provide the applicable global-roster slice for each EPIC.
 Prior tasks:
 Prior reviews:
 
@@ -24,4 +24,4 @@ outcome: <one-sentence completion condition>.
 upstream: <EP-M--slug, ...> | none.
 roster: <producer1> → <producer3> → <producer5>.
 current: <producer-slug | done | superseded>.
-note: <brief progress summary, blocker, or evidence citation such as goal.md:Lxx or a quoted goal phrase>.
+note: <brief progress summary, blocker, or evidence citation such as .harness/cycle/user-request-snapshot.md:Lxx or a quoted goal phrase>.

--- a/plugins/harness-loom/skills/harness-init/scripts/install.ts
+++ b/plugins/harness-loom/skills/harness-init/scripts/install.ts
@@ -357,7 +357,7 @@ async function verifyInstall(
     if (!ok) failures.push(`${label} missing or wrong type: ${path}`);
   };
 
-  // Cycle namespace: runtime state seeded (or preserved) by install.
+  // Cycle namespace: runtime scaffold seeded by install.
   await expect(".harness/cycle/state.md", ctx.stateMd, "file");
   await expect(".harness/cycle/events.md", ctx.eventsMd, "file");
   await expect(".harness/cycle/epics/", join(target, ".harness", "cycle", "epics"), "dir");

--- a/plugins/harness-loom/skills/harness-init/scripts/sync.ts
+++ b/plugins/harness-loom/skills/harness-init/scripts/sync.ts
@@ -57,7 +57,7 @@ import {
   access,
 } from "node:fs/promises";
 import { constants as FS } from "node:fs";
-import { join, dirname, relative } from "node:path";
+import { join, dirname, relative, resolve } from "node:path";
 import process from "node:process";
 
 // All supported platform trees are derived deploy targets. `.harness/loom/`
@@ -194,7 +194,12 @@ function injectModelIntoFrontmatter(fm: Record<string, unknown>, pin: PlatformPi
   return out;
 }
 
-function renderCodexAgentToml(fm: Record<string, unknown>, body: string, pin: PlatformPin): string {
+function renderCodexAgentToml(
+  fm: Record<string, unknown>,
+  body: string,
+  pin: PlatformPin,
+  targetRoot: string,
+): string {
   const name = String(fm.name ?? "");
   const description = String(fm.description ?? "");
   const skills = Array.isArray(fm.skills) ? (fm.skills as string[]) : [];
@@ -209,12 +214,17 @@ function renderCodexAgentToml(fm: Record<string, unknown>, body: string, pin: Pl
   tomlLines.push(body.trimEnd());
   tomlLines.push('"""');
   tomlLines.push("");
-  // Codex loads skills via repeated `[[skills.config]]` tables, one per
-  // skill — not a single `skills = [...]` array. Each entry points at the
-  // mirrored skill body under `.codex/skills/<slug>/SKILL.md`.
+  // Codex loads skills via repeated `[[skills.config]]` tables, one per skill
+  // — not a single `skills = [...]` array. `SkillConfig.path` is typed as
+  // `AbsolutePathBuf`; a relative value is resolved against the agent TOML's
+  // parent directory (`.codex/agents/`) and then silently no-ops when the
+  // canonicalize step fails, so the skill quietly never loads. Emit absolute
+  // paths to bypass that resolution entirely. `.codex/` is gitignored, so the
+  // machine-specific prefix does not leak into factory commits.
   for (const skill of skills) {
+    const absSkillPath = resolve(targetRoot, ".codex", "skills", skill, "SKILL.md");
     tomlLines.push("[[skills.config]]");
-    tomlLines.push(`path = ${JSON.stringify(`.codex/skills/${skill}/SKILL.md`)}`);
+    tomlLines.push(`path = ${JSON.stringify(absSkillPath)}`);
     tomlLines.push("enabled = true");
     tomlLines.push("");
   }
@@ -443,7 +453,7 @@ async function deployCodex(targetRoot: string, agents: AgentFile[], skills: Skil
   await wipeHarnessEntries(agentsDir, ".toml", deleted);
   await wipeHarnessEntries(skillsDir, null, deleted);
   for (const a of agents) {
-    const toml = renderCodexAgentToml(a.frontmatter, a.body, PIN.codex);
+    const toml = renderCodexAgentToml(a.frontmatter, a.body, PIN.codex, targetRoot);
     const dst = join(agentsDir, `${a.name}.toml`);
     await writeFile(dst, toml);
     copied.push(dst);

--- a/plugins/harness-loom/skills/harness-init/scripts/sync.ts
+++ b/plugins/harness-loom/skills/harness-init/scripts/sync.ts
@@ -21,7 +21,7 @@
 //   `.claude/` may belong to the user, not to a prior harness deploy, and
 //   silently overwriting it would clobber unrelated settings.
 //
-// Wipe-and-overwrite contract (goals.md L68):
+// Wipe-and-overwrite contract:
 //   For each selected platform, sync deletes only files/directories under
 //   `agents/` and `skills/` whose name (or basename) starts with `harness-`
 //   before reseeding from `.harness/loom/`. Non-harness assets the user
@@ -31,13 +31,14 @@
 // Platform contract (verified against official specs):
 //   - Codex subagents pin `model = "gpt-5.4"`, `model_reasoning_effort = "xhigh"`.
 //     Agent body goes in `developer_instructions = """..."""` — NOT `prompt`.
-//     Skills are referenced via repeated `[[skills.config]]` tables.
+//     Required skill bodies are loaded through explicit `$skill-name` mentions
+//     prepended to developer_instructions; sync does not emit `[[skills.config]]`.
 //     Source: developers.openai.com/codex/subagents
 //   - Claude agents pin `model: inherit`. Skills are loaded by directory.
 //   - Gemini agents pin `model: gemini-3.1-pro-preview`. Frontmatter is
 //     `.strict()` and rejects unknown keys (including `skills`). Skills are
-//     auto-loaded globally from `.gemini/skills/` and surfaced to every agent
-//     via progressive disclosure — no per-agent reference needed.
+//     mirrored globally under `.gemini/skills/`; required skill names are
+//     prepended to the agent body so the runtime can activate them explicitly.
 //     Source: github.com/google-gemini/gemini-cli (packages/core/src/agents/agentLoader.ts)
 //   - Each platform's hook setting wires to `bash .harness/loom/hook.sh
 //     <platform>` (Stop for claude/codex, AfterAgent for gemini).
@@ -57,7 +58,7 @@ import {
   access,
 } from "node:fs/promises";
 import { constants as FS } from "node:fs";
-import { join, dirname, relative, resolve } from "node:path";
+import { join, dirname, relative } from "node:path";
 import process from "node:process";
 
 // All supported platform trees are derived deploy targets. `.harness/loom/`
@@ -194,15 +195,55 @@ function injectModelIntoFrontmatter(fm: Record<string, unknown>, pin: PlatformPi
   return out;
 }
 
+function uniqueSkills(skills: unknown): string[] {
+  if (!Array.isArray(skills)) return [];
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const skill of skills) {
+    if (typeof skill !== "string") continue;
+    const slug = skill.trim();
+    if (slug.length === 0 || seen.has(slug)) continue;
+    seen.add(slug);
+    out.push(slug);
+  }
+  return out;
+}
+
+function skillLoadingBlock(skills: string[], platform: "codex" | "gemini"): string {
+  if (skills.length === 0) return "";
+  const names = skills.join(", ");
+  const mentions = skills.map((skill) => `$${skill}`).join(", ");
+  const lines = ["## Required Skill Loading", ""];
+  if (platform === "codex") {
+    lines.push(
+      `Before performing this role, explicitly load and follow these skill bodies: ${mentions}.`,
+      "Codex exposes skill metadata by default; these mentions are required so the full SKILL.md bodies enter context.",
+      "Do not rely on metadata-only skill visibility.",
+    );
+  } else {
+    lines.push(
+      `Before performing this role, activate and follow these skill bodies by name: ${names}.`,
+      `If the platform accepts $skill-name mentions, the equivalent mentions are: ${mentions}.`,
+      "Do not rely on metadata-only skill visibility.",
+    );
+  }
+  return lines.join("\n");
+}
+
+function withSkillLoading(body: string, skills: string[], platform: "codex" | "gemini"): string {
+  const block = skillLoadingBlock(skills, platform);
+  if (!block) return body.trimEnd();
+  return `${block}\n\n${body.trimStart().trimEnd()}`;
+}
+
 function renderCodexAgentToml(
   fm: Record<string, unknown>,
   body: string,
   pin: PlatformPin,
-  targetRoot: string,
 ): string {
   const name = String(fm.name ?? "");
   const description = String(fm.description ?? "");
-  const skills = Array.isArray(fm.skills) ? (fm.skills as string[]) : [];
+  const bodyWithSkillLoading = withSkillLoading(body, uniqueSkills(fm.skills), "codex");
   const tomlLines: string[] = [];
   tomlLines.push(`name = ${JSON.stringify(name)}`);
   tomlLines.push(`description = ${JSON.stringify(description)}`);
@@ -211,23 +252,9 @@ function renderCodexAgentToml(
   if (pin.reasoning) tomlLines.push(`model_reasoning_effort = ${JSON.stringify(pin.reasoning)}`);
   // Codex spec puts the agent prompt in `developer_instructions`, not `prompt`.
   tomlLines.push('developer_instructions = """');
-  tomlLines.push(body.trimEnd());
+  tomlLines.push(bodyWithSkillLoading);
   tomlLines.push('"""');
   tomlLines.push("");
-  // Codex loads skills via repeated `[[skills.config]]` tables, one per skill
-  // — not a single `skills = [...]` array. `SkillConfig.path` is typed as
-  // `AbsolutePathBuf`; a relative value is resolved against the agent TOML's
-  // parent directory (`.codex/agents/`) and then silently no-ops when the
-  // canonicalize step fails, so the skill quietly never loads. Emit absolute
-  // paths to bypass that resolution entirely. `.codex/` is gitignored, so the
-  // machine-specific prefix does not leak into factory commits.
-  for (const skill of skills) {
-    const absSkillPath = resolve(targetRoot, ".codex", "skills", skill, "SKILL.md");
-    tomlLines.push("[[skills.config]]");
-    tomlLines.push(`path = ${JSON.stringify(absSkillPath)}`);
-    tomlLines.push("enabled = true");
-    tomlLines.push("");
-  }
   return tomlLines.join("\n");
 }
 
@@ -453,7 +480,7 @@ async function deployCodex(targetRoot: string, agents: AgentFile[], skills: Skil
   await wipeHarnessEntries(agentsDir, ".toml", deleted);
   await wipeHarnessEntries(skillsDir, null, deleted);
   for (const a of agents) {
-    const toml = renderCodexAgentToml(a.frontmatter, a.body, PIN.codex, targetRoot);
+    const toml = renderCodexAgentToml(a.frontmatter, a.body, PIN.codex);
     const dst = join(agentsDir, `${a.name}.toml`);
     await writeFile(dst, toml);
     copied.push(dst);
@@ -482,11 +509,12 @@ async function deployGemini(targetRoot: string, agents: AgentFile[], skills: Ski
   for (const a of agents) {
     const fm = injectModelIntoFrontmatter(a.frontmatter, PIN.gemini);
     // Gemini's localAgentSchema is .strict() and rejects unknown keys like
-    // `skills` (which is a Claude-canonical field). Skills load globally from
-    // `.gemini/skills/` and surface to every agent via progressive disclosure
-    // — there is no per-agent `skills` reference in Gemini frontmatter.
+    // `skills` (which is a Claude-canonical field). Mirror skills globally
+    // under `.gemini/skills/`, then inject the required skill names into the
+    // body so the agent can explicitly activate them.
+    const bodyWithSkillLoading = withSkillLoading(a.body, uniqueSkills(fm.skills), "gemini");
     delete fm.skills;
-    const out = renderClaudeFrontmatter(fm) + a.body;
+    const out = renderClaudeFrontmatter(fm) + bodyWithSkillLoading + "\n";
     const dst = join(agentsDir, `${a.name}.md`);
     await writeFile(dst, out);
     copied.push(dst);

--- a/plugins/harness-loom/skills/harness-pair-dev/SKILL.md
+++ b/plugins/harness-loom/skills/harness-pair-dev/SKILL.md
@@ -23,7 +23,7 @@ Use `scripts/pair-dev.ts` for deterministic command validation, registered-pair 
 
 - Target is always the current working directory.
 - Read the target codebase before authoring. The pair must fit the real repo, not a stock template.
-- Normalize generated slugs into the `harness-` namespace.
+- Normalize user-facing bare names into canonical `harness-*` slugs before invoking `scripts/pair-dev.ts`; the helper accepts canonical slugs only.
 - Keep reviewer coverage explicit. Every pair is 1:1 or 1:M. Reviewer-less work belongs in a finalizer, not in `## Registered pairs`.
 - Treat roster placement as execution order. Appending is correct only when the pair truly belongs at the end of the project-global workflow.
 - Treat legacy `--split` and `--hint` as unsupported v0.3.0 surface. Split is a manual sequence of `--add`, `--improve`, and `--remove`; intent is passed as positional `<purpose>`.
@@ -36,6 +36,8 @@ Use `scripts/pair-dev.ts` for deterministic command validation, registered-pair 
 /harness-pair-dev --improve <pair-slug> "<purpose>" [--before <pair-slug> | --after <pair-slug>]
 /harness-pair-dev --remove <pair-slug>
 ```
+
+All slug-bearing arguments must be canonical before the deterministic helper or registry/files are touched. If the user says `document`, use `harness-document` for the pair slug, `--from`, reviewer slugs, and placement anchors.
 
 ### 3. `--add`
 

--- a/plugins/harness-loom/skills/harness-pair-dev/SKILL.md
+++ b/plugins/harness-loom/skills/harness-pair-dev/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: harness-pair-dev
-description: "Use when `/harness-pair-dev --add|--improve|--split <pair-slug>` is invoked to author or reshape a project-specific producer-reviewer pair inside a target harness. `--add <pair-slug> \"<purpose>\"` requires purpose as a positional argument and may repeat `--reviewer <slug>` for 1:M review. Every pair has at least one reviewer; reviewer-less cycle-end work belongs in a finalizer."
-argument-hint: "--add <pair-slug> \"<purpose>\" [--reviewer <slug> ...] | --improve <pair-slug> [--hint \"<text>\"] | --split <pair-slug>"
+description: "Use when `/harness-pair-dev --add|--improve|--remove <pair-slug>` is invoked to author, revise, or remove a project-specific producer-reviewer pair inside a target harness. `--add` and `--improve` require `<pair-slug> \"<purpose>\"`; `--add` may use `--from <existing-pair-slug>` as a registered-pair source for template-first overlay. Every pair has at least one reviewer; reviewer-less cycle-end work belongs in a finalizer."
+argument-hint: "--add <pair-slug> \"<purpose>\" [--from <existing-pair-slug>] [--reviewer <slug> ...] [--before <pair-slug> | --after <pair-slug>] | --improve <pair-slug> \"<purpose>\" [--before <pair-slug> | --after <pair-slug>] | --remove <pair-slug>"
 user-invocable: true
 ---
 
@@ -13,6 +13,10 @@ user-invocable: true
 
 Write only in canonical staging under `<target>/.harness/loom/`. Pair files live under `.harness/loom/{agents,skills}/`. Pair order lives in `.harness/loom/registry.md` `## Registered pairs`, and `register-pair.ts` is the only writer for that section. Derived platform trees are refreshed later by the target-local `node .harness/loom/sync.ts --provider <list>` command.
 
+Cycle task and review history under `.harness/cycle/` is runtime evidence, not pair-authoring state. Pair authoring may inspect active-cycle references for safety, but it must not edit or delete cycle history.
+
+Use `scripts/pair-dev.ts` for deterministic command validation, registered-pair source preparation, and guarded removal. The helper returns preparation JSON for `--add` and `--improve`; it does not claim to author pair bodies unless files are actually written.
+
 ## Methodology
 
 ### 1. Operating rules
@@ -22,39 +26,54 @@ Write only in canonical staging under `<target>/.harness/loom/`. Pair files live
 - Normalize generated slugs into the `harness-` namespace.
 - Keep reviewer coverage explicit. Every pair is 1:1 or 1:M. Reviewer-less work belongs in a finalizer, not in `## Registered pairs`.
 - Treat roster placement as execution order. Appending is correct only when the pair truly belongs at the end of the project-global workflow.
-- After authoring or rewriting a pair, tell the user to run `node .harness/loom/sync.ts --provider <list>` from the target root.
+- Treat legacy `--split` and `--hint` as unsupported v0.3.0 surface. Split is a manual sequence of `--add`, `--improve`, and `--remove`; intent is passed as positional `<purpose>`.
+- After authoring, rewriting, or removing a pair, tell the user to run `node .harness/loom/sync.ts --provider <list>` from the target root.
 
-### 2. `--add`
+### 2. Command surface
+
+```text
+/harness-pair-dev --add <pair-slug> "<purpose>" [--from <existing-pair-slug>] [--reviewer <slug> ...] [--before <pair-slug> | --after <pair-slug>]
+/harness-pair-dev --improve <pair-slug> "<purpose>" [--before <pair-slug> | --after <pair-slug>]
+/harness-pair-dev --remove <pair-slug>
+```
+
+### 3. `--add`
 
 1. Parse args and stop immediately if `<purpose>` is missing or the target does not yet contain the installed runtime foundation.
-2. Decide the reviewer shape:
+2. If `--from <existing-pair-slug>` is present, resolve it only from the target's current `.harness/loom/registry.md` `## Registered pairs`.
+3. Reject `--from` values that are snapshot paths, agent paths, skill paths, derived platform paths, missing registry entries, planner/finalizer slugs, or foundation skill names.
+4. When `--from` is present, follow `references/authoring/from-overlay.md`: start from current templates, enforce current runtime shape, then overlay compatible source-pair domain material.
+5. Let `<purpose>` override the source pair's old intent whenever the two conflict. `<purpose>` remains required even with `--from`.
+6. Decide the reviewer shape:
    - no `--reviewer` flags -> default 1:1 pair
    - repeated `--reviewer <slug>` -> 1:M pair
-3. Read the authoring references, current roster, and relevant target code before writing anything.
-4. Author the producer, reviewer(s), and shared pair skill from templates. Identity, principles, methodology, evaluation criteria, and taboos should all point back to repo evidence.
-5. Run `register-pair.ts` to update `## Registered pairs` in `.harness/loom/registry.md`. Pass `--before <slug>` or `--after <slug>` whenever the right workflow position is known; omit anchors only when a true append is intended.
+7. Read the authoring references, current roster, and relevant target code before writing anything.
+8. Author the producer, reviewer(s), and shared pair skill from templates. Without `--from`, ground them directly in repo evidence; with `--from`, apply template-first overlay.
+9. Run `register-pair.ts` to update `## Registered pairs` in `.harness/loom/registry.md`. Pass `--before <slug>` or `--after <slug>` whenever the right workflow position is known; omit anchors only when a true append is intended.
 
-### 3. `--improve`
+### 4. `--improve`
 
-1. Discover the existing pair from the target's registered-pairs section.
-2. Re-read the current producer, reviewer(s), pair skill, and relevant target code.
-3. If a hint exists, use it as the primary diagnosis axis. Otherwise focus on rubric hygiene and codebase drift.
-4. Replace vague or stale guidance with repo-specific evidence first.
-5. Keep names and slugs stable. Re-register only when reviewer shape or roster placement intentionally changes.
-6. If the pair has clearly become two different jobs, stop and recommend `--split` rather than overfitting one more edit.
+1. Parse args and stop immediately if `<purpose>` is missing.
+2. Discover the existing pair from the target's registered-pairs section.
+3. Re-read the current producer, reviewer(s), pair skill, authoring references, and relevant target code.
+4. Use positional `<purpose>` as the primary improvement axis, then fold in rubric hygiene and codebase drift.
+5. Replace vague or stale guidance with repo-specific evidence first.
+6. Keep names and slugs stable. Re-register only when reviewer shape or roster placement intentionally changes.
+7. If the pair has clearly become two different jobs, stop with a recommendation for an explicit `--add` + `--improve` + `--remove` sequence instead of automating a split.
 
-### 4. `--split`
+### 5. `--remove`
 
-1. Re-read the current pair, its roster position, and the relevant target code until the split boundary is clear.
-2. Choose two narrower replacement slugs and reviewer shapes that divide the original job cleanly.
-3. Author both replacement pairs before removing anything.
-4. Preserve workflow order when re-registering:
-   - insert the first replacement immediately before the old pair so it inherits that slot once the old line is removed
-   - insert the second replacement adjacent to the first with `--before` or `--after`
-5. Unregister the old pair only after both replacements exist, then delete the old producer, reviewer, and shared pair-skill files.
-6. If the boundary is still ambiguous, stop and ask the user instead of guessing.
+1. Discover the existing pair from `.harness/loom/registry.md` and resolve its producer, reviewer slug(s), and skill slug from that registry line.
+2. Reject removal of the planner, finalizer, foundation runtime skills, `registry.md`, missing pairs, and anything outside `.harness/loom/agents/` or `.harness/loom/skills/`.
+3. Inspect `.harness/cycle/state.md` when it exists. If `## Next` references the pair, or if any non-terminal EPIC roster/current field references the pair, abort before mutating files.
+4. Treat unparsable active-cycle state as unsafe and abort. The default contract has no force flag.
+5. Run `register-pair.ts --unregister --target <target> --pair <pair-slug>` to remove only the roster entry from `## Registered pairs`.
+6. Delete the pair-owned producer agent, reviewer agent(s), and pair skill directory from `.harness/loom/` after unregistering.
+7. Do not delete an agent or skill path that is still referenced by another remaining registry entry; abort or preserve it with an explicit warning rather than breaking another pair.
+8. Never delete or rewrite `.harness/cycle/`, `.harness/cycle/epics/`, task files, review files, or `events.md`. Historical task/review evidence stays intact after pair removal.
+9. Tell the user to run `node .harness/loom/sync.ts --provider <list>` after removal so derived platform trees drop stale pair files.
 
-### 5. Registration contract
+### 6. Registration contract
 
 `register-pair.ts` updates `<target>/.harness/loom/registry.md` `## Registered pairs`. That section is the project's sole roster SSOT: the orchestrator reads it at dispatch time, and the planner receives it through the dispatch envelope.
 
@@ -65,17 +84,22 @@ Its placement semantics are load-bearing:
 - append + new pair -> add to the end
 - `--before` / `--after` + new pair -> insert at the anchor
 
+For removal, `register-pair.ts --unregister` deletes only the matching roster line. File deletion and active-cycle safety checks belong to `/harness-pair-dev --remove`, not to the registry helper.
+
 Treat that section as workflow order, not as a changelog.
 
 ## Evaluation Criteria
 
 - `--add` receives a required positional `<purpose>` and uses it as the main axis for the pair.
+- `--add --from` accepts only a currently registered pair slug and applies template-first overlay, never snapshot/path/provider import or blind copy.
+- `--improve` receives a required positional `<purpose>` and uses it as the main axis for revision.
 - All authored files live under `.harness/loom/`.
-- `--add`, `--improve`, and `--split` all start from actual codebase evidence.
+- `--add` and `--improve` start from actual codebase evidence.
+- `--remove` refuses planner/finalizer/foundation targets and active-cycle references before mutating `.harness/loom/`.
+- `--remove` preserves `.harness/cycle/` task and review history.
 - Every entry in `## Registered pairs` lists at least one reviewer slug (1:1 or 1:M).
 - Registration lands in the intended roster position and remains duplicate-free.
-- `--split` preserves the original workflow coverage with two narrower replacements, then removes the old pair.
-- The user is told to run target-local sync after authoring.
+- The user is told to run target-local sync after authoring, improving, or removal.
 - Final authored files contain no leftover template placeholders.
 
 ## Taboos
@@ -85,16 +109,22 @@ Treat that section as workflow order, not as a changelog.
 - Treat roster placement as append chronology instead of a workflow decision.
 - Author a pair without at least one reviewer. Cycle-end reviewer-less work belongs inside the singleton `harness-finalizer` agent body, not in `## Registered pairs`.
 - Rename slugs casually during `--improve`.
-- Remove the old pair before the split replacements are ready.
-- Split automatically without a clear boundary or user approval.
+- Accept `--hint`; intent belongs in positional `<purpose>`.
+- Accept `--split`; split is a user-directed multi-command sequence, not a single pair-dev command.
+- Accept `--from` as a snapshot path, file path, derived platform path, or blind-copy import.
+- Preserve source `skills:` wholesale during `--from`; the new pair skill plus `harness-context` are mandatory template authority, while extra domain skills are preservation candidates.
+- Remove a pair referenced by the active cycle's `Next` or live EPIC roster.
+- Delete `.harness/cycle/` history during pair removal.
 - Edit derived platform trees directly.
 - Hand-edit registration sections instead of using `register-pair.ts`.
 
 ## References
 
+- `scripts/pair-dev.ts` — deterministic command helper for validation, `--from` source preparation, and guarded `--remove`
 - `scripts/register-pair.ts` — deterministic registration helper (writes `.harness/loom/registry.md`)
 - `templates/producer-agent.md`, `templates/reviewer-agent.md`, `templates/pair-skill.md` — skeletons copied and filled in for each new pair
 - `examples/agents/` — completed producer/reviewer exemplars to reference for tone and structure
 - `references/authoring/agent-authoring.md` — agent frontmatter, five principles, Task shape, Output Format rubric
 - `references/authoring/skill-authoring.md` — pair-skill body rules (section order, 200-line cap, description-as-trigger)
-- `references/authoring/oversized-split.md` — when and how to split an oversized SKILL.md into `references/`
+- `references/authoring/from-overlay.md` — `--add --from` template-first overlay rules and source preservation boundaries
+- `references/authoring/oversized-split.md` — when and how to split an oversized SKILL.md body into `references/`; this is not the removed pair-level `--split` command

--- a/plugins/harness-loom/skills/harness-pair-dev/examples/agents/harness-api-designer.md
+++ b/plugins/harness-loom/skills/harness-pair-dev/examples/agents/harness-api-designer.md
@@ -40,7 +40,5 @@ Files created: [{file path}]
 Files modified: [{file path}]
 Diff summary: {sections changed vs baseline, or "N/A"}
 Self-verification: {issues found and resolved during this cycle}
-Suggested next-work: "<optional forward hint for the next stage, or 'none'>"
 Remaining items: [{items not yet done}]
-Escalation: {none | structural-retreat-to-<stage>, reason}
 ```

--- a/plugins/harness-loom/skills/harness-pair-dev/examples/agents/harness-api-reviewer.md
+++ b/plugins/harness-loom/skills/harness-pair-dev/examples/agents/harness-api-reviewer.md
@@ -26,8 +26,8 @@ API Reviewer is the reviewer that grades the REST endpoint specification submitt
 3. Scan sibling endpoint specs for naming, field-casing, and error-format asymmetry.
 4. Verify that error schemas and status mappings are specified with the same density as success schemas.
 5. Record any missing authentication, pagination, or rate-limit policy as Criteria failures.
-6. Use Regression gate to check whether the spec explicitly preserves existing client compatibility.
-7. Write Verdict, FAIL items, and Feedback. `Advisory-next` is optional — emit it only when there is a non-obvious forward hint for the next stage, otherwise use `none`.
+6. Check whether the spec explicitly preserves existing client compatibility.
+7. Write Verdict, FAIL items, and Feedback with any compatibility regression evidence.
 
 ## Output Format
 
@@ -37,7 +37,5 @@ End your response with this structured block:
 Verdict: PASS / FAIL
 Criteria: [{criterion, result, evidence-citation (file:line)}]
 FAIL items: [{item, level (technical/creative/structural), reason}]
-Regression gate: {clean / regression / N/A, details}
 Feedback: {short free-form rationale}
-Advisory-next: "<optional forward hint for the next stage, or 'none'>"
 ```

--- a/plugins/harness-loom/skills/harness-pair-dev/examples/agents/harness-blog-editor.md
+++ b/plugins/harness-loom/skills/harness-pair-dev/examples/agents/harness-blog-editor.md
@@ -16,7 +16,7 @@ Blog Editor is the reviewer that grades a draft submitted by Blog Writer for str
 1. If the argument cannot be summarized in one line, mark it as a structural fail. Reason: a piece that cannot be summarized by the reviewer cannot be summarized by the reader either.
 2. Gather unsupported claims at paragraph level and cite them. Reason: unsupported assertions steadily erode trust.
 3. Prove voice drift by comparison against brand samples. Reason: a voice verdict based only on taste leaves the producer with vague rework.
-4. If you notice typo-level or sentence-level phrasing issues, optionally relay them via `Advisory-next` rather than promoting them to FAIL criteria. Reason: mixing surface corrections into a structure review weakens scope and blurs the FAIL rationale. When you have nothing non-obvious to pass forward, `Advisory-next: none` is correct.
+4. Keep typo-level or sentence-level phrasing issues in Feedback only when they clarify a structural verdict. Reason: mixing surface corrections into criteria weakens scope and blurs the FAIL rationale.
 5. Build the verdict only from file paths plus paragraph or line citations. Reason: "this feels awkward" does not tell the producer where to fix the piece.
 
 ## Task
@@ -27,7 +27,7 @@ Blog Editor is the reviewer that grades a draft submitted by Blog Writer for str
 4. Check every factual claim for source anchoring and collect missing anchor sites.
 5. Compare tone against the brand voice guide's reference samples.
 6. Record each Criteria item as PASS/FAIL with evidence paragraphs or lines.
-7. Put structure-level rework guidance into Feedback. If there is a non-obvious next-stage priority to flag, add it via `Advisory-next`; otherwise use `none`.
+7. Put structure-level rework guidance and any non-obvious next-stage priority into Feedback.
 
 ## Output Format
 
@@ -37,7 +37,5 @@ End your response with this structured block:
 Verdict: PASS / FAIL
 Criteria: [{criterion, result, evidence-citation (file:line)}]
 FAIL items: [{item, level (technical/creative/structural), reason}]
-Regression gate: {clean / regression / N/A, details}
 Feedback: {short free-form rationale}
-Advisory-next: "<optional forward hint for the next stage, or 'none'>"
 ```

--- a/plugins/harness-loom/skills/harness-pair-dev/examples/agents/harness-blog-writer.md
+++ b/plugins/harness-loom/skills/harness-pair-dev/examples/agents/harness-blog-writer.md
@@ -40,7 +40,5 @@ Files created: [{file path}]
 Files modified: [{file path}]
 Diff summary: {sections changed vs baseline, or "N/A"}
 Self-verification: {issues found and resolved during this cycle}
-Suggested next-work: "<optional forward hint for the next stage, or 'none'>"
 Remaining items: [{items not yet done}]
-Escalation: {none | structural-retreat-to-<stage>, reason}
 ```

--- a/plugins/harness-loom/skills/harness-pair-dev/examples/agents/harness-research-reviewer.md
+++ b/plugins/harness-loom/skills/harness-pair-dev/examples/agents/harness-research-reviewer.md
@@ -27,7 +27,7 @@ Research Reviewer is the reviewer that grades the synthesis memo submitted by Re
 4. Check whether direct source quotation and synthesized interpretation remain visually distinct.
 5. Review whether outlier or minority-view sections exist and preserve the substance properly.
 6. Verify that unresolved questions and follow-up research items are explicitly surfaced.
-7. Write Criteria, FAIL items, Regression gate, and Feedback. `Advisory-next` is optional — emit it only when there is a non-obvious forward hint for the next stage, otherwise use `none`.
+7. Write Criteria, FAIL items, and Feedback with any non-obvious forward risk.
 
 ## Output Format
 
@@ -37,7 +37,5 @@ End your response with this structured block:
 Verdict: PASS / FAIL
 Criteria: [{criterion, result, evidence-citation (file:line)}]
 FAIL items: [{item, level (technical/creative/structural), reason}]
-Regression gate: {clean / regression / N/A, details}
 Feedback: {short free-form rationale}
-Advisory-next: "<optional forward hint for the next stage, or 'none'>"
 ```

--- a/plugins/harness-loom/skills/harness-pair-dev/examples/agents/harness-research-synthesizer.md
+++ b/plugins/harness-loom/skills/harness-pair-dev/examples/agents/harness-research-synthesizer.md
@@ -40,7 +40,5 @@ Files created: [{file path}]
 Files modified: [{file path}]
 Diff summary: {sections changed vs baseline, or "N/A"}
 Self-verification: {issues found and resolved during this cycle}
-Suggested next-work: "<optional forward hint for the next stage, or 'none'>"
 Remaining items: [{items not yet done}]
-Escalation: {none | structural-retreat-to-<stage>, reason}
 ```

--- a/plugins/harness-loom/skills/harness-pair-dev/examples/agents/harness-test-reviewer.md
+++ b/plugins/harness-loom/skills/harness-pair-dev/examples/agents/harness-test-reviewer.md
@@ -26,8 +26,8 @@ Test Reviewer is the reviewer that grades a bundle of unit tests submitted by Te
 3. Classify each test case as happy, boundary, or error and evaluate category coverage.
 4. Inspect the files for test determinism: fixed seeds, isolated I/O, and avoidance of time/random coupling.
 5. Record each Criteria item as PASS/FAIL with evidence lines.
-6. Evaluate Regression gate for duplication or invalidation of the existing test suite.
-7. Produce the final Verdict and Feedback. `Advisory-next` is optional — emit it only when there is a non-obvious next-stage priority; otherwise use `none`.
+6. Evaluate duplication or invalidation of the existing test suite.
+7. Produce the final Verdict and Feedback with any non-obvious next-stage priority.
 
 ## Output Format
 
@@ -37,7 +37,5 @@ End your response with this structured block:
 Verdict: PASS / FAIL
 Criteria: [{criterion, result, evidence-citation (file:line)}]
 FAIL items: [{item, level (technical/creative/structural), reason}]
-Regression gate: {clean / regression / N/A, details}
 Feedback: {short free-form rationale}
-Advisory-next: "<optional forward hint for the next stage, or 'none'>"
 ```

--- a/plugins/harness-loom/skills/harness-pair-dev/examples/agents/harness-test-writer.md
+++ b/plugins/harness-loom/skills/harness-pair-dev/examples/agents/harness-test-writer.md
@@ -39,7 +39,5 @@ Files created: [{file path}]
 Files modified: [{file path}]
 Diff summary: {sections changed vs baseline, or "N/A"}
 Self-verification: {issues found and resolved during this cycle}
-Suggested next-work: "<optional forward hint for the next stage, or 'none'>"
 Remaining items: [{items not yet done}]
-Escalation: {none | structural-retreat-to-<stage>, reason}
 ```

--- a/plugins/harness-loom/skills/harness-pair-dev/references/authoring/agent-authoring.md
+++ b/plugins/harness-loom/skills/harness-pair-dev/references/authoring/agent-authoring.md
@@ -102,9 +102,7 @@ Files created: [{file path}]
 Files modified: [{file path}]
 Diff summary: {sections changed vs baseline, or "N/A"}
 Self-verification: {issues found and resolved during this cycle}
-Suggested next-work: "<optional forward hint for the next stage, or 'none'>"
 Remaining items: [{items not yet done}]
-Escalation: {none | structural-retreat-to-<stage>, reason}
 ```
 
 **Reviewer variant** — include these fields in this order:
@@ -113,19 +111,19 @@ Escalation: {none | structural-retreat-to-<stage>, reason}
 Verdict: PASS / FAIL
 Criteria: [{criterion, result, evidence-citation (file:line)}]
 FAIL items: [{item, level (technical/creative/structural), reason}]
-Regression gate: {clean / regression / N/A, details}
 Feedback: {short free-form rationale}
-Advisory-next: "<optional forward hint for the next stage, or 'none'>"
 ```
 
 - Verdict must be the exact string `PASS` or `FAIL`. No emojis, emoticons, or neutral categories such as `PARTIAL`.
 - Evidence must cite disk paths plus line ranges. "I feel" or "looks good" is not evidence.
+- A pair producer's `Status` is self-report only. The paired reviewer `Verdict` is the Pair turn's load-bearing verdict source.
 - Producers must not emit reviewer verdict fields, and reviewers must not emit producer diff fields. That is role leakage.
-- `Suggested next-work` (producer) and `Advisory-next` (reviewer) are **optional forward hints** for the next stage — emit them only when you have something non-obvious to pass forward; otherwise the value is `none`. The orchestrator does not consume these fields to decide `Next.To`; that is determined by Phase advance rules from the verdict. Do not try to steer self-recall or rework from these fields — that is a role leak into the meta-role (`harness-planner`) that alone owns its `next-action` continuation signal.
+- Put non-obvious follow-up notes in producer `Remaining items`, reviewer `FAIL items`, or reviewer `Feedback`; do not add advisory routing fields. Domain-specific regression evidence may appear in the review body or `Feedback` when the pair skill asks for it, but it is not a generic runtime field.
+- Do not add `Escalation`-style fields. Structural escalation uses only the shared top-level `## Structural Issue` block from `harness-context`.
 
-**Meta-role exception** — a meta-role that does not leave task/review files, such as `harness-planner`, may replace the Producer shape's `Files created / Files modified / Diff summary` fields with role-specific return fields such as `EPICs / Remaining / next-action / Additional pairs required`. The `next-action` field on a meta-role is load-bearing (defer-to-end continuation grammar `continue|done`, defined in its pair skill), not the same field as the executor-side optional advisory. Any agent that uses this exception must say that it is a meta-role without task/review files in either the identity paragraph or the first principle so reviewers do not grade it with the standard Producer shape.
+**Meta-role exception** — a meta-role that does not leave task/review files, such as `harness-planner`, uses its own role-specific return fields: `EPICs (this turn)`, `Remaining`, `next-action`, and `Additional pairs required`. The `next-action` field on a meta-role is load-bearing (defer-to-end continuation grammar `continue|done`, defined in its pair skill), not an executor-side advisory. Planner agents do not emit `Status` or `Escalation`; they repair the plan by emitting replacement EPICs or by resolving with zero EPICs plus `next-action: done`. Any agent that uses this exception must say that it is a meta-role without task/review files in either the identity paragraph or the first principle so reviewers do not grade it with the standard Producer shape.
 
-**Finalizer exception** — the singleton cycle-end finalizer (`harness-finalizer`) uses the Producer shape but has no paired reviewer and no pair skill. Its own `Status: PASS | FAIL` plus `Self-verification` block is the verdict the orchestrator reads. The finalizer signals RETREAT by emitting a `## Structural Issue` block **outside** the Producer fenced block (same shape as in the orchestrator and `harness-context` skills, with `Suspected upstream stage: planner`); absent that block, `Status` alone decides PASS vs FAIL. Finalizer FAIL routes to planner recall rather than in-place rework. The finalizer must not emit Reviewer-shape fields (`Verdict`, `Criteria`, `FAIL items`, `Regression gate`), and the identity paragraph must name the role as the cycle-end finalizer without a paired reviewer so reviewers grade by these Finalizer rules instead of the standard paired Producer shape.
+**Finalizer exception** — the singleton cycle-end finalizer (`harness-finalizer`) uses the finalizer shape defined in its own agent body and has no paired reviewer or pair skill. Its own `Status: PASS | FAIL` plus `Self-verification` block is the verdict the orchestrator reads. The finalizer signals RETREAT by emitting a `## Structural Issue` block **outside** the fenced block (same shape as in the orchestrator and `harness-context` skills, with `Suspected upstream stage: planner`); absent that block, `Status` alone decides PASS vs FAIL. Finalizer FAIL routes to planner recall rather than in-place rework. The finalizer must not emit Reviewer-shape fields (`Verdict`, `Criteria`, `FAIL items`) or `Escalation` fields, and the identity paragraph must name the role as the cycle-end finalizer without a paired reviewer so reviewers grade by these Finalizer rules instead of the standard paired Producer shape.
 
 ## Anti-patterns
 
@@ -149,8 +147,8 @@ When a pair reviewer grades an agent with this rubric, it checks:
 - Forbidden fields (`path`, `effort`, `allow-tools`, `allowed-tools`, `tools`) are absent from both frontmatter and body.
 - `## Principles` has exactly five items and follows Why-first positive form.
 - `## Task` has 5-10 numbered steps, each <=25 words, in active voice, each describing one concrete artifact or decision.
-- `## Output Format` exposes the correct fenced block for the role type: Producer shape for pair producers and finalizers, Reviewer shape for pair reviewers, and the Meta-role exception fields for the planner.
-- Finalizer agents include a `## Structural Issue` block (same shape as in `harness-context` §7) outside the Producer fenced block to signal RETREAT, with `Suspected upstream stage: planner`. They emit no Reviewer-shape fields.
+- `## Output Format` exposes the correct fenced block for the role type: Producer shape for pair producers, Reviewer shape for pair reviewers, Meta-role exception fields for the planner, and Finalizer exception fields for the finalizer.
+- Finalizer agents include a `## Structural Issue` block (same shape as in `harness-context` §7) outside the Finalizer fenced block to signal RETREAT, with `Suspected upstream stage: planner`. They emit no Reviewer-shape fields.
 - There is no procedural drift, skill-body duplication, or embedded pair-reviewer criteria.
 - No emojis are present.
 
@@ -162,4 +160,4 @@ When a pair reviewer grades an agent with this rubric, it checks:
 - Describe orchestrator routing or state-writing procedures in the agent body; routing and state belong only to the orchestrator.
 - Duplicate the pair skill body inside the agent; that creates two sources of truth and guarantees drift.
 - Use emojis as decoration.
-- Treat `Suggested next-work` or `Advisory-next` as routing authority; the orchestrator synthesizes the real next step.
+- Add advisory routing fields such as `Suggested next-work`, `Advisory-next`, `Regression gate`, or `Escalation`; use role body, `Remaining items`, `Feedback`, or `## Structural Issue` instead.

--- a/plugins/harness-loom/skills/harness-pair-dev/references/authoring/from-overlay.md
+++ b/plugins/harness-loom/skills/harness-pair-dev/references/authoring/from-overlay.md
@@ -1,0 +1,90 @@
+---
+name: from-overlay
+description: "Use when `/harness-pair-dev --add <pair> \"<purpose>\" --from <existing-pair>` authors a new pair from a currently registered source pair. Defines template-first overlay, mandatory runtime shape, and source material preservation rules."
+user-invocable: false
+---
+
+# From Overlay
+
+`--from` means "start from the current pair templates, then overlay compatible source-pair knowledge." It is not a blind copy, snapshot import, filesystem import, or provider-tree import.
+
+The source pair must already be registered in the target's current `.harness/loom/registry.md`. A current registered pair is trusted more than an auto-setup snapshot, so preserve useful domain shape aggressively, but never let source text override current harness runtime contracts.
+
+## Methodology
+
+### 1. Template-first sequence
+
+1. Run `scripts/pair-dev.ts --add <new-pair> "<purpose>" --from <source-pair>` and confirm it returns preparation JSON.
+2. Read the source pair skill and source producer/reviewer agents from `.harness/loom/`.
+3. Create the new pair from the current templates:
+   - `templates/pair-skill.md`
+   - `templates/producer-agent.md`
+   - `templates/reviewer-agent.md`
+4. Fill every mandatory runtime field for the new pair first.
+5. Overlay source-pair material only after the new template shape is valid.
+6. Register the new pair with `register-pair.ts`.
+7. Tell the user to run `node .harness/loom/sync.ts --provider <list>`.
+
+### 2. Mandatory new shape
+
+These fields come from the current templates and authoring rubrics, not from the source pair:
+
+- Frontmatter `name` must match the new filename slug.
+- Frontmatter `description` must be a one-line active trigger for the new role.
+- Pair agent `skills:` must list the new pair skill first and `harness-context` second.
+- Pair skill frontmatter `name` must be the new pair skill slug.
+- Producer and reviewer output formats must match the current `agent-authoring.md` Producer/Reviewer variants.
+- Structural Issue shape must match `harness-context`.
+- Agent bodies must not claim authority to write `.harness/cycle/` or derived provider trees.
+- `<purpose>` is the primary intent for the new pair and wins over conflicting source intent.
+
+### 3. Preserve by default
+
+Preserve or adapt these source-pair elements when they still fit `<purpose>` and the target repo:
+
+- Domain identity and vocabulary.
+- Why-first principle ideas, rewritten into the current five-principle shape when needed.
+- Methodology steps that describe real domain work.
+- Evaluation criteria that a reviewer can still verify with files, diffs, tests, or source evidence.
+- Taboos that encode real project risks.
+- Reviewer-specific axes, especially when the source pair has multiple reviewers.
+- File paths, subsystem names, or repo conventions that are still present.
+- Examples or terminology that make the new pair easier to use.
+- Extra domain skills from source agent frontmatter, when they are still relevant and available.
+
+### 4. Skill preservation rule
+
+Do not preserve the source `skills:` list wholesale.
+
+- Always use the new pair skill slug as the first skill.
+- Always include `harness-context` as the second skill.
+- Treat source extra/domain skills as preservation candidates only after those two required entries.
+- Do not carry over the source pair skill slug.
+- Do not duplicate `harness-context`.
+- Do not add unavailable or irrelevant domain skills just because the source used them.
+
+### 5. Rename and conflict rules
+
+- Replace old pair, producer, reviewer, and skill slugs with the new slugs unless the old slug is intentionally cited as historical source evidence.
+- If the source reviewer count differs from the requested reviewer count, map source reviewer guidance by closest responsibility and report any dropped axis.
+- If source text conflicts with current `harness-context`, current agent/skill authoring rubrics, or `<purpose>`, keep the current contract and summarize the dropped source idea.
+- If source material is too broad for the new purpose, preserve the narrower relevant part and leave the rest out.
+- If the source pair appears stale or internally inconsistent, use it as evidence only and say what was not preserved.
+
+## Evaluation Criteria
+
+- The new pair starts from current templates and passes the current agent/skill authoring rubrics.
+- The new agents list the new pair skill plus `harness-context`; only relevant extra domain skills are carried over.
+- Source domain material is preserved where compatible instead of being flattened into a generic template.
+- `<purpose>` remains visible as the new pair's primary intent.
+- No source slug, output format, or authority claim leaks into the new pair by accident.
+- The author reports important preserved, adapted, and dropped source elements.
+
+## Taboos
+
+- Blind-copy source pair files into the new pair.
+- Treat `--from` as a snapshot path, filesystem path, or derived provider-tree import.
+- Preserve an old Output Format because the source used it.
+- Preserve source `skills:` wholesale.
+- Drop all source domain guidance and produce a generic pair despite `--from`.
+- Let source text override `harness-context`, current templates, or `<purpose>`.

--- a/plugins/harness-loom/skills/harness-pair-dev/scripts/pair-dev.ts
+++ b/plugins/harness-loom/skills/harness-pair-dev/scripts/pair-dev.ts
@@ -371,10 +371,12 @@ async function assertActiveCycleSafe(target: string, entry: RegistryEntry): Prom
   return result;
 }
 
-function referencedSlugs(entries: RegistryEntry[]): Set<string> {
+function referencedFileSlugs(entries: RegistryEntry[]): Set<string> {
+  // Pair slugs are registry identifiers, not filesystem targets. Sharedness
+  // for file deletion is decided only by producer/reviewer/skill slugs that
+  // map to real paths under .harness/loom/{agents,skills}/.
   const refs = new Set<string>();
   for (const entry of entries) {
-    refs.add(entry.pair);
     refs.add(entry.producer);
     refs.add(entry.skill);
     for (const reviewer of entry.reviewers) refs.add(reviewer);
@@ -416,7 +418,7 @@ function buildRemovalPlan(target: string, entries: RegistryEntry[], existing: Re
   for (const entry of entries) validateRegistryEntry(entry);
 
   const postRemovalEntries = entries.filter((entry) => entry.pair !== existing.pair);
-  const remainingRefs = referencedSlugs(postRemovalEntries);
+  const remainingRefs = referencedFileSlugs(postRemovalEntries);
   const loomRoot = join(target, ".harness", "loom");
   const targets: RemovalTarget[] = [];
 

--- a/plugins/harness-loom/skills/harness-pair-dev/scripts/pair-dev.ts
+++ b/plugins/harness-loom/skills/harness-pair-dev/scripts/pair-dev.ts
@@ -311,11 +311,15 @@ function checkActiveCycleState(raw: string, protectedSlugs: Set<string>): Active
     return { safe: false, reason: "state.md is missing ## Next or ## EPIC summaries" };
   }
 
-  const nextRefs = intersectingReferences(next, protectedSlugs);
+  const nextTo = parseField(next, "To");
+  if (nextTo === null) {
+    return { safe: false, reason: "state.md ## Next is missing To" };
+  }
+  const nextRefs = intersectingReferences(nextTo, protectedSlugs);
   if (nextRefs.length > 0) {
     return {
       safe: false,
-      reason: "active-cycle ## Next references the pair being removed",
+      reason: "active-cycle ## Next To references the pair being removed",
       references: nextRefs,
     };
   }

--- a/plugins/harness-loom/skills/harness-pair-dev/scripts/pair-dev.ts
+++ b/plugins/harness-loom/skills/harness-pair-dev/scripts/pair-dev.ts
@@ -1,0 +1,551 @@
+#!/usr/bin/env node
+// Purpose: deterministic helper for the v0.3.0 harness-pair-dev command
+// surface. This script validates add/improve source references and performs guarded
+// pair removal in the current target. It does not author LLM-written pair
+// bodies; successful add/improve calls return preparation JSON only.
+
+import { spawnSync } from "node:child_process";
+import { constants as FS } from "node:fs";
+import { access, readFile, rm } from "node:fs/promises";
+import { dirname, join, relative, resolve } from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+type Action = "add" | "improve" | "remove";
+
+interface Args {
+  action: Action;
+  pair: string;
+  purpose?: string;
+  from?: string;
+  reviewers: string[];
+  before?: string;
+  after?: string;
+}
+
+interface RegistryEntry {
+  pair: string;
+  producer: string;
+  reviewers: string[];
+  skill: string;
+  line: string;
+}
+
+interface Placement {
+  mode: "append" | "before" | "after";
+  anchor?: string;
+}
+
+interface ActiveCycleCheck {
+  safe: boolean;
+  reason?: string;
+  references?: string[];
+}
+
+interface RemovalTarget {
+  kind: "agent" | "skill";
+  slug: string;
+  path: string;
+  shared: boolean;
+}
+
+interface RemovalPlan {
+  targets: RemovalTarget[];
+  preservedShared: string[];
+}
+
+const SLUG_RE = /^harness-[a-z0-9]+(-[a-z0-9]+)*$/;
+const FOUNDATION_SLUGS = new Set([
+  "harness-context",
+  "harness-orchestrate",
+  "harness-planning",
+  "harness-planner",
+  "harness-finalizer",
+]);
+const TERMINAL_CURRENT = new Set(["done", "superseded"]);
+const SYNC_HANDOFF = "node .harness/loom/sync.ts --provider <list>";
+
+function die(message: string, code = 1): never {
+  process.stderr.write(`pair-dev: ${message}\n`);
+  process.exit(code);
+}
+
+function help(): never {
+  process.stdout.write(
+    [
+      "Usage:",
+      '  node <harness-pair-dev>/scripts/pair-dev.ts --add <pair-slug> "<purpose>" [--from <existing-pair-slug>] [--reviewer <slug> ...] [--before <pair-slug> | --after <pair-slug>]',
+      '  node <harness-pair-dev>/scripts/pair-dev.ts --improve <pair-slug> "<purpose>" [--before <pair-slug> | --after <pair-slug>]',
+      "  node <harness-pair-dev>/scripts/pair-dev.ts --remove <pair-slug>",
+      "",
+      "Target root is the current working directory. Add/improve return validation summaries; remove mutates .harness/loom only.",
+    ].join("\n") + "\n",
+  );
+  process.exit(0);
+}
+
+function requireValue(rest: string[], index: number, flag: string): string {
+  const value = rest[index + 1];
+  if (value === undefined || value.startsWith("--")) die(`${flag} requires a value`);
+  return value;
+}
+
+function parseCommand(rest: string[]): { action: Action; pair: string; nextIndex: number } {
+  let found: { action: Action; pair: string; nextIndex: number } | null = null;
+  for (let i = 0; i < rest.length; i++) {
+    const arg = rest[i];
+    if (arg === "--split") {
+      die("--split is unsupported in harness-pair-dev v0.3.0; use explicit --add/--improve/--remove steps");
+    }
+    if (arg === "--hint") {
+      die('--hint is unsupported in harness-pair-dev v0.3.0; pass intent as positional "<purpose>"');
+    }
+    if (arg === "--add" || arg === "--improve" || arg === "--remove") {
+      if (found) die("use exactly one of --add, --improve, or --remove");
+      const pair = requireValue(rest, i, arg);
+      found = { action: arg.slice(2) as Action, pair, nextIndex: i + 2 };
+      i++;
+    }
+  }
+  if (!found) die("use exactly one of --add, --improve, or --remove");
+  return found;
+}
+
+function parseArgs(argv: string[]): Args {
+  const rest = argv.slice(2);
+  if (rest.includes("--help") || rest.includes("-h")) help();
+
+  const command = parseCommand(rest);
+  const out: Args = {
+    action: command.action,
+    pair: command.pair,
+    reviewers: [],
+  };
+
+  for (let i = 0; i < rest.length; i++) {
+    const arg = rest[i];
+    if (arg === "--add" || arg === "--improve" || arg === "--remove") {
+      i++;
+    } else if (arg === "--from") {
+      out.from = requireValue(rest, i, "--from");
+      i++;
+    } else if (arg === "--reviewer") {
+      out.reviewers.push(requireValue(rest, i, "--reviewer"));
+      i++;
+    } else if (arg === "--before") {
+      out.before = requireValue(rest, i, "--before");
+      i++;
+    } else if (arg === "--after") {
+      out.after = requireValue(rest, i, "--after");
+      i++;
+    } else if (arg === "--split") {
+      die("--split is unsupported in harness-pair-dev v0.3.0; use explicit --add/--improve/--remove steps");
+    } else if (arg === "--hint") {
+      die('--hint is unsupported in harness-pair-dev v0.3.0; pass intent as positional "<purpose>"');
+    } else if (arg.startsWith("--")) {
+      die(`unknown argument: ${arg}`);
+    } else {
+      if (i === command.nextIndex && out.action !== "remove" && out.purpose === undefined) {
+        out.purpose = arg;
+      } else if (i !== command.nextIndex - 1) {
+        die(`unexpected positional argument: ${arg}`);
+      }
+    }
+  }
+
+  if (!SLUG_RE.test(out.pair)) die(`pair slug must start with "harness-" (got: ${out.pair})`);
+  if (FOUNDATION_SLUGS.has(out.pair)) die(`${out.pair} is a foundation or singleton role, not a removable pair`);
+  if (out.before && out.after) die("use either --before or --after, not both");
+  for (const [flag, value] of [["--before", out.before], ["--after", out.after]] as const) {
+    if (value && !SLUG_RE.test(value)) die(`${flag} must be a harness pair slug (got: ${value})`);
+    if (value && value === out.pair) die("placement anchor cannot reference the same pair");
+  }
+  for (const reviewer of out.reviewers) {
+    if (!SLUG_RE.test(reviewer)) die(`--reviewer must be a harness slug (got: ${reviewer})`);
+  }
+  if (new Set(out.reviewers).size !== out.reviewers.length) die("duplicate --reviewer values are not allowed");
+
+  if (out.action === "add") {
+    if (!out.purpose) die('--add requires positional "<purpose>" after <pair-slug>');
+  } else if (out.action === "improve") {
+    if (!out.purpose) die('--improve requires positional "<purpose>" after <pair-slug>');
+    if (out.from) die("--from is only supported with --add");
+    if (out.reviewers.length > 0) die("--reviewer is only supported with --add");
+  } else {
+    if (out.purpose) die("--remove does not accept a purpose");
+    if (out.from) die("--from is only supported with --add");
+    if (out.reviewers.length > 0) die("--reviewer is only supported with --add");
+    if (out.before || out.after) die("--before/--after cannot be used with --remove");
+  }
+
+  return out;
+}
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await access(path, FS.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function normalizeCRLF(raw: string): string {
+  return raw.replace(/\r\n/g, "\n");
+}
+
+function extractSection(raw: string, heading: string): string | null {
+  const headingLine = `## ${heading}`;
+  const normalized = normalizeCRLF(raw);
+  const inlineIndex = normalized.indexOf(`\n${headingLine}\n`);
+  const headingIndex =
+    inlineIndex !== -1
+      ? inlineIndex + 1
+      : normalized.startsWith(`${headingLine}\n`)
+      ? 0
+      : -1;
+  if (headingIndex === -1) return null;
+  const bodyStart = normalized.indexOf("\n", headingIndex) + 1;
+  const nextHeading = normalized.indexOf("\n## ", bodyStart);
+  const bodyEnd = nextHeading === -1 ? normalized.length : nextHeading;
+  return normalized.slice(bodyStart, bodyEnd);
+}
+
+function parseRegistryLine(line: string): RegistryEntry | null {
+  const match = line.match(
+    /^-\s+(harness-[a-z0-9]+(?:-[a-z0-9]+)*)\s*:\s*producer\s+`([^`]+)`\s+↔\s+(reviewer|reviewers)\s+(.+),\s+skill\s+`([^`]+)`\s*$/,
+  );
+  if (!match) return null;
+  const reviewerPart = match[4];
+  const reviewers = Array.from(reviewerPart.matchAll(/`([^`]+)`/g), (item) => item[1]);
+  if (reviewers.length === 0) return null;
+  return {
+    pair: match[1],
+    producer: match[2],
+    reviewers,
+    skill: match[5],
+    line,
+  };
+}
+
+function parseRegistry(raw: string): RegistryEntry[] {
+  const section = extractSection(raw, "Registered pairs");
+  if (section === null) die("missing ## Registered pairs in .harness/loom/registry.md");
+  return section
+    .split("\n")
+    .map((line) => parseRegistryLine(line))
+    .filter((entry): entry is RegistryEntry => entry !== null);
+}
+
+async function readRegistry(target: string): Promise<{ path: string; entries: RegistryEntry[] }> {
+  const registryPath = join(target, ".harness", "loom", "registry.md");
+  if (!(await exists(registryPath))) die(`missing ${registryPath} (run /harness-init first)`);
+  const raw = await readFile(registryPath, "utf8");
+  return { path: registryPath, entries: parseRegistry(raw) };
+}
+
+function findEntry(entries: RegistryEntry[], pair: string): RegistryEntry | null {
+  return entries.find((entry) => entry.pair === pair) ?? null;
+}
+
+function placement(args: Args): Placement {
+  if (args.before) return { mode: "before", anchor: args.before };
+  if (args.after) return { mode: "after", anchor: args.after };
+  return { mode: "append" };
+}
+
+function assertAnchor(entries: RegistryEntry[], args: Args): void {
+  const anchor = args.before ?? args.after;
+  if (!anchor) return;
+  if (!findEntry(entries, anchor)) die(`placement anchor is not a registered pair: ${anchor}`);
+}
+
+function validateFrom(entries: RegistryEntry[], from: string): RegistryEntry {
+  if (
+    from.includes("/") ||
+    from.includes("\\") ||
+    from.startsWith(".") ||
+    from.endsWith(".md")
+  ) {
+    die("--from accepts a registered pair slug, not a file, snapshot, or platform path");
+  }
+  if (FOUNDATION_SLUGS.has(from)) die(`--from ${from} is a foundation or singleton role, not a registered pair`);
+  if (!SLUG_RE.test(from)) die(`--from must be a registered harness pair slug (got: ${from})`);
+  const entry = findEntry(entries, from);
+  if (!entry) die(`--from pair is not registered: ${from}`);
+  return entry;
+}
+
+function extractHarnessSlugs(text: string): Set<string> {
+  return new Set(Array.from(text.matchAll(/\bharness-[a-z0-9]+(?:-[a-z0-9]+)*\b/g), (match) => match[0]));
+}
+
+function intersectingReferences(text: string, protectedSlugs: Set<string>): string[] {
+  const refs = extractHarnessSlugs(text);
+  return [...protectedSlugs].filter((slug) => refs.has(slug));
+}
+
+function parseField(section: string, field: string): string | null {
+  const match = section.match(new RegExp(`^${field}:\\s*(.*)$`, "m"));
+  return match ? match[1].trim() : null;
+}
+
+function parseEpicSections(summaries: string): Array<{ epic: string; body: string }> {
+  return summaries
+    .split(/\n(?=###\s+EP-\d+--)/)
+    .map((section) => {
+      const match = section.match(/^###\s+(EP-\d+--[^\n]+)\n([\s\S]*)$/);
+      return match ? { epic: match[1], body: match[2] } : null;
+    })
+    .filter((section): section is { epic: string; body: string } => section !== null);
+}
+
+function checkActiveCycleState(raw: string, protectedSlugs: Set<string>): ActiveCycleCheck {
+  const normalized = normalizeCRLF(raw);
+  if (!normalized.startsWith("# Runtime State\n")) {
+    return { safe: false, reason: "state.md is not in the canonical runtime-state shape" };
+  }
+  const next = extractSection(normalized, "Next");
+  const summaries = extractSection(normalized, "EPIC summaries");
+  if (next === null || summaries === null) {
+    return { safe: false, reason: "state.md is missing ## Next or ## EPIC summaries" };
+  }
+
+  const nextRefs = intersectingReferences(next, protectedSlugs);
+  if (nextRefs.length > 0) {
+    return {
+      safe: false,
+      reason: "active-cycle ## Next references the pair being removed",
+      references: nextRefs,
+    };
+  }
+
+  const epicSections = parseEpicSections(summaries);
+  const trimmedSummaries = summaries.trim();
+  if (epicSections.length === 0) {
+    if (trimmedSummaries.length === 0 || /There are no EPICs yet\./.test(trimmedSummaries)) {
+      return { safe: true };
+    }
+    return { safe: false, reason: "state.md EPIC summaries could not be parsed" };
+  }
+
+  for (const { epic, body } of epicSections) {
+    const roster = parseField(body, "roster");
+    const current = parseField(body, "current");
+    if (roster === null || current === null) {
+      return { safe: false, reason: `state.md ${epic} is missing roster or current` };
+    }
+    if (TERMINAL_CURRENT.has(current)) continue;
+    const refs = [
+      ...intersectingReferences(roster, protectedSlugs),
+      ...intersectingReferences(current, protectedSlugs),
+    ];
+    const uniqueRefs = [...new Set(refs)];
+    if (uniqueRefs.length > 0) {
+      return {
+        safe: false,
+        reason: `live EPIC ${epic} references the pair being removed`,
+        references: uniqueRefs,
+      };
+    }
+  }
+
+  return { safe: true };
+}
+
+async function assertActiveCycleSafe(target: string, entry: RegistryEntry): Promise<ActiveCycleCheck> {
+  const statePath = join(target, ".harness", "cycle", "state.md");
+  if (!(await exists(statePath))) return { safe: true };
+  const protectedSlugs = new Set([entry.pair, entry.producer, entry.skill, ...entry.reviewers]);
+  const raw = await readFile(statePath, "utf8");
+  const result = checkActiveCycleState(raw, protectedSlugs);
+  if (!result.safe) {
+    die(
+      `refusing to remove ${entry.pair}: ${result.reason}${
+        result.references && result.references.length > 0
+          ? ` (${result.references.join(", ")})`
+          : ""
+      }`,
+    );
+  }
+  return result;
+}
+
+function referencedSlugs(entries: RegistryEntry[]): Set<string> {
+  const refs = new Set<string>();
+  for (const entry of entries) {
+    refs.add(entry.pair);
+    refs.add(entry.producer);
+    refs.add(entry.skill);
+    for (const reviewer of entry.reviewers) refs.add(reviewer);
+  }
+  return refs;
+}
+
+function validateRegisteredSlug(role: string, slug: string): void {
+  if (!SLUG_RE.test(slug)) die(`registered ${role} slug is invalid: ${slug}`);
+  if (FOUNDATION_SLUGS.has(slug)) {
+    die(`registered ${role} slug is reserved for a foundation or singleton role: ${slug}`);
+  }
+}
+
+function validateRegistryEntry(entry: RegistryEntry): void {
+  validateRegisteredSlug("pair", entry.pair);
+  validateRegisteredSlug("producer", entry.producer);
+  for (const reviewer of entry.reviewers) validateRegisteredSlug("reviewer", reviewer);
+  validateRegisteredSlug("skill", entry.skill);
+}
+
+function safeResolve(base: string, ...parts: string[]): string {
+  const resolved = resolve(base, ...parts);
+  const root = resolve(base);
+  const rel = relative(root, resolved);
+  if (rel === "" || rel.startsWith("..") || resolve(root, rel) !== resolved) {
+    die(`refusing to operate outside ${root}`);
+  }
+  return resolved;
+}
+
+async function removePath(path: string): Promise<"deleted" | "missing"> {
+  if (!(await exists(path))) return "missing";
+  await rm(path, { recursive: true, force: true });
+  return "deleted";
+}
+
+function buildRemovalPlan(target: string, entries: RegistryEntry[], existing: RegistryEntry): RemovalPlan {
+  for (const entry of entries) validateRegistryEntry(entry);
+
+  const postRemovalEntries = entries.filter((entry) => entry.pair !== existing.pair);
+  const remainingRefs = referencedSlugs(postRemovalEntries);
+  const loomRoot = join(target, ".harness", "loom");
+  const targets: RemovalTarget[] = [];
+
+  for (const slug of [existing.producer, ...existing.reviewers]) {
+    const path = safeResolve(loomRoot, "agents", `${slug}.md`);
+    targets.push({ kind: "agent", slug, path, shared: remainingRefs.has(slug) });
+  }
+
+  const skillPath = safeResolve(loomRoot, "skills", existing.skill);
+  targets.push({
+    kind: "skill",
+    slug: existing.skill,
+    path: skillPath,
+    shared: remainingRefs.has(existing.skill),
+  });
+
+  return {
+    targets,
+    preservedShared: targets.filter((target) => target.shared).map((target) => target.path),
+  };
+}
+
+function unregister(target: string, pair: string): unknown {
+  const scriptPath = join(dirname(fileURLToPath(import.meta.url)), "register-pair.ts");
+  const result = spawnSync(process.execPath, [scriptPath, "--unregister", "--target", target, "--pair", pair], {
+    encoding: "utf8",
+  });
+  if (result.status !== 0) {
+    die(result.stderr.trim() || `register-pair --unregister failed with status ${result.status}`);
+  }
+  try {
+    return JSON.parse(result.stdout);
+  } catch {
+    die("register-pair --unregister did not return JSON");
+  }
+}
+
+async function prepareAdd(target: string, args: Args): Promise<unknown> {
+  const registry = await readRegistry(target);
+  if (findEntry(registry.entries, args.pair)) die(`${args.pair} is already registered; use --improve`);
+  assertAnchor(registry.entries, args);
+  const from = args.from ? validateFrom(registry.entries, args.from) : null;
+  const reviewers = args.reviewers.length > 0 ? args.reviewers : [`${args.pair}-reviewer`];
+  return {
+    action: "prepare-add",
+    authored: false,
+    target,
+    pair: args.pair,
+    purpose: args.purpose,
+    producer: `${args.pair}-producer`,
+    reviewers,
+    skill: args.pair,
+    from,
+    placement: placement(args),
+    writes: [],
+    providerTreesWritten: [],
+    syncCommand: SYNC_HANDOFF,
+    nextStep:
+      "Author producer/reviewer/skill files under .harness/loom using template-first overlay when --from is present, then register the pair and run the sync command.",
+  };
+}
+
+async function prepareImprove(target: string, args: Args): Promise<unknown> {
+  const registry = await readRegistry(target);
+  const existing = findEntry(registry.entries, args.pair);
+  if (!existing) die(`cannot improve missing registered pair: ${args.pair}`);
+  assertAnchor(registry.entries, args);
+  return {
+    action: "prepare-improve",
+    authored: false,
+    target,
+    pair: args.pair,
+    purpose: args.purpose,
+    existing,
+    placement: placement(args),
+    writes: [],
+    providerTreesWritten: [],
+    syncCommand: SYNC_HANDOFF,
+    nextStep:
+      "Revise the existing loom agent/skill files from current repo evidence, re-register only if placement or reviewer shape changes, then run the sync command.",
+  };
+}
+
+async function removePair(target: string, args: Args): Promise<unknown> {
+  const beforeRegistry = await readRegistry(target);
+  const existing = findEntry(beforeRegistry.entries, args.pair);
+  if (!existing) die(`cannot remove missing registered pair: ${args.pair}`);
+  await assertActiveCycleSafe(target, existing);
+  const removalPlan = buildRemovalPlan(target, beforeRegistry.entries, existing);
+
+  const unregisterSummary = unregister(target, args.pair);
+  const deleted: string[] = [];
+  const missing: string[] = [];
+
+  for (const removalTarget of removalPlan.targets) {
+    if (removalTarget.shared) {
+      continue;
+    }
+    const result = await removePath(removalTarget.path);
+    if (result === "deleted") deleted.push(removalTarget.path);
+    else missing.push(removalTarget.path);
+  }
+
+  return {
+    action: "remove",
+    target,
+    pair: existing.pair,
+    removedEntry: existing,
+    unregister: unregisterSummary,
+    deleted,
+    missing,
+    preservedShared: removalPlan.preservedShared,
+    cycleHistoryPreserved: true,
+    providerTreesWritten: [],
+    syncCommand: SYNC_HANDOFF,
+  };
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  const target = process.cwd();
+  let summary: unknown;
+  if (args.action === "add") summary = await prepareAdd(target, args);
+  else if (args.action === "improve") summary = await prepareImprove(target, args);
+  else summary = await removePair(target, args);
+  process.stdout.write(JSON.stringify(summary, null, 2) + "\n");
+}
+
+main().catch((err) => {
+  const msg = err instanceof Error ? err.message : String(err);
+  die(msg);
+});

--- a/plugins/harness-loom/skills/harness-pair-dev/templates/producer-agent.md
+++ b/plugins/harness-loom/skills/harness-pair-dev/templates/producer-agent.md
@@ -35,7 +35,5 @@ Files created: [{file path}]
 Files modified: [{file path}]
 Diff summary: {sections changed vs baseline, or "N/A"}
 Self-verification: {issues found and resolved during this cycle}
-Suggested next-work: "<optional forward hint for the next stage, or 'none'>"
 Remaining items: [{items not yet done}]
-Escalation: {none | structural-retreat-to-<stage>, reason}
 ```

--- a/plugins/harness-loom/skills/harness-pair-dev/templates/reviewer-agent.md
+++ b/plugins/harness-loom/skills/harness-pair-dev/templates/reviewer-agent.md
@@ -32,7 +32,5 @@ End your response with this structured block:
 Verdict: PASS / FAIL
 Criteria: [{criterion, result, evidence-citation (file:line)}]
 FAIL items: [{item, level (technical/creative/structural), reason}]
-Regression gate: {clean / regression / N/A, details}
 Feedback: {short free-form rationale}
-Advisory-next: "<optional forward hint for the next stage, or 'none'>"
 ```

--- a/tests/auto-setup.test.mjs
+++ b/tests/auto-setup.test.mjs
@@ -76,6 +76,22 @@ function readAgentBodies(target, slugs) {
   return Object.fromEntries(slugs.map((slug) => [slug, readAgent(target, slug)]));
 }
 
+function assertReconstructedProducerAgent(body, { pair, skill, producer }) {
+  assert.match(body, new RegExp(`^name: ${producer}$`, "m"));
+  assert.match(body, new RegExp(`^skills:\\n  - ${skill}\\n  - harness-context$`, "m"));
+  assert.match(body, new RegExp(`registered \`${pair}\` harness pair`));
+  assert.match(body, /^## Output Format$/m);
+  assert.match(body, /End your response with this structured block:/);
+  assert.match(body, /Status: PASS \/ FAIL/);
+  assert.match(body, /Files created: \[\{file path\}\]/);
+  assert.match(body, /Files modified: \[\{file path\}\]/);
+  assert.match(body, /Diff summary: \{sections changed vs baseline, or "N\/A"\}/);
+  assert.match(body, /Self-verification: \{issues found and resolved during this cycle\}/);
+  assert.match(body, /Remaining items: \[\{items not yet done\}\]/);
+  assert.doesNotMatch(body, /Suggested next-work|Advisory-next|Regression gate|Escalation/);
+  assert.doesNotMatch(body, /Verdict: PASS \/ FAIL/);
+}
+
 function assertReconstructedReviewerAgent(body, { pair, skill, reviewer }) {
   assert.match(body, new RegExp(`^name: ${reviewer}$`, "m"));
   assert.match(
@@ -94,9 +110,8 @@ function assertReconstructedReviewerAgent(body, { pair, skill, reviewer }) {
   assert.match(body, /Verdict: PASS \/ FAIL/);
   assert.match(body, /Criteria: \[\{criterion, result, evidence-citation \(file:line\)\}\]/);
   assert.match(body, /FAIL items: \[\{item, level \(technical\/creative\/structural\), reason\}\]/);
-  assert.match(body, /Regression gate: \{clean \/ regression \/ N\/A, details\}/);
   assert.match(body, /Feedback: \{short free-form rationale\}/);
-  assert.match(body, /Advisory-next: "<optional forward hint for the next stage, or 'none'>"/);
+  assert.doesNotMatch(body, /Suggested next-work|Advisory-next|Regression gate|Escalation/);
   assert.doesNotMatch(body, /Status: PASS \/ FAIL/);
 }
 
@@ -257,9 +272,11 @@ test("auto-setup reconstructs registered pair files and registry after refresh",
     assert.match(currentSkill, /custom build scripts/);
     assert.match(currentSkill, /Current project files and tests are cited/);
 
-    const producer = readFileSync(join(target, ".harness/loom/agents/harness-demo-producer.md"), "utf8");
-    assert.match(producer, /name: harness-demo-producer/);
-    assert.match(producer, /Status: PASS \/ FAIL/);
+    assertReconstructedProducerAgent(readAgent(target, "harness-demo-producer"), {
+      pair: "harness-demo",
+      skill: "harness-demo",
+      producer: "harness-demo-producer",
+    });
     for (const reviewer of ["harness-demo-reviewer", "harness-demo-security-reviewer"]) {
       assertReconstructedReviewerAgent(readAgent(target, reviewer), {
         pair: "harness-demo",
@@ -324,6 +341,15 @@ test("auto-setup reconstructs customized finalizer on current skeleton", () => {
     assert.match(currentFinalizer, /### Preserved Intent Evidence/);
     assert.match(currentFinalizer, /CHANGELOG/);
     assert.match(currentFinalizer, /Files left alone \(intentionally\)/);
+    assert.match(currentFinalizer, /Status: PASS \/ FAIL/);
+    assert.match(currentFinalizer, /Self-verification:/);
+    assert.match(currentFinalizer, /Remaining items: \[\{items not yet done\}\]/);
+    assert.match(currentFinalizer, /## Structural Issue/);
+    assert.match(currentFinalizer, /Suspected upstream stage:\s*planner/i);
+    assert.doesNotMatch(currentFinalizer, /^(Suggested next-work|Advisory-next|Regression gate|Escalation):/m);
+    assert.doesNotMatch(currentFinalizer, /^Verdict: PASS \/ FAIL$/m);
+    assert.doesNotMatch(currentFinalizer, /^Criteria:/m);
+    assert.doesNotMatch(currentFinalizer, /^FAIL items:/m);
     assert.doesNotMatch(currentFinalizer, /Summary: release docs refreshed/);
     assertNoProviderTrees(target);
   } finally {
@@ -394,6 +420,11 @@ test("auto-setup rerun allocates a new snapshot and keeps reconstructed pair ide
     assert.ok(existsSync(second.snapshot.path));
     assert.equal(skillAfterSecond, skillAfterFirst);
     assert.deepEqual(agentBodiesAfterSecond, agentBodiesAfterFirst);
+    assertReconstructedProducerAgent(agentBodiesAfterSecond["harness-demo-producer"], {
+      pair: "harness-demo",
+      skill: "harness-demo",
+      producer: "harness-demo-producer",
+    });
     assertReconstructedReviewerAgent(agentBodiesAfterSecond["harness-demo-reviewer"], {
       pair: "harness-demo",
       skill: "harness-demo",

--- a/tests/auto-setup.test.mjs
+++ b/tests/auto-setup.test.mjs
@@ -1,0 +1,459 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  AUTO_SETUP_SCRIPT,
+  INSTALL_SCRIPT,
+  cleanupDir,
+  makeTempDir,
+  runNode,
+} from "./helpers.mjs";
+
+function runAutoSetup(target, extraArgs = []) {
+  const r = runNode(AUTO_SETUP_SCRIPT, [target, ...extraArgs]);
+  assert.equal(r.status, 0, r.stderr);
+  return { result: r, summary: JSON.parse(r.stdout) };
+}
+
+function installTo(target) {
+  const r = runNode(INSTALL_SCRIPT, [target]);
+  assert.equal(r.status, 0, r.stderr);
+}
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function assertNoProviderTrees(target) {
+  for (const platformDir of [".claude", ".codex", ".gemini"]) {
+    assert.ok(!existsSync(join(target, platformDir)), `auto-setup must not create ${platformDir}/`);
+  }
+}
+
+function snapshotTree(root) {
+  const out = new Map();
+  function walk(dir, prefix) {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name);
+      const rel = prefix ? `${prefix}/${entry.name}` : entry.name;
+      if (entry.isDirectory()) walk(full, rel);
+      else if (entry.isFile()) out.set(rel, readFileSync(full, "utf8"));
+    }
+  }
+  if (existsSync(root)) walk(root, "");
+  return out;
+}
+
+function assertTreeUnchanged(before, root) {
+  const after = snapshotTree(root);
+  assert.equal(after.size, before.size, `${root} file count must not change`);
+  for (const [path, body] of before) {
+    assert.equal(after.get(path), body, `${root}/${path} must be preserved byte-for-byte`);
+  }
+}
+
+function assertManifestShape(manifest) {
+  assert.deepEqual(Object.keys(manifest).slice(0, 10), [
+    "schemaVersion",
+    "tool",
+    "targetPath",
+    "createdAt",
+    "snapshotPath",
+    "copiedNamespaces",
+    "activeCycle",
+    "registrySummary",
+    "finalizerSummary",
+    "nextAction",
+  ]);
+}
+
+function readAgent(target, slug) {
+  return readFileSync(join(target, ".harness/loom/agents", `${slug}.md`), "utf8");
+}
+
+function readAgentBodies(target, slugs) {
+  return Object.fromEntries(slugs.map((slug) => [slug, readAgent(target, slug)]));
+}
+
+function assertReconstructedReviewerAgent(body, { pair, skill, reviewer }) {
+  assert.match(body, new RegExp(`^name: ${reviewer}$`, "m"));
+  assert.match(
+    body,
+    new RegExp(
+      `^description: "Use when \`/harness-orchestrate\` dispatches the \`${pair}\` reviewer turn\\. Read the shared pair skill plus \`harness-context\`, grade the paired producer task, and end with the Reviewer Output Format block\\."$`,
+      "m",
+    ),
+  );
+  assert.match(body, new RegExp(`^skills:\\n  - ${skill}\\n  - harness-context$`, "m"));
+  assert.match(body, new RegExp(`registered \`${pair}\` harness pair`));
+  assert.match(body, /Check contract freshness\. Reason: reconstructed pairs must follow current templates and harness-context law\./);
+  assert.match(body, /Verify the producer used current contracts rather than stale snapshot copies\./);
+  assert.match(body, /^## Output Format$/m);
+  assert.match(body, /End your response with this structured block:/);
+  assert.match(body, /Verdict: PASS \/ FAIL/);
+  assert.match(body, /Criteria: \[\{criterion, result, evidence-citation \(file:line\)\}\]/);
+  assert.match(body, /FAIL items: \[\{item, level \(technical\/creative\/structural\), reason\}\]/);
+  assert.match(body, /Regression gate: \{clean \/ regression \/ N\/A, details\}/);
+  assert.match(body, /Feedback: \{short free-form rationale\}/);
+  assert.match(body, /Advisory-next: "<optional forward hint for the next stage, or 'none'>"/);
+  assert.doesNotMatch(body, /Status: PASS \/ FAIL/);
+}
+
+test("auto-setup fresh target installs foundation and prints explicit sync handoff", () => {
+  const target = makeTempDir();
+  try {
+    writeFileSync(join(target, "README.md"), "# Demo\n");
+
+    const { summary } = runAutoSetup(target, ["--provider", "codex"]);
+
+    assert.equal(summary.mode, "fresh");
+    assert.equal(summary.snapshot.created, false);
+    assert.equal(summary.activeCycle.classification, "absent");
+    assert.equal(summary.install.summary.verification.ok, true);
+    assert.equal(summary.syncCommand, "node .harness/loom/sync.ts --provider codex");
+    assert.deepEqual(summary.providerTreesWritten, []);
+    assert.match(summary.convergence.pairRecommendations.join("\n"), /documentation evidence/);
+    assert.ok(existsSync(join(target, ".harness/loom/sync.ts")));
+    assert.ok(existsSync(join(target, ".harness/cycle/state.md")));
+    assertNoProviderTrees(target);
+  } finally {
+    cleanupDir(target);
+  }
+});
+
+test("auto-setup rejects unknown flags before writing harness state", () => {
+  const target = makeTempDir();
+  try {
+    const r = runNode(AUTO_SETUP_SCRIPT, [target, "--force"]);
+    assert.notEqual(r.status, 0);
+    assert.match(r.stderr, /unknown flag: --force/);
+    assert.ok(!existsSync(join(target, ".harness")), "invalid args must not create .harness/");
+  } finally {
+    cleanupDir(target);
+  }
+});
+
+test("auto-setup preserves pre-existing provider trees and only prints sync handoff", () => {
+  const target = makeTempDir();
+  try {
+    installTo(target);
+    mkdirSync(join(target, ".claude/agents"), { recursive: true });
+    mkdirSync(join(target, ".claude/skills/user-skill"), { recursive: true });
+    mkdirSync(join(target, ".codex/agents"), { recursive: true });
+    mkdirSync(join(target, ".gemini/skills/harness-stale"), { recursive: true });
+    writeFileSync(join(target, ".claude/settings.json"), '{"permissions":{"allow":["Bash(ls)"]}}\n');
+    writeFileSync(join(target, ".claude/agents/team-reviewer.md"), "USER CLAUDE AGENT\n");
+    writeFileSync(join(target, ".claude/skills/user-skill/SKILL.md"), "USER CLAUDE SKILL\n");
+    writeFileSync(join(target, ".codex/config.toml"), "[features]\nuser_feature = true\n");
+    writeFileSync(join(target, ".codex/agents/harness-stale-producer.toml"), "STALE BUT UNTOUCHED\n");
+    writeFileSync(join(target, ".gemini/settings.json"), '{"hooks":{"AfterAgent":[]}}\n');
+    writeFileSync(join(target, ".gemini/skills/harness-stale/SKILL.md"), "STALE GEMINI SKILL\n");
+
+    const before = new Map([
+      [".claude", snapshotTree(join(target, ".claude"))],
+      [".codex", snapshotTree(join(target, ".codex"))],
+      [".gemini", snapshotTree(join(target, ".gemini"))],
+    ]);
+
+    const { summary } = runAutoSetup(target, ["--provider", "claude,gemini"]);
+
+    assert.equal(summary.mode, "existing");
+    assert.equal(summary.syncCommand, "node .harness/loom/sync.ts --provider claude,gemini");
+    assert.equal(
+      summary.nextAction,
+      "From the target root, run `node .harness/loom/sync.ts --provider claude,gemini` for any platform trees you want to refresh.",
+    );
+    assert.deepEqual(summary.providerTreesWritten, []);
+    for (const platformDir of [".claude", ".codex", ".gemini"]) {
+      assertTreeUnchanged(before.get(platformDir), join(target, platformDir));
+    }
+    assert.ok(!existsSync(join(target, ".claude/agents/harness-planner.md")));
+    assert.ok(!existsSync(join(target, ".codex/hooks.json")));
+    assert.ok(!existsSync(join(target, ".gemini/agents/harness-planner.md")));
+  } finally {
+    cleanupDir(target);
+  }
+});
+
+test("auto-setup reconstructs registered pair files and registry after refresh", () => {
+  const target = makeTempDir();
+  try {
+    installTo(target);
+    const oldSkill = [
+      "---",
+      "name: harness-demo",
+      'description: "Use when maintaining custom demo build scripts."',
+      "user-invocable: false",
+      "---",
+      "",
+      "# Old Demo",
+      "",
+      "## Design Thinking",
+      "",
+      "Own custom demo release packaging.",
+      "",
+      "## Methodology",
+      "",
+      "Keep custom build scripts and fixture snapshots aligned.",
+      "",
+      "## Evaluation Criteria",
+      "",
+      "- Old criterion.",
+      "",
+      "## Taboos",
+      "",
+      "- Old taboo.",
+      "",
+    ].join("\n");
+    mkdirSync(join(target, ".harness/loom/skills/harness-demo"), { recursive: true });
+    writeFileSync(join(target, ".harness/loom/skills/harness-demo/SKILL.md"), oldSkill);
+    writeFileSync(
+      join(target, ".harness/loom/agents/harness-demo-producer.md"),
+      "---\nname: harness-demo-producer\n---\n\n# Producer\n\n## Task\n\n1. Maintain custom build scripts.\n",
+    );
+    writeFileSync(
+      join(target, ".harness/loom/agents/harness-demo-reviewer.md"),
+      "---\nname: harness-demo-reviewer\n---\n\n# Reviewer\n\n## Task\n\n1. Audit fixture snapshots.\n",
+    );
+    writeFileSync(
+      join(target, ".harness/loom/agents/harness-demo-security-reviewer.md"),
+      "---\nname: harness-demo-security-reviewer\n---\n\n# Security Reviewer\n\n## Task\n\n1. Check release safety notes.\n",
+    );
+    writeFileSync(
+      join(target, ".harness/loom/registry.md"),
+      [
+        "# Registry",
+        "",
+        "## Registered pairs",
+        "",
+        "- harness-demo: producer `harness-demo-producer` ↔ reviewers [`harness-demo-reviewer`, `harness-demo-security-reviewer`], skill `harness-demo`",
+        "",
+      ].join("\n"),
+    );
+
+    const { summary } = runAutoSetup(target);
+    const manifest = readJson(summary.snapshot.manifestPath);
+
+    assert.equal(summary.mode, "existing");
+    assert.equal(summary.snapshot.created, true);
+    assert.deepEqual(summary.snapshot.copiedNamespaces, [".harness/cycle", ".harness/loom"]);
+    assertManifestShape(manifest);
+    assert.equal(manifest.registrySummary.pairCount, 1);
+    assert.equal(manifest.registrySummary.pairs[0].pair, "harness-demo");
+    assert.equal(manifest.activeCycle.classification, "pristine");
+    assert.ok(existsSync(join(summary.snapshot.path, "loom/skills/harness-demo/SKILL.md")));
+    assert.ok(existsSync(join(summary.snapshot.path, "cycle/state.md")));
+
+    assert.equal(summary.convergence.pairReconstructions[0].status, "reconstructed");
+    assert.deepEqual(summary.convergence.pairReconstructions[0].reviewers, [
+      "harness-demo-reviewer",
+      "harness-demo-security-reviewer",
+    ]);
+    const currentSkill = readFileSync(join(target, ".harness/loom/skills/harness-demo/SKILL.md"), "utf8");
+    assert.notEqual(currentSkill, oldSkill);
+    assert.match(currentSkill, /name: harness-demo/);
+    assert.match(currentSkill, /### Preserved Snapshot Intent/);
+    assert.match(currentSkill, /custom build scripts/);
+    assert.match(currentSkill, /Current project files and tests are cited/);
+
+    const producer = readFileSync(join(target, ".harness/loom/agents/harness-demo-producer.md"), "utf8");
+    assert.match(producer, /name: harness-demo-producer/);
+    assert.match(producer, /Status: PASS \/ FAIL/);
+    for (const reviewer of ["harness-demo-reviewer", "harness-demo-security-reviewer"]) {
+      assertReconstructedReviewerAgent(readAgent(target, reviewer), {
+        pair: "harness-demo",
+        skill: "harness-demo",
+        reviewer,
+      });
+    }
+
+    const registry = readFileSync(join(target, ".harness/loom/registry.md"), "utf8");
+    assert.match(
+      registry,
+      /- harness-demo: producer `harness-demo-producer` ↔ reviewers \[`harness-demo-reviewer`, `harness-demo-security-reviewer`\], skill `harness-demo`/,
+    );
+    assert.equal(registry.match(/^- harness-demo:/gm).length, 1);
+    assertNoProviderTrees(target);
+  } finally {
+    cleanupDir(target);
+  }
+});
+
+test("auto-setup reconstructs customized finalizer on current skeleton", () => {
+  const target = makeTempDir();
+  try {
+    installTo(target);
+    writeFileSync(
+      join(target, ".harness/loom/agents/harness-finalizer.md"),
+      [
+        "---",
+        "name: harness-finalizer",
+        "skills:",
+        "  - harness-context",
+        "---",
+        "",
+        "# Finalizer",
+        "",
+        "## Task",
+        "",
+        "1. Refresh docs/ and CHANGELOG.md after verified release work.",
+        "",
+        "## Output Format",
+        "",
+        "Status: PASS / FAIL",
+        "Summary: release docs refreshed",
+        "Self-verification: docs and changelog checked",
+        "",
+      ].join("\n"),
+    );
+
+    const { summary } = runAutoSetup(target);
+    const manifest = readJson(summary.snapshot.manifestPath);
+
+    assert.equal(summary.finalizerSummary.status, "customized");
+    assert.equal(summary.finalizerSummary.customized, true);
+    assert.ok(summary.finalizerSummary.signals.includes("docs"));
+    assert.equal(manifest.finalizerSummary.status, "customized");
+    assert.match(manifest.finalizerSummary.recommendation, /snapshot finalizer as intent evidence/);
+    assert.match(readFileSync(join(summary.snapshot.path, "loom/agents/harness-finalizer.md"), "utf8"), /CHANGELOG/);
+
+    assert.equal(summary.convergence.finalizerReconstruction.status, "reconstructed");
+    const currentFinalizer = readFileSync(join(target, ".harness/loom/agents/harness-finalizer.md"), "utf8");
+    assert.match(currentFinalizer, /The finalizer is a \*\*singleton cycle-end role\*\*/);
+    assert.match(currentFinalizer, /### Preserved Intent Evidence/);
+    assert.match(currentFinalizer, /CHANGELOG/);
+    assert.match(currentFinalizer, /Files left alone \(intentionally\)/);
+    assert.doesNotMatch(currentFinalizer, /Summary: release docs refreshed/);
+    assertNoProviderTrees(target);
+  } finally {
+    cleanupDir(target);
+  }
+});
+
+test("auto-setup rerun allocates a new snapshot and keeps reconstructed pair idempotent", () => {
+  const target = makeTempDir();
+  try {
+    installTo(target);
+    mkdirSync(join(target, ".harness/loom/skills/harness-demo"), { recursive: true });
+    writeFileSync(
+      join(target, ".harness/loom/skills/harness-demo/SKILL.md"),
+      [
+        "---",
+        "name: harness-demo",
+        'description: "Use when maintaining demo workflows."',
+        "user-invocable: false",
+        "---",
+        "",
+        "# Demo",
+        "",
+        "## Methodology",
+        "",
+        "Preserve deterministic demo workflow evidence.",
+        "",
+      ].join("\n"),
+    );
+    writeFileSync(
+      join(target, ".harness/loom/agents/harness-demo-producer.md"),
+      "---\nname: harness-demo-producer\n---\n\n# Producer\n\n## Task\n\n1. Produce demo workflow changes.\n",
+    );
+    writeFileSync(
+      join(target, ".harness/loom/agents/harness-demo-reviewer.md"),
+      "---\nname: harness-demo-reviewer\n---\n\n# Reviewer\n\n## Task\n\n1. Review demo workflow changes.\n",
+    );
+    writeFileSync(
+      join(target, ".harness/loom/registry.md"),
+      [
+        "# Registry",
+        "",
+        "## Registered pairs",
+        "",
+        "- harness-demo: producer `harness-demo-producer` ↔ reviewer `harness-demo-reviewer`, skill `harness-demo`",
+        "",
+      ].join("\n"),
+    );
+
+    const first = runAutoSetup(target).summary;
+    const skillAfterFirst = readFileSync(join(target, ".harness/loom/skills/harness-demo/SKILL.md"), "utf8");
+    const agentBodiesAfterFirst = readAgentBodies(target, [
+      "harness-demo-producer",
+      "harness-demo-reviewer",
+    ]);
+    const registryAfterFirst = readFileSync(join(target, ".harness/loom/registry.md"), "utf8");
+
+    const second = runAutoSetup(target).summary;
+    const skillAfterSecond = readFileSync(join(target, ".harness/loom/skills/harness-demo/SKILL.md"), "utf8");
+    const agentBodiesAfterSecond = readAgentBodies(target, [
+      "harness-demo-producer",
+      "harness-demo-reviewer",
+    ]);
+    const registryAfterSecond = readFileSync(join(target, ".harness/loom/registry.md"), "utf8");
+
+    assert.notEqual(first.snapshot.path, second.snapshot.path);
+    assert.ok(existsSync(first.snapshot.path));
+    assert.ok(existsSync(second.snapshot.path));
+    assert.equal(skillAfterSecond, skillAfterFirst);
+    assert.deepEqual(agentBodiesAfterSecond, agentBodiesAfterFirst);
+    assertReconstructedReviewerAgent(agentBodiesAfterSecond["harness-demo-reviewer"], {
+      pair: "harness-demo",
+      skill: "harness-demo",
+      reviewer: "harness-demo-reviewer",
+    });
+    assert.equal(registryAfterSecond, registryAfterFirst);
+    assert.equal(registryAfterSecond.match(/^- harness-demo:/gm).length, 1);
+    assertNoProviderTrees(target);
+  } finally {
+    cleanupDir(target);
+  }
+});
+
+test("auto-setup warns and snapshots active cycle before discard and reseed", () => {
+  const target = makeTempDir();
+  try {
+    installTo(target);
+    const statePath = join(target, ".harness/cycle/state.md");
+    const activeState = readFileSync(statePath, "utf8").replace("loop: false", "loop: true");
+    writeFileSync(statePath, `<!-- active-cycle-sentinel -->\n${activeState}`);
+
+    const { result, summary } = runAutoSetup(target);
+    const manifest = readJson(summary.snapshot.manifestPath);
+
+    assert.match(result.stderr, /warning .*Existing cycle classified as active/);
+    assert.equal(summary.activeCycle.classification, "active");
+    assert.equal(manifest.activeCycle.classification, "active");
+    assert.ok(summary.warnings[0].includes("discarded/reseeded"));
+    assert.match(readFileSync(join(summary.snapshot.path, "cycle/state.md"), "utf8"), /active-cycle-sentinel/);
+
+    const currentState = readFileSync(statePath, "utf8");
+    assert.doesNotMatch(currentState, /active-cycle-sentinel/);
+    assert.match(currentState, /^loop: false$/m);
+    assertNoProviderTrees(target);
+  } finally {
+    cleanupDir(target);
+  }
+});
+
+test("auto-setup warns and preserves unknown cycle before discard and reseed", () => {
+  const target = makeTempDir();
+  try {
+    installTo(target);
+    const cycleDir = join(target, ".harness/cycle");
+    const statePath = join(cycleDir, "state.md");
+    writeFileSync(join(cycleDir, "unknown-cycle-sentinel.txt"), "preserve me\n");
+    rmSync(statePath);
+
+    const { result, summary } = runAutoSetup(target);
+    const manifest = readJson(summary.snapshot.manifestPath);
+
+    assert.match(result.stderr, /warning .*Existing cycle classified as unknown/);
+    assert.equal(summary.activeCycle.classification, "unknown");
+    assert.equal(manifest.activeCycle.classification, "unknown");
+    assert.match(readFileSync(join(summary.snapshot.path, "cycle/unknown-cycle-sentinel.txt"), "utf8"), /preserve me/);
+
+    assert.ok(existsSync(statePath));
+    assert.ok(!existsSync(join(cycleDir, "unknown-cycle-sentinel.txt")));
+    assertNoProviderTrees(target);
+  } finally {
+    cleanupDir(target);
+  }
+});

--- a/tests/auto-setup.test.mjs
+++ b/tests/auto-setup.test.mjs
@@ -297,6 +297,49 @@ test("auto-setup reconstructs registered pair files and registry after refresh",
   }
 });
 
+test("auto-setup skips registry pairs that reuse foundation slugs before reconstruction writes", () => {
+  const target = makeTempDir();
+  try {
+    installTo(target);
+    const originalPlanner = readFileSync(join(target, ".harness/loom/agents/harness-planner.md"), "utf8");
+    const originalContext = readFileSync(join(target, ".harness/loom/skills/harness-context/SKILL.md"), "utf8");
+    writeFileSync(
+      join(target, ".harness/loom/registry.md"),
+      [
+        "# Registry",
+        "",
+        "## Registered pairs",
+        "",
+        "- harness-bad: producer `harness-planner` ↔ reviewer `harness-bad-reviewer`, skill `harness-context`",
+        "",
+      ].join("\n"),
+    );
+
+    const { summary } = runAutoSetup(target);
+
+    assert.equal(summary.convergence.pairReconstructions.length, 1);
+    assert.equal(summary.convergence.pairReconstructions[0].status, "skipped");
+    assert.match(
+      summary.convergence.pairReconstructions[0].reason,
+      /producer slug is reserved for a foundation or singleton role: harness-planner/,
+    );
+    assert.equal(
+      readFileSync(join(target, ".harness/loom/agents/harness-planner.md"), "utf8"),
+      originalPlanner,
+    );
+    assert.equal(
+      readFileSync(join(target, ".harness/loom/skills/harness-context/SKILL.md"), "utf8"),
+      originalContext,
+    );
+    assert.equal(existsSync(join(target, ".harness/loom/agents/harness-bad-reviewer.md")), false);
+    const registry = readFileSync(join(target, ".harness/loom/registry.md"), "utf8");
+    assert.doesNotMatch(registry, /^- harness-bad:/m);
+    assertNoProviderTrees(target);
+  } finally {
+    cleanupDir(target);
+  }
+});
+
 test("auto-setup reconstructs customized finalizer on current skeleton", () => {
   const target = makeTempDir();
   try {

--- a/tests/auto-setup.test.mjs
+++ b/tests/auto-setup.test.mjs
@@ -340,6 +340,52 @@ test("auto-setup skips registry pairs that reuse foundation slugs before reconst
   }
 });
 
+test("auto-setup skips registry pairs with shared or colliding reconstruction artifacts", () => {
+  const target = makeTempDir();
+  try {
+    installTo(target);
+    writeFileSync(
+      join(target, ".harness/loom/registry.md"),
+      [
+        "# Registry",
+        "",
+        "## Registered pairs",
+        "",
+        "- harness-alpha: producer `harness-alpha-producer` ↔ reviewer `harness-shared-reviewer`, skill `harness-shared`",
+        "- harness-beta: producer `harness-beta-producer` ↔ reviewer `harness-shared-reviewer`, skill `harness-shared`",
+        "- harness-collision: producer `harness-collision-agent` ↔ reviewer `harness-collision-agent`, skill `harness-collision`",
+        "",
+      ].join("\n"),
+    );
+
+    const { summary } = runAutoSetup(target);
+    const byPair = Object.fromEntries(
+      summary.convergence.pairReconstructions.map((reconstruction) => [reconstruction.pair, reconstruction]),
+    );
+
+    assert.equal(summary.convergence.pairReconstructions.length, 3);
+    assert.equal(byPair["harness-alpha"].status, "skipped");
+    assert.equal(byPair["harness-beta"].status, "skipped");
+    assert.equal(byPair["harness-collision"].status, "skipped");
+    assert.match(byPair["harness-alpha"].reason, /skill slug is shared by multiple pair entries.*harness-shared/);
+    assert.match(byPair["harness-beta"].reason, /skill slug is shared by multiple pair entries.*harness-shared/);
+    assert.match(
+      byPair["harness-collision"].reason,
+      /producer and reviewer share the same agent slug: harness-collision-agent/,
+    );
+    assert.equal(existsSync(join(target, ".harness/loom/skills/harness-shared/SKILL.md")), false);
+    assert.equal(existsSync(join(target, ".harness/loom/agents/harness-shared-reviewer.md")), false);
+    assert.equal(existsSync(join(target, ".harness/loom/agents/harness-collision-agent.md")), false);
+    const registry = readFileSync(join(target, ".harness/loom/registry.md"), "utf8");
+    assert.doesNotMatch(registry, /^- harness-alpha:/m);
+    assert.doesNotMatch(registry, /^- harness-beta:/m);
+    assert.doesNotMatch(registry, /^- harness-collision:/m);
+    assertNoProviderTrees(target);
+  } finally {
+    cleanupDir(target);
+  }
+});
+
 test("auto-setup reconstructs customized finalizer on current skeleton", () => {
   const target = makeTempDir();
   try {

--- a/tests/harness-init-skill-anchors.test.mjs
+++ b/tests/harness-init-skill-anchors.test.mjs
@@ -33,3 +33,15 @@ test("harness-init skill describes canonical state in .harness/, not in platform
     assert.ok(!body.includes(token), `skill must not describe ${token} as canonical`);
   }
 });
+
+test("harness-init skill keeps request snapshots out of install ownership", () => {
+  const body = readFileSync(HARNESS_INIT_SKILL, "utf8");
+  assert.ok(
+    body.includes("Install does not create `.harness/cycle/goal.md` or `.harness/cycle/user-request-snapshot.md`"),
+    "skill must state install does not seed goal or request snapshot placeholders",
+  );
+  assert.ok(
+    body.includes("direct runtime goal entry owns cycle-local request snapshots"),
+    "skill must assign cycle-local request snapshots to runtime goal entry",
+  );
+});

--- a/tests/helpers.mjs
+++ b/tests/helpers.mjs
@@ -10,6 +10,8 @@ export const REPO_ROOT = resolve(HERE, "..");
 export const INSTALL_SCRIPT = join(REPO_ROOT, "plugins/harness-loom/skills/harness-init/scripts/install.ts");
 export const SYNC_SCRIPT = join(REPO_ROOT, "plugins/harness-loom/skills/harness-init/scripts/sync.ts");
 export const REGISTER_PAIR_SCRIPT = join(REPO_ROOT, "plugins/harness-loom/skills/harness-pair-dev/scripts/register-pair.ts");
+export const PAIR_DEV_SCRIPT = join(REPO_ROOT, "plugins/harness-loom/skills/harness-pair-dev/scripts/pair-dev.ts");
+export const AUTO_SETUP_SCRIPT = join(REPO_ROOT, "plugins/harness-loom/skills/harness-auto-setup/scripts/auto-setup.ts");
 
 export function makeTempDir(prefix = "harness-loom-") {
   return mkdtempSync(join(tmpdir(), prefix));

--- a/tests/install.test.mjs
+++ b/tests/install.test.mjs
@@ -16,6 +16,8 @@ test("install.ts scaffolds .harness/cycle/ + .harness/loom/ and skips .claude/",
     assert.equal(r.status, 0, r.stderr);
     const summary = JSON.parse(r.stdout);
     assert.equal(summary.verification.ok, true, JSON.stringify(summary.verification));
+    assert.equal(summary.goalMd, undefined);
+    assert.equal(summary.verification.checks[".harness/cycle/goal.md"], undefined);
 
     for (const p of [
       ".harness/cycle/state.md",
@@ -32,6 +34,12 @@ test("install.ts scaffolds .harness/cycle/ + .harness/loom/ and skips .claude/",
       ".harness/loom/agents/harness-finalizer.md",
     ]) {
       assert.ok(existsSync(join(target, p)), `expected ${p} to exist`);
+    }
+    for (const p of [
+      ".harness/cycle/goal.md",
+      ".harness/cycle/user-request-snapshot.md",
+    ]) {
+      assert.ok(!existsSync(join(target, p)), `install must not create ${p}`);
     }
 
     // install must not write any platform tree. Hook wiring belongs to sync.ts

--- a/tests/pair-dev.test.mjs
+++ b/tests/pair-dev.test.mjs
@@ -1,0 +1,679 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import {
+  INSTALL_SCRIPT,
+  PAIR_DEV_SCRIPT,
+  REPO_ROOT,
+  REGISTER_PAIR_SCRIPT,
+  cleanupDir,
+  makeTempDir,
+  runNode,
+} from "./helpers.mjs";
+
+function installTo(target) {
+  const result = runNode(INSTALL_SCRIPT, [target]);
+  assert.equal(result.status, 0, result.stderr);
+}
+
+function runPairDev(target, args) {
+  return runNode(PAIR_DEV_SCRIPT, args, { cwd: target });
+}
+
+function registerPair(target, { pair, producer, reviewers, skill }) {
+  const args = [
+    "--target", target,
+    "--pair", pair,
+    "--producer", producer,
+    "--skill", skill,
+  ];
+  for (const reviewer of reviewers) args.splice(args.length - 2, 0, "--reviewer", reviewer);
+  const result = runNode(REGISTER_PAIR_SCRIPT, args);
+  assert.equal(result.status, 0, result.stderr);
+}
+
+function writePairFiles(target, { producer, reviewers, skill }) {
+  const agentsDir = join(target, ".harness/loom/agents");
+  const skillDir = join(target, ".harness/loom/skills", skill);
+  mkdirSync(agentsDir, { recursive: true });
+  mkdirSync(skillDir, { recursive: true });
+  writeFileSync(
+    join(agentsDir, `${producer}.md`),
+    `---\nname: ${producer}\n---\n\n# Producer\n`,
+  );
+  for (const reviewer of reviewers) {
+    writeFileSync(
+      join(agentsDir, `${reviewer}.md`),
+      `---\nname: ${reviewer}\n---\n\n# Reviewer\n`,
+    );
+  }
+  writeFileSync(
+    join(skillDir, "SKILL.md"),
+    `---\nname: ${skill}\nuser-invocable: false\n---\n\n# ${skill}\n`,
+  );
+}
+
+function registryBody(target) {
+  return readFileSync(join(target, ".harness/loom/registry.md"), "utf8");
+}
+
+function snapshotFiles(paths) {
+  return new Map(paths.map((path) => [path, readFileSync(path, "utf8")]));
+}
+
+function assertFilesUnchanged(snapshot) {
+  for (const [path, body] of snapshot) {
+    assert.equal(readFileSync(path, "utf8"), body, `${path} should be unchanged`);
+  }
+}
+
+function snapshotTree(root) {
+  const entries = new Map();
+
+  function walk(path) {
+    if (!existsSync(path)) {
+      entries.set(path, { type: "missing" });
+      return;
+    }
+    const stat = statSync(path);
+    if (stat.isDirectory()) {
+      entries.set(path, { type: "dir" });
+      for (const name of readdirSync(path).sort()) {
+        walk(join(path, name));
+      }
+      return;
+    }
+    if (stat.isFile()) {
+      entries.set(path, { type: "file", body: readFileSync(path, "utf8") });
+      return;
+    }
+    entries.set(path, { type: "other" });
+  }
+
+  walk(root);
+  return entries;
+}
+
+function snapshotTrees(roots) {
+  return new Map(roots.map((root) => [root, snapshotTree(root)]));
+}
+
+function assertTreeSnapshotUnchanged(root, before) {
+  const after = snapshotTree(root);
+  assert.deepEqual(
+    [...after.keys()].sort(),
+    [...before.keys()].sort(),
+    `${root} file list should be unchanged`,
+  );
+  for (const [path, entry] of before) {
+    assert.deepEqual(after.get(path), entry, `${path} should be unchanged`);
+  }
+}
+
+function assertTreesUnchanged(snapshots) {
+  for (const [root, before] of snapshots) {
+    assertTreeSnapshotUnchanged(root, before);
+  }
+}
+
+function noWriteSnapshotRoots(target) {
+  return [
+    join(target, ".harness/loom"),
+    join(target, ".claude"),
+    join(target, ".codex"),
+    join(target, ".gemini"),
+  ];
+}
+
+function writeCycleHistoryFixture(target) {
+  const statePath = join(target, ".harness/cycle/state.md");
+  const eventsPath = join(target, ".harness/cycle/events.md");
+  const taskDir = join(target, ".harness/cycle/epics/EP-1--history/tasks");
+  const reviewDir = join(target, ".harness/cycle/epics/EP-1--history/reviews");
+  const laterTaskDir = join(target, ".harness/cycle/epics/EP-2--later/tasks");
+  mkdirSync(taskDir, { recursive: true });
+  mkdirSync(reviewDir, { recursive: true });
+  mkdirSync(laterTaskDir, { recursive: true });
+  writeFileSync(
+    statePath,
+    [
+      "# Runtime State",
+      "",
+      "Goal (from goals.md): preserve history",
+      "Phase: harness-other-producer",
+      "loop: false",
+      "planner-continuation: none",
+      "",
+      "## Next",
+      "To: harness-other-producer",
+      "EPIC: EP-2--later",
+      "Task path: .harness/cycle/epics/EP-2--later/tasks/T001--later.md",
+      "Intent: Continue unrelated work.",
+      "Prior tasks:",
+      "- .harness/cycle/epics/EP-1--history/tasks/T001--removed-pair.md",
+      "Prior reviews:",
+      "- .harness/cycle/epics/EP-1--history/reviews/T001--removed-pair--reviewer.md",
+      "",
+      "## EPIC summaries",
+      "",
+      "### EP-1--history",
+      "outcome: historical removed-pair evidence remains readable",
+      "upstream: none",
+      "roster: harness-other-producer",
+      "current: done",
+      "note: history complete",
+      "",
+      "### EP-2--later",
+      "outcome: unrelated work remains active",
+      "upstream: none",
+      "roster: harness-other-producer",
+      "current: harness-other-producer",
+      "note: unrelated active EPIC",
+      "",
+    ].join("\n"),
+  );
+  writeFileSync(
+    eventsPath,
+    [
+      "# Events",
+      "",
+      "- 2026-04-22T00:00:00Z task=T001 role=harness-remove-producer outcome=PASS path=.harness/cycle/epics/EP-1--history/tasks/T001--removed-pair.md",
+      "- 2026-04-22T00:01:00Z task=T001 role=harness-remove-reviewer outcome=PASS path=.harness/cycle/epics/EP-1--history/reviews/T001--removed-pair--reviewer.md",
+      "",
+    ].join("\n"),
+  );
+  writeFileSync(
+    join(taskDir, "T001--removed-pair.md"),
+    "Historical task content from harness-remove-producer must survive pair removal.\n",
+  );
+  writeFileSync(
+    join(reviewDir, "T001--removed-pair--reviewer.md"),
+    "Historical review content from harness-remove-reviewer must survive pair removal.\n",
+  );
+  writeFileSync(
+    join(laterTaskDir, ".gitkeep"),
+    "epic directory marker survives pair removal\n",
+  );
+}
+
+function extractMarkdownSection(raw, heading) {
+  const marker = `### ${heading}`;
+  const start = raw.indexOf(`${marker}\n`);
+  assert.notEqual(start, -1, `missing ${marker}`);
+  const bodyStart = start + marker.length + 1;
+  const next = raw.indexOf("\n### ", bodyStart);
+  return raw.slice(bodyStart, next === -1 ? raw.length : next);
+}
+
+test("pair-dev SKILL anchors the v0.3.0 clean-break command surface", () => {
+  const skill = readFileSync(
+    join(REPO_ROOT, "plugins/harness-loom/skills/harness-pair-dev/SKILL.md"),
+    "utf8",
+  );
+  const commandSurface = extractMarkdownSection(skill, "2. Command surface");
+
+  assert.match(
+    commandSurface,
+    /^\/harness-pair-dev --add <pair-slug> "<purpose>" \[--from <existing-pair-slug>\] \[--reviewer <slug> \.\.\.\] \[--before <pair-slug> \| --after <pair-slug>\]$/m,
+  );
+  assert.match(
+    commandSurface,
+    /^\/harness-pair-dev --improve <pair-slug> "<purpose>" \[--before <pair-slug> \| --after <pair-slug>\]$/m,
+  );
+  assert.match(commandSurface, /^\/harness-pair-dev --remove <pair-slug>$/m);
+  assert.doesNotMatch(commandSurface, /--hint|--split/);
+  assert.match(skill, /Treat legacy `--split` and `--hint` as unsupported v0\.3\.0 surface/);
+});
+
+test("pair-dev --remove unregisters a pair, deletes owned loom files, and preserves cycle history", () => {
+  const target = makeTempDir();
+  try {
+    installTo(target);
+    const pair = {
+      pair: "harness-remove",
+      producer: "harness-remove-producer",
+      reviewers: ["harness-remove-reviewer"],
+      skill: "harness-remove",
+    };
+    registerPair(target, pair);
+    writePairFiles(target, pair);
+    writeCycleHistoryFixture(target);
+    const cycleSnapshot = snapshotTree(join(target, ".harness/cycle"));
+
+    const result = runPairDev(target, ["--remove", "harness-remove"]);
+    assert.equal(result.status, 0, result.stderr);
+    const summary = JSON.parse(result.stdout);
+
+    assert.equal(summary.action, "remove");
+    assert.equal(summary.cycleHistoryPreserved, true);
+    assert.deepEqual(summary.providerTreesWritten, []);
+    assert.equal(summary.syncCommand, "node .harness/loom/sync.ts --provider <list>");
+    assert.doesNotMatch(registryBody(target), /^- harness-remove:/m);
+    assert.equal(existsSync(join(target, ".harness/loom/agents/harness-remove-producer.md")), false);
+    assert.equal(existsSync(join(target, ".harness/loom/agents/harness-remove-reviewer.md")), false);
+    assert.equal(existsSync(join(target, ".harness/loom/skills/harness-remove")), false);
+    assertTreeSnapshotUnchanged(join(target, ".harness/cycle"), cycleSnapshot);
+  } finally {
+    cleanupDir(target);
+  }
+});
+
+test("pair-dev --remove validates malformed registry slugs before unregistering or deleting files", () => {
+  const cases = [
+    {
+      label: "producer path",
+      line:
+        "- harness-malformed: producer `harness-malformed/producer` ↔ reviewer `harness-malformed-reviewer`, skill `harness-malformed`",
+      error: /registered producer slug is invalid: harness-malformed\/producer/,
+    },
+    {
+      label: "reviewer path",
+      line:
+        "- harness-malformed: producer `harness-malformed-producer` ↔ reviewers [`harness-malformed-reviewer`, `harness-malformed/reviewer`], skill `harness-malformed`",
+      error: /registered reviewer slug is invalid: harness-malformed\/reviewer/,
+    },
+    {
+      label: "skill path",
+      line:
+        "- harness-malformed: producer `harness-malformed-producer` ↔ reviewer `harness-malformed-reviewer`, skill `harness-malformed/skill`",
+      error: /registered skill slug is invalid: harness-malformed\/skill/,
+    },
+  ];
+
+  for (const { label, line, error } of cases) {
+    const target = makeTempDir();
+    try {
+      installTo(target);
+      const pair = {
+        pair: "harness-malformed",
+        producer: "harness-malformed-producer",
+        reviewers: ["harness-malformed-reviewer"],
+        skill: "harness-malformed",
+      };
+      registerPair(target, pair);
+      writePairFiles(target, pair);
+
+      const registryPath = join(target, ".harness/loom/registry.md");
+      const validRegistry = readFileSync(registryPath, "utf8");
+      const malformedRegistry = validRegistry.replace(/^- harness-malformed:.*$/m, line);
+      assert.notEqual(malformedRegistry, validRegistry, `${label} should rewrite the registry fixture`);
+      writeFileSync(registryPath, malformedRegistry);
+
+      const beforeRegistry = readFileSync(registryPath, "utf8");
+      const fileSnapshot = snapshotFiles([
+        join(target, ".harness/loom/agents/harness-malformed-producer.md"),
+        join(target, ".harness/loom/agents/harness-malformed-reviewer.md"),
+        join(target, ".harness/loom/skills/harness-malformed/SKILL.md"),
+      ]);
+
+      const result = runPairDev(target, ["--remove", "harness-malformed"]);
+      assert.notEqual(result.status, 0, `${label} should fail`);
+      assert.match(result.stderr, error);
+      assert.equal(readFileSync(registryPath, "utf8"), beforeRegistry, `${label} registry changed`);
+      assert.match(registryBody(target), /^- harness-malformed:/m);
+      assertFilesUnchanged(fileSnapshot);
+    } finally {
+      cleanupDir(target);
+    }
+  }
+});
+
+test("pair-dev --remove refuses active-cycle references before mutating loom files", () => {
+  const target = makeTempDir();
+  try {
+    installTo(target);
+    const pair = {
+      pair: "harness-active",
+      producer: "harness-active-producer",
+      reviewers: ["harness-active-reviewer"],
+      skill: "harness-active",
+    };
+    registerPair(target, pair);
+    writePairFiles(target, pair);
+    const statePath = join(target, ".harness/cycle/state.md");
+    const activeState = [
+      "# Runtime State",
+      "",
+      "Goal (from goals.md): demo",
+      "Phase: harness-active-producer",
+      "loop: false",
+      "planner-continuation: none",
+      "",
+      "## Next",
+      "To: harness-active-producer",
+      "EPIC: EP-1--active",
+      "Task path: .harness/cycle/epics/EP-1--active/tasks/T001--active.md",
+      "Intent: Continue the active pair.",
+      "Prior tasks:",
+      "Prior reviews:",
+      "",
+      "## EPIC summaries",
+      "",
+      "### EP-1--active",
+      "outcome: active work completes",
+      "upstream: none",
+      "roster: harness-active-producer",
+      "current: harness-active-producer",
+      "note: active",
+      "",
+    ].join("\n");
+    writeFileSync(statePath, activeState);
+    const beforeRegistry = registryBody(target);
+    const fileSnapshot = snapshotFiles([
+      join(target, ".harness/loom/agents/harness-active-producer.md"),
+      join(target, ".harness/loom/agents/harness-active-reviewer.md"),
+      join(target, ".harness/loom/skills/harness-active/SKILL.md"),
+    ]);
+
+    const result = runPairDev(target, ["--remove", "harness-active"]);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /refusing to remove harness-active/);
+    assert.match(result.stderr, /active-cycle ## Next references/);
+    assert.equal(registryBody(target), beforeRegistry);
+    assertFilesUnchanged(fileSnapshot);
+    assert.equal(readFileSync(statePath, "utf8"), activeState);
+  } finally {
+    cleanupDir(target);
+  }
+});
+
+test("pair-dev --remove refuses live EPIC roster references when Next is clear", () => {
+  const target = makeTempDir();
+  try {
+    installTo(target);
+    const pair = {
+      pair: "harness-live",
+      producer: "harness-live-producer",
+      reviewers: ["harness-live-reviewer"],
+      skill: "harness-live",
+    };
+    registerPair(target, pair);
+    writePairFiles(target, pair);
+    const statePath = join(target, ".harness/cycle/state.md");
+    const activeState = [
+      "# Runtime State",
+      "",
+      "Goal (from goals.md): demo",
+      "Phase: harness-other-producer",
+      "loop: false",
+      "planner-continuation: none",
+      "",
+      "## Next",
+      "To: harness-other-producer",
+      "EPIC: EP-1--active",
+      "Task path: .harness/cycle/epics/EP-1--active/tasks/T001--active.md",
+      "Intent: Continue another pair.",
+      "Prior tasks:",
+      "Prior reviews:",
+      "",
+      "## EPIC summaries",
+      "",
+      "### EP-1--active",
+      "outcome: active work completes",
+      "upstream: none",
+      "roster: harness-live-producer",
+      "current: harness-other-producer",
+      "note: active",
+      "",
+    ].join("\n");
+    writeFileSync(statePath, activeState);
+    const beforeRegistry = registryBody(target);
+    const fileSnapshot = snapshotFiles([
+      join(target, ".harness/loom/agents/harness-live-producer.md"),
+      join(target, ".harness/loom/agents/harness-live-reviewer.md"),
+      join(target, ".harness/loom/skills/harness-live/SKILL.md"),
+    ]);
+
+    const result = runPairDev(target, ["--remove", "harness-live"]);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /live EPIC EP-1--active references/);
+    assert.equal(registryBody(target), beforeRegistry);
+    assertFilesUnchanged(fileSnapshot);
+    assert.equal(readFileSync(statePath, "utf8"), activeState);
+  } finally {
+    cleanupDir(target);
+  }
+});
+
+test("pair-dev --remove refuses live EPIC current-only references when Next and roster are clear", () => {
+  const target = makeTempDir();
+  try {
+    installTo(target);
+    const pair = {
+      pair: "harness-current",
+      producer: "harness-current-producer",
+      reviewers: ["harness-current-reviewer"],
+      skill: "harness-current",
+    };
+    registerPair(target, pair);
+    writePairFiles(target, pair);
+    const statePath = join(target, ".harness/cycle/state.md");
+    const activeState = [
+      "# Runtime State",
+      "",
+      "Goal (from goals.md): demo",
+      "Phase: harness-other-producer",
+      "loop: false",
+      "planner-continuation: none",
+      "",
+      "## Next",
+      "To: harness-other-producer",
+      "EPIC: EP-1--active",
+      "Task path: .harness/cycle/epics/EP-1--active/tasks/T001--active.md",
+      "Intent: Continue another pair.",
+      "Prior tasks:",
+      "Prior reviews:",
+      "",
+      "## EPIC summaries",
+      "",
+      "### EP-1--active",
+      "outcome: active work completes",
+      "upstream: none",
+      "roster: harness-other-producer",
+      "current: harness-current-producer",
+      "note: active",
+      "",
+    ].join("\n");
+    writeFileSync(statePath, activeState);
+    const beforeRegistry = registryBody(target);
+    const loomSnapshot = snapshotTree(join(target, ".harness/loom"));
+    const cycleSnapshot = snapshotTree(join(target, ".harness/cycle"));
+
+    const result = runPairDev(target, ["--remove", "harness-current"]);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /live EPIC EP-1--active references/);
+    assert.match(result.stderr, /harness-current-producer/);
+    assert.equal(registryBody(target), beforeRegistry);
+    assertTreeSnapshotUnchanged(join(target, ".harness/loom"), loomSnapshot);
+    assertTreeSnapshotUnchanged(join(target, ".harness/cycle"), cycleSnapshot);
+    assert.equal(readFileSync(statePath, "utf8"), activeState);
+  } finally {
+    cleanupDir(target);
+  }
+});
+
+test("pair-dev --remove preserves shared agent and skill paths referenced by remaining registry entries", () => {
+  const target = makeTempDir();
+  try {
+    installTo(target);
+    const alpha = {
+      pair: "harness-alpha",
+      producer: "harness-alpha-producer",
+      reviewers: ["harness-shared-reviewer"],
+      skill: "harness-shared",
+    };
+    const beta = {
+      pair: "harness-beta",
+      producer: "harness-beta-producer",
+      reviewers: ["harness-shared-reviewer"],
+      skill: "harness-shared",
+    };
+    registerPair(target, alpha);
+    registerPair(target, beta);
+    writePairFiles(target, alpha);
+    writeFileSync(
+      join(target, ".harness/loom/agents/harness-beta-producer.md"),
+      "---\nname: harness-beta-producer\n---\n\n# Producer\n",
+    );
+
+    const result = runPairDev(target, ["--remove", "harness-alpha"]);
+    assert.equal(result.status, 0, result.stderr);
+    const summary = JSON.parse(result.stdout);
+
+    assert.doesNotMatch(registryBody(target), /^- harness-alpha:/m);
+    assert.match(registryBody(target), /^- harness-beta:/m);
+    assert.equal(existsSync(join(target, ".harness/loom/agents/harness-alpha-producer.md")), false);
+    assert.equal(existsSync(join(target, ".harness/loom/agents/harness-shared-reviewer.md")), true);
+    assert.equal(existsSync(join(target, ".harness/loom/skills/harness-shared/SKILL.md")), true);
+    assert.ok(
+      summary.preservedShared.some((path) => path.endsWith("agents/harness-shared-reviewer.md")),
+    );
+    assert.ok(summary.preservedShared.some((path) => path.endsWith("skills/harness-shared")));
+  } finally {
+    cleanupDir(target);
+  }
+});
+
+test("pair-dev --add --from accepts only currently registered pair slugs as overlay sources", () => {
+  const target = makeTempDir();
+  try {
+    installTo(target);
+    registerPair(target, {
+      pair: "harness-source",
+      producer: "harness-source-producer",
+      reviewers: ["harness-source-reviewer"],
+      skill: "harness-source",
+    });
+    mkdirSync(join(target, ".codex/agents"), { recursive: true });
+    writeFileSync(
+      join(target, ".codex/agents/user-owned.md"),
+      "provider tree content must not be touched by pair-dev preparation\n",
+    );
+
+    const acceptedSnapshot = snapshotTrees(noWriteSnapshotRoots(target));
+    const accepted = runPairDev(target, [
+      "--add", "harness-target", "Use the source pair as an overlay source.",
+      "--from", "harness-source",
+    ]);
+    assert.equal(accepted.status, 0, accepted.stderr);
+    const summary = JSON.parse(accepted.stdout);
+    assert.equal(summary.action, "prepare-add");
+    assert.equal(summary.authored, false);
+    assert.equal(summary.from.pair, "harness-source");
+    assert.deepEqual(summary.writes, []);
+    assert.deepEqual(summary.providerTreesWritten, []);
+    assert.doesNotMatch(registryBody(target), /^- harness-target:/m);
+    assertTreesUnchanged(acceptedSnapshot);
+
+    const rejected = [
+      [".harness/_archive/snapshots/demo", /not a file, snapshot, or platform path/],
+      [".codex/agents/harness-source.md", /not a file, snapshot, or platform path/],
+      ["harness-planner", /foundation or singleton/],
+      ["harness-finalizer", /foundation or singleton/],
+      ["harness-orchestrate", /foundation or singleton/],
+      ["harness-missing", /not registered/],
+    ];
+    for (const [from, pattern] of rejected) {
+      const rejectedSnapshot = snapshotTrees(noWriteSnapshotRoots(target));
+      const result = runPairDev(target, [
+        "--add", "harness-target", "Use evidence.",
+        "--from", from,
+      ]);
+      assert.notEqual(result.status, 0, `${from} should be rejected`);
+      assert.match(result.stderr, pattern);
+      assertTreesUnchanged(rejectedSnapshot);
+    }
+  } finally {
+    cleanupDir(target);
+  }
+});
+
+test("pair-dev --add requires positional purpose", () => {
+  const target = makeTempDir();
+  try {
+    installTo(target);
+    const before = snapshotTrees(noWriteSnapshotRoots(target));
+
+    const result = runPairDev(target, ["--add", "harness-missing-purpose"]);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /--add requires positional "<purpose>"/);
+    assertTreesUnchanged(before);
+  } finally {
+    cleanupDir(target);
+  }
+});
+
+test("pair-dev --improve requires positional purpose", () => {
+  const target = makeTempDir();
+  try {
+    installTo(target);
+    registerPair(target, {
+      pair: "harness-existing",
+      producer: "harness-existing-producer",
+      reviewers: ["harness-existing-reviewer"],
+      skill: "harness-existing",
+    });
+
+    const result = runPairDev(target, ["--improve", "harness-existing"]);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /--improve requires positional "<purpose>"/);
+  } finally {
+    cleanupDir(target);
+  }
+});
+
+test("pair-dev --improve returns positional purpose in a no-write preparation summary", () => {
+  const target = makeTempDir();
+  try {
+    installTo(target);
+    registerPair(target, {
+      pair: "harness-existing",
+      producer: "harness-existing-producer",
+      reviewers: ["harness-existing-reviewer"],
+      skill: "harness-existing",
+    });
+    const beforeRegistry = registryBody(target);
+    const purpose = "Tighten review around source-backed removal safety.";
+
+    const result = runPairDev(target, ["--improve", "harness-existing", purpose]);
+    assert.equal(result.status, 0, result.stderr);
+    const summary = JSON.parse(result.stdout);
+
+    assert.equal(summary.action, "prepare-improve");
+    assert.equal(summary.authored, false);
+    assert.equal(summary.purpose, purpose);
+    assert.equal(summary.existing.pair, "harness-existing");
+    assert.deepEqual(summary.writes, []);
+    assert.deepEqual(summary.providerTreesWritten, []);
+    assert.equal(summary.syncCommand, "node .harness/loom/sync.ts --provider <list>");
+    assert.equal(registryBody(target), beforeRegistry);
+  } finally {
+    cleanupDir(target);
+  }
+});
+
+test("pair-dev rejects legacy --split and --hint", () => {
+  const target = makeTempDir();
+  try {
+    const split = runPairDev(target, ["--split", "harness-demo"]);
+    assert.notEqual(split.status, 0);
+    assert.match(split.stderr, /--split is unsupported/);
+
+    const hint = runPairDev(target, [
+      "--improve", "harness-demo", "Revise the pair.",
+      "--hint", "old syntax",
+    ]);
+    assert.notEqual(hint.status, 0);
+    assert.match(hint.stderr, /--hint is unsupported/);
+  } finally {
+    cleanupDir(target);
+  }
+});

--- a/tests/pair-dev.test.mjs
+++ b/tests/pair-dev.test.mjs
@@ -542,7 +542,53 @@ test("pair-dev --remove preserves shared agent and skill paths referenced by rem
   }
 });
 
-test("pair-dev --add --from accepts only currently registered pair slugs as overlay sources", () => {
+test("pair-dev --remove does not treat a colliding pair identifier as shared-file evidence", () => {
+  const target = makeTempDir();
+  try {
+    installTo(target);
+    const victim = {
+      pair: "harness-foo",
+      producer: "harness-foo-producer",
+      reviewers: ["harness-foo-reviewer"],
+      skill: "harness-foo",
+    };
+    const collider = {
+      pair: "harness-foo-producer",
+      producer: "harness-bar-producer",
+      reviewers: ["harness-bar-reviewer"],
+      skill: "harness-bar",
+    };
+    registerPair(target, victim);
+    registerPair(target, collider);
+    writePairFiles(target, victim);
+    writePairFiles(target, collider);
+
+    const result = runPairDev(target, ["--remove", "harness-foo"]);
+    assert.equal(result.status, 0, result.stderr);
+    const summary = JSON.parse(result.stdout);
+
+    assert.doesNotMatch(registryBody(target), /^- harness-foo:/m);
+    assert.match(registryBody(target), /^- harness-foo-producer:/m);
+
+    assert.equal(
+      existsSync(join(target, ".harness/loom/agents/harness-foo-producer.md")),
+      false,
+      "victim producer file must be deleted even when a remaining pair's identifier collides with its slug",
+    );
+    assert.equal(existsSync(join(target, ".harness/loom/agents/harness-foo-reviewer.md")), false);
+    assert.equal(existsSync(join(target, ".harness/loom/skills/harness-foo")), false);
+
+    assert.equal(existsSync(join(target, ".harness/loom/agents/harness-bar-producer.md")), true);
+    assert.equal(existsSync(join(target, ".harness/loom/agents/harness-bar-reviewer.md")), true);
+    assert.equal(existsSync(join(target, ".harness/loom/skills/harness-bar/SKILL.md")), true);
+
+    assert.deepEqual(summary.preservedShared, []);
+  } finally {
+    cleanupDir(target);
+  }
+});
+
+test("pair-dev --add --from accepts only currently registered pair slugs as evidence", () => {
   const target = makeTempDir();
   try {
     installTo(target);

--- a/tests/pair-dev.test.mjs
+++ b/tests/pair-dev.test.mjs
@@ -158,9 +158,9 @@ function writeCycleHistoryFixture(target) {
       "Task path: .harness/cycle/epics/EP-2--later/tasks/T001--later.md",
       "Intent: Continue unrelated work.",
       "Prior tasks:",
-      "- .harness/cycle/epics/EP-1--history/tasks/T001--removed-pair.md",
+      "- .harness/cycle/epics/EP-1--history/tasks/T001--harness-remove-producer.md",
       "Prior reviews:",
-      "- .harness/cycle/epics/EP-1--history/reviews/T001--removed-pair--reviewer.md",
+      "- .harness/cycle/epics/EP-1--history/reviews/T001--harness-remove-reviewer.md",
       "",
       "## EPIC summaries",
       "",
@@ -185,17 +185,17 @@ function writeCycleHistoryFixture(target) {
     [
       "# Events",
       "",
-      "- 2026-04-22T00:00:00Z task=T001 role=harness-remove-producer outcome=PASS path=.harness/cycle/epics/EP-1--history/tasks/T001--removed-pair.md",
-      "- 2026-04-22T00:01:00Z task=T001 role=harness-remove-reviewer outcome=PASS path=.harness/cycle/epics/EP-1--history/reviews/T001--removed-pair--reviewer.md",
+      "- 2026-04-22T00:00:00Z task=T001 role=harness-remove-producer outcome=PASS path=.harness/cycle/epics/EP-1--history/tasks/T001--harness-remove-producer.md",
+      "- 2026-04-22T00:01:00Z task=T001 role=harness-remove-reviewer outcome=PASS path=.harness/cycle/epics/EP-1--history/reviews/T001--harness-remove-reviewer.md",
       "",
     ].join("\n"),
   );
   writeFileSync(
-    join(taskDir, "T001--removed-pair.md"),
+    join(taskDir, "T001--harness-remove-producer.md"),
     "Historical task content from harness-remove-producer must survive pair removal.\n",
   );
   writeFileSync(
-    join(reviewDir, "T001--removed-pair--reviewer.md"),
+    join(reviewDir, "T001--harness-remove-reviewer.md"),
     "Historical review content from harness-remove-reviewer must survive pair removal.\n",
   );
   writeFileSync(
@@ -376,7 +376,7 @@ test("pair-dev --remove refuses active-cycle references before mutating loom fil
     const result = runPairDev(target, ["--remove", "harness-active"]);
     assert.notEqual(result.status, 0);
     assert.match(result.stderr, /refusing to remove harness-active/);
-    assert.match(result.stderr, /active-cycle ## Next references/);
+    assert.match(result.stderr, /active-cycle ## Next To references/);
     assert.equal(registryBody(target), beforeRegistry);
     assertFilesUnchanged(fileSnapshot);
     assert.equal(readFileSync(statePath, "utf8"), activeState);

--- a/tests/register-pair.test.mjs
+++ b/tests/register-pair.test.mjs
@@ -16,20 +16,23 @@ function installTo(target) {
 }
 
 test("README claim about prefix handling matches register-pair contract", () => {
-  // README must NOT promise auto-prepending of unprefixed slugs — register-pair
-  // strictly rejects unprefixed slugs (see prefixRe in register-pair.ts and
-  // the dedicated rejection test below).
+  // README may describe assistant-level bare-name normalization, but persisted
+  // files and registry entries must still be canonical harness-* slugs.
   const readme = readFileSync(join(REPO_ROOT, "README.md"), "utf8");
   assert.doesNotMatch(
     readme,
-    /unprefixed slugs are auto-prepended/i,
-    "README must not promise auto-prepend; register-pair.ts rejects unprefixed slugs",
+    /register-pair\.ts auto-prepends|helper auto-prepends/i,
+    "README must not promise helper-level auto-prepend; register-pair.ts rejects unprefixed slugs",
   );
-  // Quickstart should surface the actual rule so users do not feed bare slugs.
   assert.match(
     readme,
-    /must start with the `harness-` prefix|register-pair\.ts rejects unprefixed/i,
-    "README must surface the actual register-pair prefix requirement",
+    /Canonical pair slugs use the `harness-` prefix/,
+    "README must surface the canonical slug prefix requirement",
+  );
+  assert.match(
+    readme,
+    /generated files and registry entries are always written as `harness-document`/,
+    "README must say bare user-facing names normalize before persistence",
   );
 });
 

--- a/tests/role-output-surface-anchors.test.mjs
+++ b/tests/role-output-surface-anchors.test.mjs
@@ -1,0 +1,196 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { REPO_ROOT } from "./helpers.mjs";
+
+const PRODUCER_TEMPLATE = join(
+  REPO_ROOT,
+  "plugins/harness-loom/skills/harness-pair-dev/templates/producer-agent.md",
+);
+const REVIEWER_TEMPLATE = join(
+  REPO_ROOT,
+  "plugins/harness-loom/skills/harness-pair-dev/templates/reviewer-agent.md",
+);
+const EXAMPLE_AGENT_DIR = join(
+  REPO_ROOT,
+  "plugins/harness-loom/skills/harness-pair-dev/examples/agents",
+);
+const AGENT_AUTHORING = join(
+  REPO_ROOT,
+  "plugins/harness-loom/skills/harness-pair-dev/references/authoring/agent-authoring.md",
+);
+const ORCHESTRATE_TEMPLATE = join(
+  REPO_ROOT,
+  "plugins/harness-loom/skills/harness-init/references/runtime/harness-orchestrate/SKILL.template.md",
+);
+const CONTEXT_TEMPLATE = join(
+  REPO_ROOT,
+  "plugins/harness-loom/skills/harness-init/references/runtime/harness-context/SKILL.template.md",
+);
+const PLANNING_TEMPLATE = join(
+  REPO_ROOT,
+  "plugins/harness-loom/skills/harness-init/references/runtime/harness-planning/SKILL.template.md",
+);
+const PLANNER_TEMPLATE = join(
+  REPO_ROOT,
+  "plugins/harness-loom/skills/harness-init/references/runtime/harness-planner.template.md",
+);
+const FINALIZER_TEMPLATE = join(
+  REPO_ROOT,
+  "plugins/harness-loom/skills/harness-init/references/runtime/harness-finalizer.template.md",
+);
+
+const PRODUCER_BLOCK = [
+  "Status: PASS / FAIL",
+  "Summary: {what was produced in one line}",
+  "Files created: [{file path}]",
+  "Files modified: [{file path}]",
+  'Diff summary: {sections changed vs baseline, or "N/A"}',
+  "Self-verification: {issues found and resolved during this cycle}",
+  "Remaining items: [{items not yet done}]",
+].join("\n");
+
+const REVIEWER_BLOCK = [
+  "Verdict: PASS / FAIL",
+  "Criteria: [{criterion, result, evidence-citation (file:line)}]",
+  "FAIL items: [{item, level (technical/creative/structural), reason}]",
+  "Feedback: {short free-form rationale}",
+].join("\n");
+
+const LEGACY_FIELD_LINE = /^(Suggested next-work|Advisory-next|Regression gate|Escalation):/m;
+const LEGACY_FIELD_NAME = /\b(Suggested next-work|Advisory-next|Regression gate|Escalation)\b/;
+
+function read(path) {
+  return readFileSync(path, "utf8");
+}
+
+function codeBlockAfter(body, marker) {
+  const markerIndex = body.indexOf(marker);
+  assert.notEqual(markerIndex, -1, `missing marker ${marker}`);
+  const fenceStart = body.indexOf("```", markerIndex);
+  assert.notEqual(fenceStart, -1, `missing code fence after ${marker}`);
+  const blockStart = body.indexOf("\n", fenceStart);
+  assert.notEqual(blockStart, -1, `missing code fence newline after ${marker}`);
+  const fenceEnd = body.indexOf("\n```", blockStart + 1);
+  assert.notEqual(fenceEnd, -1, `missing code fence end after ${marker}`);
+  return body.slice(blockStart + 1, fenceEnd).trim();
+}
+
+function sectionBetween(body, start, end) {
+  const startIndex = body.indexOf(start);
+  assert.notEqual(startIndex, -1, `missing section ${start}`);
+  const endIndex = body.indexOf(end, startIndex + start.length);
+  assert.notEqual(endIndex, -1, `missing section end ${end}`);
+  return body.slice(startIndex, endIndex);
+}
+
+function assertNoLegacyFieldLines(body, label) {
+  assert.doesNotMatch(
+    body,
+    LEGACY_FIELD_LINE,
+    `${label} must not expose legacy advisory/escalation output fields`,
+  );
+}
+
+function exampleAgentPaths() {
+  return readdirSync(EXAMPLE_AGENT_DIR)
+    .filter((entry) => entry.endsWith(".md"))
+    .sort()
+    .map((entry) => join(EXAMPLE_AGENT_DIR, entry));
+}
+
+test("pair-dev source templates expose reduced pair output fields only", () => {
+  const producer = read(PRODUCER_TEMPLATE);
+  const reviewer = read(REVIEWER_TEMPLATE);
+  const producerBlock = codeBlockAfter(producer, "## Output Format");
+  const reviewerBlock = codeBlockAfter(reviewer, "## Output Format");
+
+  assert.equal(producerBlock, PRODUCER_BLOCK);
+  assert.equal(reviewerBlock, REVIEWER_BLOCK);
+  assertNoLegacyFieldLines(producer, "producer template");
+  assertNoLegacyFieldLines(reviewer, "reviewer template");
+  assert.doesNotMatch(producerBlock, /^Verdict:|^Criteria:|^FAIL items:|^Feedback:/m);
+  assert.doesNotMatch(reviewerBlock, /^Status:|^Files created:|^Files modified:|^Diff summary:|^Self-verification:/m);
+});
+
+test("pair-dev completed example agents expose reduced role output fields only", () => {
+  const paths = exampleAgentPaths();
+  assert.ok(paths.length > 0, "expected completed pair-dev example agents");
+
+  for (const path of paths) {
+    const body = read(path);
+    const label = path.slice(REPO_ROOT.length + 1);
+    const outputBlock = codeBlockAfter(body, "## Output Format");
+
+    if (outputBlock.startsWith("Status:")) {
+      assert.equal(outputBlock, PRODUCER_BLOCK, `${label} producer block must match reduced shape`);
+    } else if (outputBlock.startsWith("Verdict:")) {
+      assert.equal(outputBlock, REVIEWER_BLOCK, `${label} reviewer block must match reduced shape`);
+    } else {
+      assert.fail(`${label} has an unrecognized Output Format block`);
+    }
+
+    assertNoLegacyFieldLines(outputBlock, `${label} output block`);
+    assert.doesNotMatch(body, LEGACY_FIELD_NAME, `${label} must not advertise legacy advisory fields`);
+  }
+});
+
+test("agent authoring guidance pins reduced pair surfaces and role exceptions", () => {
+  const body = read(AGENT_AUTHORING);
+  const rules = sectionBetween(body, "## Output Format Rules", "## Anti-patterns");
+
+  assert.equal(codeBlockAfter(rules, "**Producer variant**"), PRODUCER_BLOCK);
+  assert.equal(codeBlockAfter(rules, "**Reviewer variant**"), REVIEWER_BLOCK);
+  assert.match(rules, /A pair producer's `Status` is self-report only/);
+  assert.match(rules, /The paired reviewer `Verdict` is the Pair turn's load-bearing verdict source/);
+  assert.match(rules, /Planner agents do not emit `Status` or `Escalation`/);
+  assert.match(rules, /`next-action` field on a meta-role is load-bearing/);
+  assert.match(rules, /Its own `Status: PASS \| FAIL` plus `Self-verification` block is the verdict/);
+  assert.match(rules, /must not emit Reviewer-shape fields/);
+  assertNoLegacyFieldLines(rules, "agent authoring output rules");
+});
+
+test("planner and finalizer templates preserve load-bearing fields and omit legacy field lines", () => {
+  const planner = read(PLANNER_TEMPLATE);
+  const planning = read(PLANNING_TEMPLATE);
+  const finalizer = read(FINALIZER_TEMPLATE);
+  const plannerBlock = codeBlockAfter(planner, "## Output Format");
+  const finalizerBlock = codeBlockAfter(finalizer, "## Output Format");
+
+  assert.match(plannerBlock, /^EPICs \(this turn\):/m);
+  assert.match(plannerBlock, /^Remaining:/m);
+  assert.match(plannerBlock, /^next-action: <"done" \| "continue/m);
+  assert.match(plannerBlock, /^Additional pairs required:/m);
+  assert.doesNotMatch(plannerBlock, /^Status:|^Summary:|^Escalation:/m);
+  assert.match(planner, /`next-action` is load-bearing/);
+  assert.match(planning, /Planner output contains no task file paths, no `Status`, no `Escalation`/);
+
+  assert.match(finalizerBlock, /^Status: PASS \/ FAIL$/m);
+  assert.match(finalizerBlock, /^Self-verification:/m);
+  assert.match(finalizerBlock, /^Remaining items:/m);
+  assert.doesNotMatch(finalizerBlock, /^Verdict:|^Criteria:|^FAIL items:|^Escalation:/m);
+  assert.match(finalizer, /Optional line: inside the fenced block, include `Files left alone \(intentionally\)/);
+
+  for (const [label, contract] of [
+    ["planner template", planner],
+    ["planning template", planning],
+    ["finalizer template", finalizer],
+  ]) {
+    assertNoLegacyFieldLines(contract, label);
+  }
+});
+
+test("runtime contracts reject advisory routing fields and keep Structural Issue as the escalation surface", () => {
+  const orchestrate = read(ORCHESTRATE_TEMPLATE);
+  const context = read(CONTEXT_TEMPLATE);
+
+  assert.match(orchestrate, /Advisory or escalation routing fields are not part of the runtime output contract/);
+  assert.match(orchestrate, /synthesizes the real `Next` from reviewer verdicts, planner `next-action`, finalizer `Status`, and `## Structural Issue`/);
+  assert.match(orchestrate, /`## Structural Issue` is the only structural escalation surface/);
+  assert.match(context, /Add advisory or escalation routing fields/);
+  assert.match(context, /use `Remaining items`, `Feedback`, or `## Structural Issue` according to role/);
+
+  assertNoLegacyFieldLines(orchestrate, "orchestrate template");
+  assertNoLegacyFieldLines(context, "context template");
+});

--- a/tests/runtime-template-anchors.test.mjs
+++ b/tests/runtime-template-anchors.test.mjs
@@ -7,7 +7,8 @@ import { REPO_ROOT } from "./helpers.mjs";
 // Runtime template anchors. These tests pin the load-bearing tokens the
 // `harness-orchestrate/SKILL.template.md` body exposes to runtime readers, so a
 // future refactor cannot silently drop the Pair/Finalizer separation, the
-// defer-to-end continuation flag, or the zero-emit safety.
+// role-specific dispatch envelope, the defer-to-end continuation flag, or the
+// zero-emit safety.
 
 const ORCHESTRATE_TEMPLATE = join(
   REPO_ROOT,
@@ -37,6 +38,22 @@ const STATE_SCHEMA = join(
   REPO_ROOT,
   "plugins/harness-loom/skills/harness-init/references/runtime/harness-orchestrate/references/state-md-schema.md",
 );
+const DISPATCH_ENVELOPE = join(
+  REPO_ROOT,
+  "plugins/harness-loom/skills/harness-init/references/runtime/harness-orchestrate/references/dispatch-envelope.md",
+);
+const STATE_MACHINE = join(
+  REPO_ROOT,
+  "plugins/harness-loom/skills/harness-init/references/runtime/harness-orchestrate/references/state-machine.md",
+);
+
+function sectionBetween(body, start, end) {
+  const startIndex = body.indexOf(start);
+  assert.notEqual(startIndex, -1, `expected section start ${start}`);
+  const endIndex = body.indexOf(end, startIndex + start.length);
+  assert.notEqual(endIndex, -1, `expected section end ${end}`);
+  return body.slice(startIndex, endIndex);
+}
 
 test("orchestrate template exists at the canonical factory path", () => {
   assert.ok(
@@ -61,7 +78,7 @@ test("orchestrate template declares the three runtime turn kinds", () => {
   );
 });
 
-test("orchestrate template documents the ↔ arrow as the mandatory Pair roster token", () => {
+test("orchestrate template documents the ↔ segment as the mandatory Pair roster binding", () => {
   const body = readFileSync(ORCHESTRATE_TEMPLATE, "utf8");
   assert.ok(
     body.includes("↔"),
@@ -74,8 +91,29 @@ test("orchestrate template documents the ↔ arrow as the mandatory Pair roster 
   );
   assert.match(
     body,
-    /`↔`\s*arrow\s*is\s*load-bearing/i,
-    "orchestrate must flag the ↔ arrow as load-bearing so parsers cannot treat it as decoration",
+    /`↔` segment binds a producer to its reviewer set/,
+    "orchestrate must define the ↔ segment as the producer/reviewer binding",
+  );
+  assert.match(
+    body,
+    /line position is the producer's global stage index/,
+    "orchestrate must preserve the roster line-position global stage anchor",
+  );
+});
+
+test("runtime DFA reference keeps the four-state transition contract", () => {
+  const body = readFileSync(STATE_MACHINE, "utf8");
+  for (const state of ["Planner", "Pair", "Finalizer", "Halt"]) {
+    assert.ok(body.includes(`\`${state}\``), `DFA must name ${state}`);
+  }
+  assert.match(body, /Planner\s+-> Pair\s+\(ready set non-empty\)/);
+  assert.match(body, /Pair\s+-> Planner\s+\(planner recall\)/);
+  assert.match(body, /Finalizer -> Halt\s+\(PASS\)/);
+  assert.match(body, /Finalizer -> Planner\s+\(FAIL \/ RETREAT\)/);
+  assert.match(
+    body,
+    /all live EPICs terminal \+ `planner-continuation: none`/,
+    "DFA must keep the terminal finalizer gate tied to planner-continuation: none",
   );
 });
 
@@ -180,10 +218,35 @@ test("state-md-schema marks planner-continuation as planner-owned", () => {
   );
 });
 
-test("orchestrate template exposes Phase advance — Pair rules and Phase advance — Finalizer rules", () => {
+test("orchestrate template keeps one-turn persistence and verdict anchors", () => {
   const body = readFileSync(ORCHESTRATE_TEMPLATE, "utf8");
-  assert.match(body, /Phase advance — Pair rules/);
-  assert.match(body, /Phase advance — Finalizer rules/);
+  assert.match(
+    body,
+    /Turn rhythm \(one response = consume `Next`, produce the next `Next`\)/,
+    "orchestrate must keep one response scoped to one runtime turn",
+  );
+  assert.match(body, /Persist artifacts by turn kind/);
+  assert.match(body, /Extract the verdict/);
+  assert.match(
+    body,
+    /Raise `loop: true` only if a valid next dispatch exists/,
+    "orchestrate must not re-enter without a committed valid Next",
+  );
+  assert.match(
+    body,
+    /Subagents run with `fork_context=false`/,
+    "orchestrate must keep subagent evidence isolated from producer transcript/tool trace",
+  );
+});
+
+test("orchestrate template exposes Pair and Finalizer verdict branches", () => {
+  const body = readFileSync(ORCHESTRATE_TEMPLATE, "utf8");
+  assert.match(body, /#### Pair verdict branch/);
+  assert.match(body, /The verdict source is the aggregated reviewer set/);
+  assert.match(body, /Rework \(FAIL\)/);
+  assert.match(body, /Retreat \(structural\)/);
+  assert.match(body, /Forward advance \(PASS\)/);
+  assert.match(body, /#### Finalizer verdict branch/);
   // Finalizer FAIL/RETREAT must route to planner recall (no in-place rework).
   assert.match(
     body,
@@ -195,6 +258,79 @@ test("orchestrate template exposes Phase advance — Pair rules and Phase advanc
     /not (reworked in place|in-place rework)/i,
     "Finalizer rules must declare no in-place rework",
   );
+});
+
+test("dispatch envelope defines role-specific minimum fields without forwarding placeholders", () => {
+  const body = readFileSync(DISPATCH_ENVELOPE, "utf8");
+  const common = sectionBetween(body, "## Common fields", "## Pair envelope");
+  const pair = sectionBetween(body, "## Pair envelope", "## Planner envelope");
+  const planner = sectionBetween(body, "## Planner envelope", "## Finalizer envelope");
+  const finalizer = body.slice(body.indexOf("## Finalizer envelope"));
+
+  for (const token of [
+    "`Goal`",
+    "`User request snapshot`",
+    "`Turn intent`",
+    "`Scope`",
+  ]) {
+    assert.ok(common.includes(token), `common envelope must include ${token}`);
+  }
+  assert.match(
+    common,
+    /`Turn intent` — the subagent-facing copy of `Next\.Intent`/,
+    "dispatch envelope must expose Next.Intent as Turn intent",
+  );
+  assert.match(
+    common,
+    /Omit placeholder fields that do not apply to the role/,
+    "dispatch envelope must omit unrelated-role placeholder fields",
+  );
+
+  for (const token of [
+    "`Focus EPIC`",
+    "`Task path`",
+    "`Prior tasks`",
+    "`Prior reviews`",
+    "`rubric: skills/<slug>/SKILL.md`",
+  ]) {
+    assert.ok(pair.includes(token), `pair envelope must include ${token}`);
+  }
+  assert.match(pair, /reviewer-only `Axis`/);
+
+  for (const token of [
+    "`Existing EPICs`",
+    "`Recent events`",
+    "`Registered roster`",
+  ]) {
+    assert.ok(planner.includes(token), `planner envelope must include ${token}`);
+  }
+  assert.match(
+    planner,
+    /Planner envelopes do not include `Task path: \(none\)` or `Focus EPIC: \(none\)` placeholders/,
+    "planner envelope must explicitly avoid task/EPIC placeholders",
+  );
+
+  for (const token of ["`Task path`", "`Prior tasks`", "`Prior reviews`"]) {
+    assert.ok(finalizer.includes(token), `finalizer envelope must include ${token}`);
+  }
+  assert.match(
+    finalizer,
+    /Finalizer envelopes do not include `Focus EPIC: \(none\)`, a pair rubric line, or reviewer-only `Axis`/,
+    "finalizer envelope must avoid unrelated Pair/EPIC fields",
+  );
+});
+
+test("harness-context stays subagent-facing and omits orchestrator routing law", () => {
+  const body = readFileSync(CONTEXT_TEMPLATE, "utf8");
+  assert.match(body, /orchestrator decides routing, state updates, and re-dispatch/);
+  assert.match(body, /role-specific envelope/);
+  assert.match(body, /Common fields.*`Goal`, `User request snapshot`, `Turn intent`, and `Scope`/s);
+  assert.doesNotMatch(body, /Phase advance/);
+  assert.doesNotMatch(body, /Pair verdict branch/);
+  assert.doesNotMatch(body, /Finalizer verdict branch/);
+  assert.doesNotMatch(body, /Terminal resolution/);
+  assert.doesNotMatch(body, /ready set/);
+  assert.doesNotMatch(body, /planner-continuation:/);
 });
 
 test("orchestrate template gates dispatch through a ready set at the same global roster position", () => {
@@ -318,6 +454,75 @@ test("state.template.md initializes planner-continuation: none", () => {
   );
 });
 
+test("runtime templates propagate the cycle-local user request snapshot", () => {
+  const orchestrate = readFileSync(ORCHESTRATE_TEMPLATE, "utf8");
+  const context = readFileSync(CONTEXT_TEMPLATE, "utf8");
+  const planner = readFileSync(PLANNER_TEMPLATE, "utf8");
+  const planning = readFileSync(PLANNING_TEMPLATE, "utf8");
+  const dispatch = readFileSync(DISPATCH_ENVELOPE, "utf8");
+  const schema = readFileSync(STATE_SCHEMA, "utf8");
+  const finalizer = readFileSync(FINALIZER_TEMPLATE, "utf8");
+  const scopedRuntimeContracts = [
+    orchestrate,
+    context,
+    planner,
+    planning,
+    dispatch,
+    schema,
+    finalizer,
+  ];
+
+  for (const body of scopedRuntimeContracts) {
+    assert.match(
+      body,
+      /User request snapshot/,
+      "runtime contracts must name the User request snapshot envelope field",
+    );
+    assert.doesNotMatch(body, /Goal source/);
+    assert.doesNotMatch(body, /Reference materials/);
+    assert.doesNotMatch(body, /\.harness\/cycle\/goal\.md/);
+    assert.doesNotMatch(body, /Current phase/);
+    assert.match(
+      body,
+      /Turn intent/,
+      "runtime contracts must use Turn intent for subagent-facing Next.Intent",
+    );
+  }
+  for (const body of [orchestrate, dispatch, schema]) {
+    assert.match(
+      body,
+      /\.harness\/cycle\/user-request-snapshot\.md/,
+      "orchestrator-owned contracts must point at the cycle-local request snapshot",
+    );
+  }
+  assert.match(
+    orchestrate,
+    /every Planner, Pair, and Finalizer envelope/,
+    "orchestrate must explicitly carry the snapshot through every turn kind",
+  );
+  assert.match(
+    context,
+    /Read `User request snapshot` before narrowing the work if it contains constraints beyond `Turn intent`/,
+  );
+  assert.match(
+    planner,
+    /Read `Goal`, `User request snapshot`[\s\S]{0,120}`Turn intent`/,
+  );
+  assert.match(
+    planning,
+    /Prefer `User request snapshot` over the short `Goal` summary/i,
+  );
+  assert.match(
+    dispatch,
+    /planner, pair producers\/reviewers, and the finalizer read it/i,
+  );
+  assert.match(
+    schema,
+    /harness-init` must not seed a placeholder snapshot/,
+    "schema must keep install-time placeholder snapshots out of the contract",
+  );
+});
+
 test("orchestrate template encodes the defer-to-end continuation flow", () => {
   const body = readFileSync(ORCHESTRATE_TEMPLATE, "utf8");
   assert.ok(
@@ -386,4 +591,3 @@ test("runtime templates outside the finalizer do not reference factory-only plug
     }
   }
 });
-

--- a/tests/sync.test.mjs
+++ b/tests/sync.test.mjs
@@ -42,6 +42,9 @@ test("sync --provider claude derives .claude/{agents, skills, settings.json} fro
     assert.ok(existsSync(join(target, ".claude/skills/harness-orchestrate/SKILL.md")));
     assert.ok(existsSync(join(target, ".claude/skills/harness-planning/SKILL.md")));
     assert.ok(existsSync(join(target, ".claude/skills/harness-context/SKILL.md")));
+    const planner = readFileSync(join(target, ".claude/agents/harness-planner.md"), "utf8");
+    assert.match(planner, /^skills:\n  - harness-planning\n  - harness-context$/m);
+    assert.doesNotMatch(planner, /Required Skill Loading/);
 
     // settings.json hook wires the loom hook.sh rather than a cycle-owned path.
     const settings = JSON.parse(readFileSync(join(target, ".claude/settings.json"), "utf8"));
@@ -116,6 +119,33 @@ test("sync --provider gemini writes AfterAgent settings.json pointing at .harnes
     assert.equal(item.type, "command");
     assert.equal(item.command, "bash .harness/loom/hook.sh gemini");
     assert.equal(item.timeout, 60000);
+  } finally {
+    cleanupDir(target);
+  }
+});
+
+test("sync --provider gemini strips skills frontmatter but injects required skill loading into agent bodies", () => {
+  const target = makeTempDir();
+  try {
+    installTo(target);
+    assert.equal(runNode(SYNC_SCRIPT, ["--provider", "gemini"], { cwd: target }).status, 0);
+
+    const planner = readFileSync(join(target, ".gemini/agents/harness-planner.md"), "utf8");
+    const finalizer = readFileSync(join(target, ".gemini/agents/harness-finalizer.md"), "utf8");
+
+    assert.doesNotMatch(planner, /^skills:/m);
+    assert.match(planner, /^## Required Skill Loading$/m);
+    assert.match(planner, /activate and follow these skill bodies by name: harness-planning, harness-context\./);
+    assert.match(planner, /\$harness-planning, \$harness-context/);
+    assert.match(planner, /^# Planner$/m);
+
+    assert.doesNotMatch(finalizer, /^skills:/m);
+    assert.match(finalizer, /activate and follow these skill bodies by name: harness-context\./);
+    assert.match(finalizer, /\$harness-context/);
+    assert.doesNotMatch(finalizer, /\$harness-planning/);
+
+    assert.ok(existsSync(join(target, ".gemini/skills/harness-planning/SKILL.md")));
+    assert.ok(existsSync(join(target, ".gemini/skills/harness-context/SKILL.md")));
   } finally {
     cleanupDir(target);
   }
@@ -247,45 +277,29 @@ test("sync errors on bare invocation — deploy is always an explicit opt-in", (
   }
 });
 
-test("sync --provider codex emits absolute [[skills.config]] paths that actually exist", () => {
+test("sync --provider codex omits skills.config and injects required skill mentions into agent bodies", () => {
   const target = makeTempDir();
   try {
     installTo(target);
     assert.equal(runNode(SYNC_SCRIPT, ["--provider", "codex"], { cwd: target }).status, 0);
 
-    // Every generated codex agent TOML must encode absolute skill paths.
-    // Relative `.codex/skills/...` resolves against `.codex/agents/` and then
-    // silently no-ops when canonicalize fails — hence this guard.
-    const agentsDir = join(target, ".codex/agents");
-    const tomls = readdirSync(agentsDir).filter((n) => n.endsWith(".toml"));
-    assert.ok(tomls.length > 0, "codex agent TOMLs must exist after sync");
+    const planner = readFileSync(join(target, ".codex/agents/harness-planner.toml"), "utf8");
+    const finalizer = readFileSync(join(target, ".codex/agents/harness-finalizer.toml"), "utf8");
 
-    let pathLinesAsserted = 0;
-    for (const name of tomls) {
-      const body = readFileSync(join(agentsDir, name), "utf8");
-      const pathLines = body
-        .split("\n")
-        .filter((l) => /^path\s*=\s*"/.test(l));
-      for (const line of pathLines) {
-        const match = line.match(/^path\s*=\s*"([^"]+)"/);
-        assert.ok(match, `could not parse path line in ${name}: ${line}`);
-        const p = match[1];
-        assert.match(
-          p,
-          /^\/.+\/\.codex\/skills\/[^/]+\/SKILL\.md$/,
-          `${name} path must be absolute .codex/skills/<slug>/SKILL.md, got: ${p}`,
-        );
-        assert.ok(
-          existsSync(p),
-          `${name} references skill path that does not exist on disk: ${p}`,
-        );
-        pathLinesAsserted += 1;
-      }
-    }
-    assert.ok(
-      pathLinesAsserted > 0,
-      "at least one [[skills.config]] path must have been asserted",
-    );
+    assert.doesNotMatch(planner, /\[\[skills\.config\]\]/);
+    assert.doesNotMatch(planner, /^path\s*=\s*"/m);
+    assert.match(planner, /^developer_instructions = """$/m);
+    assert.match(planner, /^## Required Skill Loading$/m);
+    assert.match(planner, /\$harness-planning, \$harness-context/);
+    assert.match(planner, /Codex exposes skill metadata by default/);
+    assert.match(planner, /^# Planner$/m);
+
+    assert.doesNotMatch(finalizer, /\[\[skills\.config\]\]/);
+    assert.match(finalizer, /\$harness-context/);
+    assert.doesNotMatch(finalizer, /\$harness-planning/);
+
+    assert.ok(existsSync(join(target, ".codex/skills/harness-planning/SKILL.md")));
+    assert.ok(existsSync(join(target, ".codex/skills/harness-context/SKILL.md")));
   } finally {
     cleanupDir(target);
   }

--- a/tests/sync.test.mjs
+++ b/tests/sync.test.mjs
@@ -247,6 +247,50 @@ test("sync errors on bare invocation — deploy is always an explicit opt-in", (
   }
 });
 
+test("sync --provider codex emits absolute [[skills.config]] paths that actually exist", () => {
+  const target = makeTempDir();
+  try {
+    installTo(target);
+    assert.equal(runNode(SYNC_SCRIPT, ["--provider", "codex"], { cwd: target }).status, 0);
+
+    // Every generated codex agent TOML must encode absolute skill paths.
+    // Relative `.codex/skills/...` resolves against `.codex/agents/` and then
+    // silently no-ops when canonicalize fails — hence this guard.
+    const agentsDir = join(target, ".codex/agents");
+    const tomls = readdirSync(agentsDir).filter((n) => n.endsWith(".toml"));
+    assert.ok(tomls.length > 0, "codex agent TOMLs must exist after sync");
+
+    let pathLinesAsserted = 0;
+    for (const name of tomls) {
+      const body = readFileSync(join(agentsDir, name), "utf8");
+      const pathLines = body
+        .split("\n")
+        .filter((l) => /^path\s*=\s*"/.test(l));
+      for (const line of pathLines) {
+        const match = line.match(/^path\s*=\s*"([^"]+)"/);
+        assert.ok(match, `could not parse path line in ${name}: ${line}`);
+        const p = match[1];
+        assert.match(
+          p,
+          /^\/.+\/\.codex\/skills\/[^/]+\/SKILL\.md$/,
+          `${name} path must be absolute .codex/skills/<slug>/SKILL.md, got: ${p}`,
+        );
+        assert.ok(
+          existsSync(p),
+          `${name} references skill path that does not exist on disk: ${p}`,
+        );
+        pathLinesAsserted += 1;
+      }
+    }
+    assert.ok(
+      pathLinesAsserted > 0,
+      "at least one [[skills.config]] path must have been asserted",
+    );
+  } finally {
+    cleanupDir(target);
+  }
+});
+
 test("sync does not deploy to a pre-existing .claude/ without explicit --provider", () => {
   const target = makeTempDir();
   try {


### PR DESCRIPTION
## Summary
- introduce the v0.3.0 harness refresh surface: /harness-auto-setup, guarded pair removal, and template-first --from pair authoring
- reduce runtime envelopes and role output contracts to load-bearing fields
- preserve full user request snapshots through runtime dispatch
- align Codex and Gemini sync with explicit required skill loading while keeping Claude skills frontmatter unchanged

## Validation
- node --test tests/*.mjs