### PR TITLE
Fix #3: sync refuses to overwrite malformed platform settings

### DIFF
--- a/plugins/harness-loom/skills/harness-init/scripts/sync.ts
+++ b/plugins/harness-loom/skills/harness-init/scripts/sync.ts
@@ -138,6 +138,30 @@ async function exists(path: string): Promise<boolean> {
   }
 }
 
+// Read an existing JSON file that sync is about to merge into and overwrite.
+// On parse failure (or non-object top level) we refuse to proceed instead of
+// silently replacing user-owned settings with `{}`. The caller is expected to
+// have already confirmed the file exists.
+async function readJsonObjectOrThrow(path: string): Promise<Record<string, unknown>> {
+  const raw = await readFile(path, "utf8");
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `refusing to overwrite malformed ${path}: ${msg}. Fix or remove the file, then re-run sync.`,
+    );
+  }
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    const shape = Array.isArray(parsed) ? "array" : parsed === null ? "null" : typeof parsed;
+    throw new Error(
+      `refusing to overwrite ${path}: expected top-level JSON object, got ${shape}. Fix or remove the file, then re-run sync.`,
+    );
+  }
+  return parsed as Record<string, unknown>;
+}
+
 // ---------------------------------------------------------------- frontmatter
 
 function parseFrontmatter(raw: string): { fm: Record<string, unknown>; body: string } {
@@ -348,11 +372,7 @@ async function writeClaudeSettings(targetRoot: string): Promise<string> {
   await mkdir(dirname(settingsPath), { recursive: true });
   let existing: Record<string, unknown> = {};
   if (await exists(settingsPath)) {
-    try {
-      existing = JSON.parse(await readFile(settingsPath, "utf8")) as Record<string, unknown>;
-    } catch {
-      existing = {};
-    }
+    existing = await readJsonObjectOrThrow(settingsPath);
   }
   const hooks = (existing.hooks as Record<string, unknown>) ?? {};
   hooks.Stop = [
@@ -375,11 +395,7 @@ async function writeCodexHookConfig(targetRoot: string): Promise<string> {
   await mkdir(dirname(hooksPath), { recursive: true });
   let payload: Record<string, unknown> = {};
   if (await exists(hooksPath)) {
-    try {
-      payload = JSON.parse(await readFile(hooksPath, "utf8")) as Record<string, unknown>;
-    } catch {
-      payload = {};
-    }
+    payload = await readJsonObjectOrThrow(hooksPath);
   }
   const hooks = (payload.hooks as Record<string, unknown>) ?? {};
   hooks.Stop = [
@@ -420,11 +436,7 @@ async function writeGeminiHookConfig(targetRoot: string): Promise<string> {
   await mkdir(dirname(settingsPath), { recursive: true });
   let existing: Record<string, unknown> = {};
   if (await exists(settingsPath)) {
-    try {
-      existing = JSON.parse(await readFile(settingsPath, "utf8")) as Record<string, unknown>;
-    } catch {
-      existing = {};
-    }
+    existing = await readJsonObjectOrThrow(settingsPath);
   }
   const hooks = (existing.hooks as Record<string, unknown>) ?? {};
   // Gemini hook schema (docs/hooks/reference.md): 2-layer nested

--- a/tests/sync.test.mjs
+++ b/tests/sync.test.mjs
@@ -332,3 +332,60 @@ test("sync does not deploy to a pre-existing .claude/ without explicit --provide
     cleanupDir(target);
   }
 });
+
+// Regression for issue #3: sync used to `catch { payload = {} }` on malformed
+// user-owned settings files and then overwrite the whole file — destroying
+// recoverable permissions/env/theme state. The write functions now refuse to
+// proceed when the pre-existing file is not a JSON object, leaving the file
+// verbatim so the user can repair it manually.
+for (const [label, providerArg, relPath] of [
+  ["claude settings.json", "claude", ".claude/settings.json"],
+  ["codex hooks.json", "codex", ".codex/hooks.json"],
+  ["gemini settings.json", "gemini", ".gemini/settings.json"],
+]) {
+  test(`sync refuses to overwrite malformed ${label} instead of silently wiping it`, () => {
+    const target = makeTempDir();
+    try {
+      installTo(target);
+      const abs = join(target, relPath);
+      mkdirSync(join(target, relPath.split("/")[0]), { recursive: true });
+      const corrupt = "not-json {{{";
+      writeFileSync(abs, corrupt);
+
+      const r = runNode(SYNC_SCRIPT, ["--provider", providerArg], { cwd: target });
+      assert.notEqual(r.status, 0, "sync must exit non-zero on malformed config");
+      assert.match(
+        r.stderr,
+        /refusing to overwrite malformed .*\bFix or remove the file, then re-run sync\.$/m,
+        "stderr must name the file and instruct the user to repair it",
+      );
+
+      // File contents must be preserved byte-for-byte.
+      assert.equal(readFileSync(abs, "utf8"), corrupt);
+    } finally {
+      cleanupDir(target);
+    }
+  });
+
+  test(`sync refuses to overwrite non-object ${label} (top-level array)`, () => {
+    const target = makeTempDir();
+    try {
+      installTo(target);
+      const abs = join(target, relPath);
+      mkdirSync(join(target, relPath.split("/")[0]), { recursive: true });
+      const arrayJson = "[1, 2, 3]\n";
+      writeFileSync(abs, arrayJson);
+
+      const r = runNode(SYNC_SCRIPT, ["--provider", providerArg], { cwd: target });
+      assert.notEqual(r.status, 0, "sync must exit non-zero on non-object JSON");
+      assert.match(
+        r.stderr,
+        /expected top-level JSON object, got array/,
+        "stderr must name the unexpected shape",
+      );
+      assert.equal(readFileSync(abs, "utf8"), arrayJson);
+    } finally {
+      cleanupDir(target);
+    }
+  });
+}


### PR DESCRIPTION
## Summary

Closes #3.

`writeClaudeSettings`, `writeCodexHookConfig`, and `writeGeminiHookConfig` used to `catch { payload = {} }` when the pre-existing user-owned settings file failed to parse, then overwrote that same file — silently destroying permissions / hooks / env / theme state that was otherwise recoverable by hand-editing the file.

- Introduce `readJsonObjectOrThrow(path)` that throws a descriptive error naming the path and instructing the user to repair or remove the file (covers both parse errors and top-level non-object JSON such as arrays / strings / null).
- Replace the three duplicated `catch { … = {} }` sites with the shared helper so the same silent-wipe bug cannot be reintroduced one provider at a time.
- Errors bubble through `runSync` so both the CLI entry (via `main` → `die`) and the library API surface the failure consistently; `process.exit` does not fire inside library callers.

The issue's proposal (2), an explicit `--force` / `--overwrite-malformed` flag, was intentionally deferred — the existing workflow (`mv settings.json settings.json.bak && sync`) already covers the "I want to discard it" case without adding a new flag surface to maintain. This can be revisited later if a real use case emerges.

## Scope

- `plugins/harness-loom/skills/harness-init/scripts/sync.ts` — new helper, three call-site replacements.
- `tests/sync.test.mjs` — six regression tests, 3 providers × 2 failure modes.

`auto-setup.ts` has similar `catch { … }` blocks, but they parse subprocess stdout (not user-owned settings files), so they are out of scope for this fix.

## Test plan

- [x] `node --test tests/sync.test.mjs` — 20/20 pass (14 existing + 6 new).
- [x] `node --test tests/*.test.mjs` — 110/110 pass (full suite; auto-setup path that invokes sync internally is unaffected).
- [x] Regression assertions verify both non-zero exit AND byte-for-byte preservation of the corrupt file (not just "file is still not valid JSON").

🤖 Generated with [Claude Code](https://claude.com/claude-code)