### PR TITLE
[codex] Tighten harness planning and output contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- **Planner EPIC sizing now targets producer-completable outcome
+  slices.** `harness-planning` now tells the planner to split broad
+  surfaces into dependency-bearing EPICs when one producer would
+  otherwise self-defer in-scope acceptance, verification, or rendered
+  evidence. Pair dispatch envelopes and `harness-context` now treat
+  `Prior tasks` / `Prior reviews` as upstream dependency evidence that
+  producers must inspect, and reviewers may fail work that ignores those
+  artifacts or leaves current-scope completion for a future turn.
 - **Runtime and role output surfaces reduced to load-bearing fields.**
   Dispatch envelopes now expose `Turn intent` as the subagent-facing
   copy of `Next.Intent`, pair producer/reviewer output blocks no longer
@@ -15,6 +23,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   load-bearing `next-action`, and finalizer verdicts remain anchored on
   `Status` plus `Self-verification`. Structural routing now uses only
   the shared `## Structural Issue` block.
+- **Producer and finalizer gap reporting now names only blockers and
+  out-of-scope work.** The former `Remaining items` line is now
+  `Blocked or out-of-scope items`, making clear that producers cannot
+  use the field to defer in-scope acceptance, verification, or evidence.
 - **Codex and Gemini sync now injects required skill loading into agent
   bodies.** `sync.ts` derives the required skills from canonical
   `.harness/loom/agents/*.md` `skills:` frontmatter, prepends a

--- a/plugins/harness-loom/skills/harness-auto-setup/SKILL.md
+++ b/plugins/harness-loom/skills/harness-auto-setup/SKILL.md
@@ -46,26 +46,9 @@ Before any destructive refresh on a target with existing harness runtime state (
 .harness/_snapshots/auto-setup/<YYYYMMDDTHHMMSSZ>/
 ```
 
-Use the UTC run-start timestamp for the id; if a directory already exists for the same second, append `-NN` with a zero-padded monotonic counter. The snapshot directory contains:
+The snapshot preserves pre-refresh `.harness/loom/` and `.harness/cycle/` when present, plus deterministic `manifest.json` provenance. Read `references/snapshot-provenance.md` before changing snapshot id allocation, copied namespaces, manifest keys, active-cycle fields, or failure behavior.
 
-- `manifest.json` — deterministic JSON summary with stable key order
-- `loom/` — copy of pre-refresh `.harness/loom/` when present
-- `cycle/` — copy of pre-refresh `.harness/cycle/` when present
-
-`manifest.json` must include at least:
-
-- `schemaVersion`
-- `tool`
-- `targetPath`
-- `createdAt`
-- `snapshotPath`
-- `copiedNamespaces`
-- `activeCycle`
-- `registrySummary`
-- `finalizerSummary`
-- `nextAction`
-
-Keep `copiedNamespaces` sorted and use target-relative namespace names such as `.harness/loom` and `.harness/cycle`. `activeCycle` must record the classification plus the parse reason. Do not snapshot derived platform trees by default; they are deployment outputs and are refreshed only by explicit sync.
+Do not snapshot derived platform trees by default; they are deployment outputs and are refreshed only by explicit sync.
 
 If snapshot creation fails, stop before running install or deleting anything.
 
@@ -186,5 +169,6 @@ The script snapshots existing `.harness/loom/` / `.harness/cycle/`, classifies a
 
 - `../harness-init/SKILL.md` — foundation installer boundary
 - `../harness-pair-dev/SKILL.md` — pair authoring and registry mutation boundary
+- `references/snapshot-provenance.md` — snapshot directory, manifest shape, and failure contract
 - `../harness-init/references/runtime/registry.md` — target-side pair roster contract
 - `../harness-init/references/runtime/harness-finalizer.template.md` — singleton finalizer skeleton and Output Format

--- a/plugins/harness-loom/skills/harness-auto-setup/references/snapshot-provenance.md
+++ b/plugins/harness-loom/skills/harness-auto-setup/references/snapshot-provenance.md
@@ -1,0 +1,49 @@
+---
+name: auto-setup-snapshot-provenance
+description: "Use when changing or reviewing `/harness-auto-setup` snapshot directory allocation, manifest shape, copied namespaces, active-cycle provenance, or snapshot failure behavior."
+---
+
+# Snapshot Provenance Contract
+
+This reference owns the schema-level snapshot details for `harness-auto-setup`. `SKILL.md` owns the workflow sequence and authority boundaries.
+
+## Snapshot Directory
+
+Before any destructive refresh on a target with existing `.harness/loom/` or `.harness/cycle/`, create:
+
+```text
+.harness/_snapshots/auto-setup/<YYYYMMDDTHHMMSSZ>/
+```
+
+Use the UTC run-start timestamp for the id. If a directory already exists for the same second, append `-NN` with a zero-padded monotonic counter.
+
+## Snapshot Contents
+
+- `manifest.json` — deterministic JSON summary with stable key order.
+- `loom/` — copy of pre-refresh `.harness/loom/` when present.
+- `cycle/` — copy of pre-refresh `.harness/cycle/` when present.
+
+Do not copy derived platform trees by default. `.claude/`, `.codex/`, and `.gemini/` are deployment outputs refreshed only by explicit sync.
+
+## Manifest Shape
+
+`manifest.json` must include at least these top-level keys in stable order:
+
+1. `schemaVersion`
+2. `tool`
+3. `targetPath`
+4. `createdAt`
+5. `snapshotPath`
+6. `copiedNamespaces`
+7. `activeCycle`
+8. `registrySummary`
+9. `finalizerSummary`
+10. `nextAction`
+
+`copiedNamespaces` must be sorted and use target-relative namespace names such as `.harness/loom` and `.harness/cycle`.
+
+`activeCycle` must record both the classification and the parse reason so a later reviewer can tell whether the refresh discarded pristine, halted, active, or unknown cycle state.
+
+## Failure Contract
+
+If snapshot creation fails, stop before running install or deleting anything. Snapshot failure is a setup blocker, not a warning.

--- a/plugins/harness-loom/skills/harness-auto-setup/scripts/auto-setup.ts
+++ b/plugins/harness-loom/skills/harness-auto-setup/scripts/auto-setup.ts
@@ -963,7 +963,7 @@ function renderProducerAgent(pair: RegistryPair): string {
       "3. Inspect current project files named by the task scope.\n" +
       "4. Produce the requested artifact or code change inside scope.\n" +
       "5. Run the smallest relevant verification command available.\n" +
-      "6. Report changed files, verification, and remaining work in the Producer Output Format.",
+      "6. Report changed files, verification, and any blocked or out-of-scope items in the Producer Output Format.",
   });
 }
 
@@ -1117,7 +1117,7 @@ function renderFinalizerFromTemplate(template: string, evidenceLines: string[]):
     "3. Inspect project files and cycle artifacts named by the envelope.\n" +
     "4. Perform only writes justified by scope, current contracts, and project evidence.\n" +
     "5. Run the smallest relevant verification for the cycle-end duty.\n" +
-    "6. Emit the Output Format block with concrete paths, verification, and remaining items.\n\n" +
+    "6. Emit the Output Format block with concrete paths, verification, and any blocked or out-of-scope items.\n\n" +
     "If the preserved intent no longer matches the current goal or project contract, emit the Structural Issue block and return `Status: FAIL`.\n";
   return replaceSection(template, "Task", task);
 }

--- a/plugins/harness-loom/skills/harness-init/references/runtime/harness-context/SKILL.template.md
+++ b/plugins/harness-loom/skills/harness-init/references/runtime/harness-context/SKILL.template.md
@@ -31,11 +31,14 @@ At dispatch time the orchestrator supplies a role-specific envelope. Use it as t
 ### 3. If you are a pair producer
 
 - Produce the task artifact by following the pair skill's rubric.
-- Your artifact is the content that will be written to `Task path`. Include the role's reduced producer output block (`Status`, `Summary`, `Files created`, `Files modified`, `Diff summary`, `Self-verification`, `Remaining items`) plus any evidence/body required by the pair skill. A paired reviewer decides the verdict; your own `Status` is self-report only.
+- Your artifact is the content that will be written to `Task path`. Include the role's reduced producer output block (`Status`, `Summary`, `Files created`, `Files modified`, `Diff summary`, `Self-verification`, `Blocked or out-of-scope items`) plus any evidence/body required by the pair skill. A paired reviewer decides the verdict; your own `Status` is self-report only.
 - Read `User request snapshot` before narrowing the work if it contains constraints beyond `Turn intent`.
+- Treat `Turn intent` as attempt-to-completion inside `Scope`. `Blocked or out-of-scope items` may record only external blockers or work outside the current scope; it must not defer in-scope acceptance, verification, or evidence to a future turn.
+- If a blocker prevents required in-scope acceptance, verification, or evidence, return `Status: FAIL` or `## Structural Issue`; do not PASS by listing the blocker under `Blocked or out-of-scope items`.
+- When `Prior tasks` or `Prior reviews` are supplied, read them before editing and carry forward dependency decisions, unresolved reviewer findings, and upstream evidence instead of rediscovering the same surface from scratch.
 - Do not modify files outside `Scope`.
 - Task ids and task-file history are orchestrator-owned. Return the artifact content; the orchestrator records it on disk.
-- If you detect an upstream contract failure you cannot resolve inside this turn, report it with `## Structural Issue` instead of flattening it into a generic FAIL. The paired reviewer will restate and judge it in the review.
+- If the EPIC is too broad to complete inside this producer turn, or if you detect another upstream contract failure you cannot resolve inside this turn, report it with `## Structural Issue` instead of flattening it into a generic FAIL. The paired reviewer will restate and judge it in the review.
 
 ### 4. If you are the reviewer
 
@@ -44,6 +47,7 @@ At dispatch time the orchestrator supplies a role-specific envelope. Use it as t
 - If `Axis` is present, focus on criteria tagged for that axis. Untagged shared criteria still apply.
 - Use the task artifact and concrete disk evidence from the files it changed or cited. Do not use producer transcript, tool trace, or another reviewer's decision as evidence.
 - Use `User request snapshot` and `Prior reviews` as grading context. A producer can fail even when the local task is implemented if it ignores required original-request constraints or unresolved prior-review findings.
+- Use `Prior tasks` / `Prior reviews` as dependency evidence. FAIL a producer that ignores supplied upstream EPIC artifacts, reopens settled decisions without evidence, or leaves in-scope acceptance/verification/rendered evidence as planned future work.
 - End with the reduced reviewer output block: `Verdict`, `Criteria`, `FAIL items`, and `Feedback`. Put domain-specific regression notes in the body or `Feedback` when useful; do not add advisory routing fields.
 - Do not pull FAIL items from another axis into your own verdict. Cross-review synthesis belongs to the orchestrator.
 
@@ -57,8 +61,9 @@ At dispatch time the orchestrator supplies a role-specific envelope. Use it as t
 ### 6. If you are a finalizer
 
 - You run only in a cycle-end finalizer turn. There is no paired reviewer, and the concrete rubric for the turn lives inside your agent body.
-- Your reduced finalizer output block keeps `Status`, `Summary`, `Files created`, `Files modified`, `Self-verification`, and `Remaining items`; an optional `Files left alone (intentionally)` line is allowed only when useful. `Status: PASS | FAIL` plus `Self-verification` is the verdict source. Cite concrete mechanical evidence — file paths, diff summaries, exit codes, coverage tallies — not narrative.
+- Your reduced finalizer output block keeps `Status`, `Summary`, `Files created`, `Files modified`, `Self-verification`, and `Blocked or out-of-scope items`; an optional `Files left alone (intentionally)` line is allowed only when useful. `Status: PASS | FAIL` plus `Self-verification` is the verdict source. Cite concrete mechanical evidence — file paths, diff summaries, exit codes, coverage tallies — not narrative.
 - Read `User request snapshot` when cycle-end work checks request coverage or release readiness.
+- If a blocker prevents required cycle-end work, request coverage, verification, or evidence, return `Status: FAIL` or `## Structural Issue`; do not PASS by listing the blocker under `Blocked or out-of-scope items`.
 - Do not request reviewer dispatch and do not emit reviewer-shape fields. Finalizer turns leave 0 review files.
 - If an upstream contract is invalid (for example, the cycle claims to have shipped a result with no source evidence), emit the `## Structural Issue` block inside your artifact with `Suspected upstream stage: planner`. The orchestrator will recall the planner rather than redispatching the finalizer in place.
 
@@ -90,6 +95,7 @@ Assume only the skills explicitly attached to your role plus the dispatch envelo
 - Your output follows the correct role-specific return shape for pair producer, pair reviewer, planner, or finalizer.
 - You actually use the envelope fields `Goal`, `Turn intent`, `Scope`, and `Task path` when your role has one.
 - When supplied, `User request snapshot` is read or explicitly judged irrelevant to the current narrow task.
+- When supplied, `Prior tasks` / `Prior reviews` are used as upstream or rework evidence rather than ignored.
 - You do not modify anything outside `Scope`.
 - Your output contains no control-plane fields such as `Next`, `current`, or `loop`.
 - Reviewer evidence stays anchored to one task artifact.
@@ -102,8 +108,10 @@ Assume only the skills explicitly attached to your role plus the dispatch envelo
 - Write directly under `.harness/cycle/` or `.harness/loom/`; return content only.
 - Modify files outside the envelope scope.
 - Replace orchestrator routing by emitting `Next`, `current`, or `loop` in your output.
-- Add advisory or escalation routing fields; use `Remaining items`, `Feedback`, or `## Structural Issue` according to role.
+- Add advisory or escalation routing fields; use `Blocked or out-of-scope items`, `Feedback`, or `## Structural Issue` according to role.
 - Treat `Turn intent` as permission to ignore the full user request snapshot.
+- Treat `Blocked or out-of-scope items` as a way to self-defer in-scope work that the current producer should have completed.
+- Ignore supplied upstream EPIC artifacts and rediscover the same surface from scratch.
 - Use producer transcript or tool trace as reviewer evidence.
 - Try to manage task ids or on-disk history yourself.
 - Flatten a structural issue into a generic FAIL and force endless same-pair rework.

--- a/plugins/harness-loom/skills/harness-init/references/runtime/harness-finalizer.template.md
+++ b/plugins/harness-loom/skills/harness-init/references/runtime/harness-finalizer.template.md
@@ -23,7 +23,7 @@ The default body below is a safe no-op: it returns `Status: PASS` with `Summary:
 
 The default no-op task is exactly one step:
 
-1. Emit the Output Format block below with `Status: PASS`, `Summary: no cycle-end work registered for this project`, empty `Files created` / `Files modified`, and a `Self-verification` note that no cycle-end work was required. Do not touch any file.
+1. Emit the Output Format block below with `Status: PASS`, `Summary: no cycle-end work registered for this project`, empty `Files created` / `Files modified`, `Self-verification` citing that no cycle-end work was required, and `Blocked or out-of-scope items: []`. Do not touch any file.
 
 If cycle-end work exists, execute it here as a short numbered sequence: read the envelope, load project signal, walk cycle evidence, perform the domain work, decide per-file create/update/leave-alone, emit the Output Format, and surface a Structural Issue on upstream failure.
 
@@ -37,7 +37,7 @@ Summary: {what was performed in one line; default no-op uses "no cycle-end work 
 Files created: [{file path}]
 Files modified: [{file path}]
 Self-verification: {concrete mechanical evidence — file paths, diff summaries, exit codes, coverage tallies; default no-op cites "no cycle-end work required; no files touched"}
-Remaining items: [{items not yet done}]
+Blocked or out-of-scope items: [{item, reason}]
 ```
 
 Optional line: inside the fenced block, include `Files left alone (intentionally): [{file path — one-line reason}]` before `Self-verification` only when it carries useful cycle-end evidence. Omit it for the default no-op or empty lists.

--- a/plugins/harness-loom/skills/harness-init/references/runtime/harness-orchestrate/SKILL.template.md
+++ b/plugins/harness-loom/skills/harness-init/references/runtime/harness-orchestrate/SKILL.template.md
@@ -107,7 +107,7 @@ After a planner turn:
    - only `Additional pairs required` and no executable EPICs -> halt directly: clear `Next`, keep `loop: false`, clear any pending continuation flag, and tell the user to extend the harness and re-run. This blocked halt does not run the finalizer.
    - finalizer FAIL/RETREAT recall with zero executable EPICs -> halt directly: clear `Next`, keep `loop: false`, and tell the user to fix the finalizer body or the plan. This cuts any infinite Finalizer -> Planner -> Finalizer loop the planner cannot repair.
    - defer-to-end continuation recall with zero new executable EPICs -> force `planner-continuation: none`, append one orchestrator note to `events.md`, and continue with terminal handling below.
-7. If live EPICs remain and the ready set is non-empty, synthesize the next Pair dispatch from the selected EPIC.
+7. If live EPICs remain and the ready set is non-empty, synthesize the next Pair dispatch from the selected EPIC. Attach relevant same-EPIC rework artifacts plus upstream EPIC task/review artifacts that prove the selected EPIC's gate is satisfied as `Prior tasks` / `Prior reviews`.
 8. If live EPICs remain and the ready set is empty, recall the planner instead of dispatching a blocked stage:
    - `Next.To = planner`
    - `Next.EPIC = (none)`
@@ -123,7 +123,7 @@ The verdict source is the aggregated reviewer set.
 2. **Retreat (structural)** — read `Suspected upstream stage`:
    - if it resolves to `planner`, synthesize a planner recall with `Task path: (none)` and attach the relevant task/review artifacts as `Prior`
    - otherwise rewind the EPIC's `current` to that producer, carry the structural reason as `Intent`, attach the retreat-target artifacts as `Prior`, and allocate a fresh pair task path for the rewound producer
-3. **Forward advance (PASS)** — move the current EPIC to the next producer in its roster slice, or `done` if the slice is exhausted. Recompute the ready set across every live EPIC. If the ready set is non-empty, dispatch the ready EPIC with the smallest global roster position. If live EPICs remain but the ready set is empty, recall the planner with `Task path: (none)` and an `Intent` that names the gate condition. If no live EPICs remain, apply Terminal resolution below.
+3. **Forward advance (PASS)** — move the current EPIC to the next producer in its roster slice, or `done` if the slice is exhausted. Recompute the ready set across every live EPIC. If the ready set is non-empty, dispatch the ready EPIC with the smallest global roster position and attach relevant same-EPIC plus upstream dependency artifacts as `Prior tasks` / `Prior reviews`. If live EPICs remain but the ready set is empty, recall the planner with `Task path: (none)` and an `Intent` that names the gate condition. If no live EPICs remain, apply Terminal resolution below.
 
 `Phase` always echoes `Next.To`. Global stage comparison always resolves against the ordered registry, never against a per-EPIC local slot number.
 
@@ -154,6 +154,8 @@ Do not touch `planner-continuation` in this branch. The recovery loop is bounded
 Subagents run with `fork_context=false`, so the envelope is the only runtime payload they should trust for this turn. The envelope-facing field for `Next.Intent` is `Turn intent`; do not emit legacy phase wording for that field.
 
 `references/dispatch-envelope.md` owns the role-specific minimum field set. Every executable Planner, Pair, and Finalizer dispatch must carry `Goal`, `User request snapshot`, `Turn intent`, and `Scope`; placeholder fields for unrelated roles are omitted.
+
+For Pair dispatches, `Prior tasks` / `Prior reviews` are not only rework payloads. When `upstream` made an EPIC ready, attach the relevant upstream artifacts as dependency evidence so the next producer can inspect prior decisions instead of re-reading the same source surface from scratch.
 
 #### Context propagation
 

--- a/plugins/harness-loom/skills/harness-init/references/runtime/harness-orchestrate/references/dispatch-envelope.md
+++ b/plugins/harness-loom/skills/harness-init/references/runtime/harness-orchestrate/references/dispatch-envelope.md
@@ -20,11 +20,11 @@ Pair producers and reviewers receive:
 - all common fields
 - `Focus EPIC` — the selected `EP-N--slug` plus one-line outcome/note context
 - `Task path` — copied from `Next.Task path`
-- `Prior tasks` — prior task artifact paths attached for rework, retreat, or upstream evidence
-- `Prior reviews` — prior review artifact paths attached for rework, retreat, or upstream evidence
+- `Prior tasks` — prior task artifact paths attached for rework, retreat, or upstream dependency evidence
+- `Prior reviews` — prior review artifact paths attached for rework, retreat, or upstream dependency evidence
 - `rubric: skills/<slug>/SKILL.md`
 - reviewer-only `Axis` when the pair is 1:M
-- `User request snapshot` is read-only request evidence. It does not authorize routing or state mutation, but reviewers may fail work that ignores required original-request constraints.
+- `User request snapshot` is read-only request evidence. It does not authorize routing or state mutation, but reviewers may fail work that ignores required original-request constraints. `Prior tasks` / `Prior reviews` are also read-only evidence; when supplied from upstream EPICs, producers must carry forward those decisions instead of rediscovering the same files from scratch.
 
 The orchestrator resolves the reviewer set from `.harness/loom/registry.md`.
 

--- a/plugins/harness-loom/skills/harness-init/references/runtime/harness-orchestrate/references/state-md-schema.md
+++ b/plugins/harness-loom/skills/harness-init/references/runtime/harness-orchestrate/references/state-md-schema.md
@@ -50,7 +50,7 @@ note: ...
   - `EPIC` — `EP-N--slug`, or `(none)` for planner and finalizer turns
   - `Task path` — `(none)` for planner turns; canonical pair task path for Pair turns; canonical finalizer task path for Finalizer turns
   - `Intent` — one or two natural-language sentences. Dispatch envelopes expose this value as `Turn intent`. On retreat, prefix with `(retreat reason: ...)`. On a defer-to-end planner recall, prefix with `(planner continuation: ...)`.
-  - `Prior tasks` / `Prior reviews` — arrays of previous artifact paths that will be attached into the next envelope
+  - `Prior tasks` / `Prior reviews` — arrays of previous artifact paths that will be attached into the next envelope for rework, retreat, or upstream dependency evidence
 - **`## EPIC summaries` block** — one EPIC = one `### EP-N--slug` heading plus five fields: `outcome`, `upstream`, `roster`, `current`, and `note`. Pipe tables and prose blobs are forbidden.
   - `outcome` — one-sentence completion condition
   - `upstream` — same-stage gate set for ready-set computation, or `none`

--- a/plugins/harness-loom/skills/harness-init/references/runtime/harness-planner.template.md
+++ b/plugins/harness-loom/skills/harness-init/references/runtime/harness-planner.template.md
@@ -1,6 +1,6 @@
 ---
 name: harness-planner
-description: "Use whenever `/harness-orchestrate` needs to plan or re-plan EPICs for this codebase. Reads the goal and current runtime state, emits outcome EPICs with stage slices drawn from the project's fixed global roster, and uses defer-to-end continuation (`next-action: continue` recalls the planner only after all currently-live EPICs reach terminal, so re-planning runs against real execution evidence)."
+description: "Use whenever `/harness-orchestrate` needs to plan or re-plan EPICs for this codebase. Reads the goal and current runtime state, emits producer-completable outcome EPICs with stage slices drawn from the project's fixed global roster, and uses defer-to-end continuation (`next-action: continue` recalls the planner only after all currently-live EPICs reach terminal, so re-planning runs against real execution evidence)."
 skills:
   - harness-planning
   - harness-context
@@ -8,11 +8,11 @@ skills:
 
 # Planner
 
-The producer responsible for decomposing the current goal into outcome EPICs and assigning the relevant stage slice for each one. It is a **meta-role that does not create task files**. The orchestrator copies its result into `.harness/cycle/state.md` under `## EPIC summaries`.
+The producer responsible for decomposing the current goal into producer-completable outcome EPICs and assigning the relevant stage slice for each one. It is a **meta-role that does not create task files**. The orchestrator copies its result into `.harness/cycle/state.md` under `## EPIC summaries`.
 
 ## Principles
 
-1. Let the domain decide the outcomes. The planner should name real results this project needs, not generic phases.
+1. Let the domain decide the outcome slices. Each EPIC should be meaningful and sized so its producers can attempt completion without planned self-deferral.
 2. The project already owns a fixed global roster. The planner chooses a subsequence for each EPIC; it does not invent a new workflow.
 3. Keep one turn focused. Emit a small batch of careful EPICs. If later EPICs can only be sized correctly after the current batch executes, emit `next-action: continue — <reason>` — the orchestrator will recall the planner **after all currently-live EPICs reach terminal**, with events.md evidence in hand. Otherwise emit `next-action: done`.
 4. Use only real registered producers in `roster`.
@@ -24,12 +24,13 @@ The producer responsible for decomposing the current goal into outcome EPICs and
 2. Read `Goal`, `User request snapshot`, `Existing EPICs`, `Turn intent`, `Prior tasks`, `Prior reviews`, `Recent events`, and `Registered roster` from the envelope. Treat `Registered roster` as the authoritative pair list for this turn; do not consult any SKILL file to discover roster state.
 3. Scan this project's README, root docs, and major directories for domain signals.
 4. Turn the request snapshot into citation-ready notes. Prefer `User request snapshot` line citations such as `.harness/cycle/user-request-snapshot.md:Lxx "quoted phrase"` when line numbering is available; otherwise cite the quoted goal phrase from `Goal`.
-5. Name downstream EPIC slugs starting at `EP-1--{outcome-slug}`; on re-plan turns, continue numbering after the last existing EPIC.
-6. For each EPIC, emit `outcome`, `upstream`, `why`, and `roster`.
-7. Treat `upstream` as a same-stage gate across EPICs.
-8. Keep the turn small. Describe unplanned work informationally under `Remaining`, and use the load-bearing `next-action` grammar (`continue — <reason>` vs `done`) to actually trigger or end re-dispatch.
-9. If an unregistered pair is required, list it under `Additional pairs required` and do not emit that blocked EPIC as executable work.
-10. End with the load-bearing planner Output Format block below. Do not write files under `.harness/` yourself.
+5. Apply the producer-completion sizing test: split broad surfaces into dependency-bearing EPICs, and fold microscopic edits into a meaningful EPIC.
+6. Name downstream EPIC slugs starting at `EP-1--{outcome-slug}`; on re-plan turns, continue numbering after the last existing EPIC.
+7. For each EPIC, emit `outcome`, `upstream`, `why`, and `roster`.
+8. Treat `upstream` as a same-stage gate across EPICs whose artifacts downstream producers should inspect through `Prior tasks` / `Prior reviews`.
+9. Keep the turn small. Describe unplanned work informationally under `Remaining`, and use the load-bearing `next-action` grammar (`continue — <reason>` vs `done`) to actually trigger or end re-dispatch.
+10. If an unregistered pair is required, list it under `Additional pairs required` and do not emit that blocked EPIC as executable work.
+11. End with the load-bearing planner Output Format block below. Do not write files under `.harness/` yourself.
 
 ## Output Format
 

--- a/plugins/harness-loom/skills/harness-init/references/runtime/harness-planning/SKILL.template.md
+++ b/plugins/harness-loom/skills/harness-init/references/runtime/harness-planning/SKILL.template.md
@@ -1,6 +1,6 @@
 ---
 name: harness-planning
-description: "Use when the planner subagent is dispatched or when its output is audited. Defines how to read the goal, decompose it into outcome EPICs, and emit each EPIC's stage flow as a subsequence of the project's fixed global roster."
+description: "Use when the planner subagent is dispatched or when its output is audited. Defines how to read the goal, decompose it into producer-completable outcome EPICs, and emit each EPIC's stage flow as a subsequence of the project's fixed global roster."
 user-invocable: false
 ---
 
@@ -10,13 +10,13 @@ One planner turn emits a small batch of EPICs together with the stage slice each
 
 ## Design Thinking
 
-The planner decides outcomes, not implementation trivia. Each EPIC should describe one meaningful result, then name the stages needed to reach it. The planner does not redesign the runtime on every turn: the runtime already has a fixed stage order, and the planner's job is simply to choose which stages each EPIC uses, which stages can be skipped, and which upstream EPICs must stay ahead at the same stage gate.
+The planner decides outcome slices, not implementation trivia. Each EPIC should describe one meaningful result that every producer in its roster can attempt to complete in a single Pair turn. If a planned EPIC predictably requires the same producer to leave in-scope acceptance, verification, or rendered evidence for a later turn, the EPIC is too large and must be split before dispatch.
 
 This means the planner is not selecting between arbitrary DAG nodes. It is mapping domain outcomes onto a fixed project pipeline.
 
-A single outcome normally traverses **several** stages. If shipping one feature requires a schema change, an API, a UI, an end-to-end test, a doc, and a commit, that is **one EPIC with a six-stage roster**, not six EPICs each assigned to one producer. Slicing an outcome along producer-specialty lines turns the EPIC list into a team roster and hides the outcome behind the pipeline. The planner's instinct should be to **lengthen the roster within one EPIC before adding a new EPIC**.
+A good EPIC is neither a whole-surface bucket nor a tiny checklist item. "Build Home" is usually too broad; "rename one button" is too small. "Establish the Home layout foundation", "build the Home header/navigation on that foundation", and "add the Home discovery rails with empty/loading/error evidence" can be separate dependent EPICs because each leaves a reviewable product layer that downstream producers can inspect and extend.
 
-A simple test for whether two items are one outcome or two: would a user say "ship it" after the first alone? If no, they belong to one outcome. Different **surfaces** of the same shipped feature — backend, frontend, doc, release — are not separate outcomes; different **shipped results** are.
+Do not split along producer specialty. If one product slice requires an API contract, game UI, rendered evidence, docs, and release prep, that is one EPIC with a longer roster. Split only when the product result itself has dependency-bearing layers that are worth reviewing independently and can be carried forward through `upstream` evidence.
 
 ## Methodology
 
@@ -44,6 +44,14 @@ Treat the request snapshot as plain markdown text. Do not depend on special head
 ### 3. Emit EPICs directly
 
 On an initial plan, emit downstream EPICs immediately starting at `EP-1--{kebab-outcome}`. On a re-plan, keep the result append-only by appending replacement EPICs after the existing list instead of rewriting old ones in place.
+
+Before emitting an EPIC, apply the producer-completion sizing test:
+
+- Can the current producer stage complete the EPIC's acceptance, verification, and evidence obligations in one Pair turn without planned self-deferral?
+- Is the result large enough to be reviewed as a product or contract layer, not just a microscopic edit?
+- If a later EPIC depends on this one, will `Prior tasks` / `Prior reviews` give the downstream producer enough concrete evidence to continue without rediscovering the same files from scratch?
+
+If the answer is no because the surface is too broad, split the surface into dependency-bearing EPICs and connect them with `upstream`. If the answer is no because the item is too small, fold it into the nearest meaningful EPIC.
 
 Keep one turn focused. A planner turn should usually emit only a few EPICs. The `next-action` line tells the orchestrator whether another planning turn will be needed **after the current batch of EPICs finishes executing**:
 
@@ -124,6 +132,8 @@ note: upstream EP-1--domain-agent-design must stay ahead at the same stage gates
 - `roster` uses only registered producers.
 - Every EPIC `roster` is a subsequence of the project's fixed global roster.
 - `upstream` is treated as a same-stage gate.
+- Each EPIC is producer-completable: it should not require planned self-deferral by the same producer to finish in-scope acceptance, verification, or evidence.
+- Large surfaces are split into dependency-bearing product layers, and downstream EPICs can consume upstream artifacts through `Prior tasks` / `Prior reviews`.
 - Blocked work goes to `Additional pairs required` instead of being emitted as fake executable EPICs.
 - Re-planning is append-only.
 - `next-action: continue` is used only for learned replanning (later EPIC shape truly depends on earlier execution); padding-style continuation is treated as a grading failure.
@@ -140,64 +150,51 @@ note: upstream EP-1--domain-agent-design must stay ahead at the same stage gates
 - Mutate an existing EPIC in place instead of appending a replacement.
 - Overfill one planning turn with a rushed batch of EPICs instead of leaving continuation work for later.
 - Include task file paths or `current` in planner output.
-- Slice one outcome into several EPICs along producer-specialty lines (one EPIC per surface or team). The same outcome traversing multiple stages is one EPIC with a longer roster.
+- Emit a whole-surface bucket such as "Build Home" when the producer would predictably need to checkpoint partial work for a later turn.
+- Slice one product layer into several EPICs along producer-specialty lines (one EPIC per API/UI/test/doc team). The same outcome slice traversing multiple stages is one EPIC with a longer roster.
 - Emit `next-action: continue` as padding ("I might need more later, not sure yet", "want more thinking time"). Continuation is for cases where execution evidence changes the later plan — not for reserving uncertainty. A pattern of continue turns that emit zero new EPICs trips the zero-emit safety and is a grading failure.
 - Ignore `Recent events` on a defer-to-end recall. The whole point of defer-to-end is that events.md now carries evidence the initial turn could not see.
 
 ## Examples (BAD / GOOD)
-
-Assume a web fullstack project whose registered roster is:
-
-```text
-db-migration-producer → backend-api-producer → frontend-ui-producer → e2e-test-producer → doc-producer → git-producer
-```
-
-The goal asks for a user profile page.
-
-### BAD — outcome sliced along producer-specialty lines
+Assume a visual-novel player project whose registered roster is:
 
 ```text
-EP-1--profile-schema
-- roster: db-migration-producer
-
-EP-2--profile-api
-- roster: backend-api-producer
-
-EP-3--profile-ui
-- roster: frontend-ui-producer
-
-EP-4--profile-tests
-- roster: e2e-test-producer
-
-EP-5--profile-docs
-- roster: doc-producer
-
-EP-6--profile-commit
-- roster: git-producer
+api-producer → game-producer → verification-producer → doc-producer
 ```
 
-All six EPICs serve the single outcome "user can view and edit their profile." The EPIC list has become a team roster — no single EPIC names a shippable result, and the planner has quietly redesigned the runtime's fixed stage order into per-EPIC micro-flows. Fold into one EPIC with a long roster.
+The goal asks for a production-grade Home route.
 
-### GOOD — one EPIC per outcome, long roster inside
+### BAD — whole-surface bucket that invites producer self-deferral
+
+```text
+EP-1--home-route
+- outcome: Rebuild Home layout, header, discovery rails, account entry points, motion, all states, rendered evidence, and docs.
+- upstream: none
+- roster: api-producer → game-producer → verification-producer → doc-producer
+```
+
+The outcome is meaningful but too broad for one `game-producer` turn. It predicts a partial implementation followed by "finish evidence/tests next time", which wastes tokens because the next producer has to rediscover the same Home files.
+
+### GOOD — dependent producer-completable outcome slices
 
 ```text
 EPICs (this turn):
 
-EP-1--user-profile-page
-- outcome: Ship the `/profile` page so a logged-in user can view and edit their display name, handle, and bio end-to-end.
+EP-1--home-layout-foundation
+- outcome: Establish the Home route's responsive layout foundation, shared surface rhythm, and baseline loading/empty/error containers with rendered smoke evidence.
 - upstream: none
-- why: .harness/cycle/user-request-snapshot.md:L12 "Users need a profile page to manage personal info."
-- roster: db-migration-producer → backend-api-producer → frontend-ui-producer → e2e-test-producer → doc-producer → git-producer
+- why: .harness/cycle/user-request-snapshot.md:L12 "Home should feel production-grade."
+- roster: game-producer → verification-producer
 
-EP-2--profile-avatar-upload
-- outcome: Let users upload an avatar image and render it on the profile page, using the S3 direct-upload pattern.
-- upstream: EP-1--user-profile-page
-- why: .harness/cycle/user-request-snapshot.md:L18 "Avatar upload must use S3 direct-upload."
-- roster: backend-api-producer → frontend-ui-producer → e2e-test-producer → doc-producer → git-producer
+EP-2--home-header-navigation
+- outcome: Build the Home header, search/account affordances, and navigation handoff on top of the established Home layout foundation.
+- upstream: EP-1--home-layout-foundation
+- why: .harness/cycle/user-request-snapshot.md:L15 "Navigation hierarchy should be clear."
+- roster: game-producer → verification-producer
 
 Remaining: none
 next-action: done
 Additional pairs required: none
 ```
 
-Each EPIC is **one shippable outcome traversing many stages**. EP-2 skips `db-migration-producer` (no schema change) — stages may be skipped, their relative order never changes. `upstream: EP-1--user-profile-page` is a **same-stage gate**: EP-2's `backend-api-producer` turn waits for EP-1's `backend-api-producer` turn, not for all of EP-1 to finish. EP-1 and EP-2 are two EPICs because they pass the "ship it alone?" test independently — the profile page is useful without avatar upload.
+Each EPIC is a producer-completable product layer, not a phase label. `upstream` ensures downstream producers receive prior task/review artifacts as evidence, so the header work can reuse the layout decisions instead of re-reading the whole route from scratch.

--- a/plugins/harness-loom/skills/harness-pair-dev/SKILL.md
+++ b/plugins/harness-loom/skills/harness-pair-dev/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: harness-pair-dev
-description: "Use when `/harness-pair-dev --add|--improve|--remove <pair-slug>` is invoked to author, revise, or remove a project-specific producer-reviewer pair inside a target harness. `--add` and `--improve` require `<pair-slug> \"<purpose>\"`; `--add` may use `--from <existing-pair-slug>` as a registered-pair source for template-first overlay. Every pair has at least one reviewer; reviewer-less cycle-end work belongs in a finalizer."
+description: "Use when `/harness-pair-dev` is invoked to author, revise, position, or remove a target project's producer-reviewer pair in `.harness/loom/`."
 argument-hint: "--add <pair-slug> \"<purpose>\" [--from <existing-pair-slug>] [--reviewer <slug> ...] [--before <pair-slug> | --after <pair-slug>] | --improve <pair-slug> \"<purpose>\" [--before <pair-slug> | --after <pair-slug>] | --remove <pair-slug>"
 user-invocable: true
 ---

--- a/plugins/harness-loom/skills/harness-pair-dev/examples/agents/harness-api-designer.md
+++ b/plugins/harness-loom/skills/harness-pair-dev/examples/agents/harness-api-designer.md
@@ -27,7 +27,7 @@ API Designer is a producer that designs one REST endpoint or a small bundle of r
 4. State authentication/authorization requirements plus rate-limit, pagination, and filtering rules.
 5. Compare against sibling endpoints to remove naming, field-casing, and error-format asymmetry.
 6. Include at least two request/response examples so the spec remains readable from the caller's perspective.
-7. Record unresolved decisions and implementation cautions under Remaining items.
+7. Record externally blocked or out-of-scope decisions under `Blocked or out-of-scope items`.
 
 ## Output Format
 
@@ -40,5 +40,5 @@ Files created: [{file path}]
 Files modified: [{file path}]
 Diff summary: {sections changed vs baseline, or "N/A"}
 Self-verification: {issues found and resolved during this cycle}
-Remaining items: [{items not yet done}]
+Blocked or out-of-scope items: [{item, reason}]
 ```

--- a/plugins/harness-loom/skills/harness-pair-dev/examples/agents/harness-blog-writer.md
+++ b/plugins/harness-loom/skills/harness-pair-dev/examples/agents/harness-blog-writer.md
@@ -40,5 +40,5 @@ Files created: [{file path}]
 Files modified: [{file path}]
 Diff summary: {sections changed vs baseline, or "N/A"}
 Self-verification: {issues found and resolved during this cycle}
-Remaining items: [{items not yet done}]
+Blocked or out-of-scope items: [{item, reason}]
 ```

--- a/plugins/harness-loom/skills/harness-pair-dev/examples/agents/harness-research-synthesizer.md
+++ b/plugins/harness-loom/skills/harness-pair-dev/examples/agents/harness-research-synthesizer.md
@@ -27,7 +27,7 @@ Research Synthesizer is a producer that reads multiple independent sources and g
 4. Write synthesis paragraphs and leave source-citation pointers beside every claim.
 5. Preserve outliers and minority positions in a dedicated section with context.
 6. Place a decision-maker summary at the front explaining what is known and what remains unknown.
-7. Leave follow-up research questions under Remaining items.
+7. Leave externally blocked or out-of-scope research questions under `Blocked or out-of-scope items`.
 
 ## Output Format
 
@@ -40,5 +40,5 @@ Files created: [{file path}]
 Files modified: [{file path}]
 Diff summary: {sections changed vs baseline, or "N/A"}
 Self-verification: {issues found and resolved during this cycle}
-Remaining items: [{items not yet done}]
+Blocked or out-of-scope items: [{item, reason}]
 ```

--- a/plugins/harness-loom/skills/harness-pair-dev/examples/agents/harness-test-writer.md
+++ b/plugins/harness-loom/skills/harness-pair-dev/examples/agents/harness-test-writer.md
@@ -26,7 +26,7 @@ Test Writer is a producer that authors unit tests for a new or recently changed 
 3. Inspect existing test conventions file layout, naming, framework and follow them exactly.
 4. Write the test file and keep every case deterministic through fixtures or setup choices.
 5. Run the local test runner and confirm every test either passes or fails for the intended reason.
-6. Leave regression risks or uncovered branches under Remaining items for the paired reviewer.
+6. Leave only externally blocked or out-of-scope regression risks under `Blocked or out-of-scope items` for the paired reviewer.
 
 ## Output Format
 
@@ -39,5 +39,5 @@ Files created: [{file path}]
 Files modified: [{file path}]
 Diff summary: {sections changed vs baseline, or "N/A"}
 Self-verification: {issues found and resolved during this cycle}
-Remaining items: [{items not yet done}]
+Blocked or out-of-scope items: [{item, reason}]
 ```

--- a/plugins/harness-loom/skills/harness-pair-dev/references/authoring/agent-authoring.md
+++ b/plugins/harness-loom/skills/harness-pair-dev/references/authoring/agent-authoring.md
@@ -102,7 +102,7 @@ Files created: [{file path}]
 Files modified: [{file path}]
 Diff summary: {sections changed vs baseline, or "N/A"}
 Self-verification: {issues found and resolved during this cycle}
-Remaining items: [{items not yet done}]
+Blocked or out-of-scope items: [{item, reason}]
 ```
 
 **Reviewer variant** — include these fields in this order:
@@ -118,7 +118,7 @@ Feedback: {short free-form rationale}
 - Evidence must cite disk paths plus line ranges. "I feel" or "looks good" is not evidence.
 - A pair producer's `Status` is self-report only. The paired reviewer `Verdict` is the Pair turn's load-bearing verdict source.
 - Producers must not emit reviewer verdict fields, and reviewers must not emit producer diff fields. That is role leakage.
-- Put non-obvious follow-up notes in producer `Remaining items`, reviewer `FAIL items`, or reviewer `Feedback`; do not add advisory routing fields. Domain-specific regression evidence may appear in the review body or `Feedback` when the pair skill asks for it, but it is not a generic runtime field.
+- Put non-obvious follow-up notes in producer `Blocked or out-of-scope items`, reviewer `FAIL items`, or reviewer `Feedback`; do not add advisory routing fields. `Blocked or out-of-scope items` may record only out-of-scope follow-up or externally blocked work; it must not defer in-scope acceptance, verification, or evidence that the current producer turn should complete. If a blocker prevents required in-scope acceptance, verification, or evidence, the producer returns `Status: FAIL` or `## Structural Issue`; it does not PASS by listing the blocker there. Domain-specific regression evidence may appear in the review body or `Feedback` when the pair skill asks for it, but it is not a generic runtime field.
 - Do not add `Escalation`-style fields. Structural escalation uses only the shared top-level `## Structural Issue` block from `harness-context`.
 
 **Meta-role exception** — a meta-role that does not leave task/review files, such as `harness-planner`, uses its own role-specific return fields: `EPICs (this turn)`, `Remaining`, `next-action`, and `Additional pairs required`. The `next-action` field on a meta-role is load-bearing (defer-to-end continuation grammar `continue|done`, defined in its pair skill), not an executor-side advisory. Planner agents do not emit `Status` or `Escalation`; they repair the plan by emitting replacement EPICs or by resolving with zero EPICs plus `next-action: done`. Any agent that uses this exception must say that it is a meta-role without task/review files in either the identity paragraph or the first principle so reviewers do not grade it with the standard Producer shape.
@@ -160,4 +160,4 @@ When a pair reviewer grades an agent with this rubric, it checks:
 - Describe orchestrator routing or state-writing procedures in the agent body; routing and state belong only to the orchestrator.
 - Duplicate the pair skill body inside the agent; that creates two sources of truth and guarantees drift.
 - Use emojis as decoration.
-- Add advisory routing fields such as `Suggested next-work`, `Advisory-next`, `Regression gate`, or `Escalation`; use role body, `Remaining items`, `Feedback`, or `## Structural Issue` instead.
+- Add advisory routing fields such as `Suggested next-work`, `Advisory-next`, `Regression gate`, or `Escalation`; use role body, `Blocked or out-of-scope items`, `Feedback`, or `## Structural Issue` instead.

--- a/plugins/harness-loom/skills/harness-pair-dev/templates/producer-agent.md
+++ b/plugins/harness-loom/skills/harness-pair-dev/templates/producer-agent.md
@@ -35,5 +35,5 @@ Files created: [{file path}]
 Files modified: [{file path}]
 Diff summary: {sections changed vs baseline, or "N/A"}
 Self-verification: {issues found and resolved during this cycle}
-Remaining items: [{items not yet done}]
+Blocked or out-of-scope items: [{item, reason}]
 ```

--- a/tests/auto-setup-skill-anchors.test.mjs
+++ b/tests/auto-setup-skill-anchors.test.mjs
@@ -1,0 +1,41 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { REPO_ROOT } from "./helpers.mjs";
+
+const AUTO_SETUP_SKILL = join(
+  REPO_ROOT,
+  "plugins/harness-loom/skills/harness-auto-setup/SKILL.md",
+);
+const SNAPSHOT_REFERENCE = join(
+  REPO_ROOT,
+  "plugins/harness-loom/skills/harness-auto-setup/references/snapshot-provenance.md",
+);
+
+test("harness-auto-setup skill points schema details to snapshot provenance reference", () => {
+  const body = readFileSync(AUTO_SETUP_SKILL, "utf8");
+  assert.ok(existsSync(SNAPSHOT_REFERENCE), "snapshot provenance reference must exist");
+  assert.match(body, /references\/snapshot-provenance\.md/);
+  assert.match(body, /If snapshot creation fails, stop before running install or deleting anything\./);
+});
+
+test("snapshot provenance reference preserves manifest and namespace contract", () => {
+  const body = readFileSync(SNAPSHOT_REFERENCE, "utf8");
+  for (const key of [
+    "schemaVersion",
+    "tool",
+    "targetPath",
+    "createdAt",
+    "snapshotPath",
+    "copiedNamespaces",
+    "activeCycle",
+    "registrySummary",
+    "finalizerSummary",
+    "nextAction",
+  ]) {
+    assert.match(body, new RegExp(`\`${key}\``), `missing manifest key ${key}`);
+  }
+  assert.match(body, /copiedNamespaces` must be sorted/);
+  assert.match(body, /Do not copy derived platform trees by default/);
+});

--- a/tests/auto-setup.test.mjs
+++ b/tests/auto-setup.test.mjs
@@ -87,7 +87,7 @@ function assertReconstructedProducerAgent(body, { pair, skill, producer }) {
   assert.match(body, /Files modified: \[\{file path\}\]/);
   assert.match(body, /Diff summary: \{sections changed vs baseline, or "N\/A"\}/);
   assert.match(body, /Self-verification: \{issues found and resolved during this cycle\}/);
-  assert.match(body, /Remaining items: \[\{items not yet done\}\]/);
+  assert.match(body, /Blocked or out-of-scope items: \[\{item, reason\}\]/);
   assert.doesNotMatch(body, /Suggested next-work|Advisory-next|Regression gate|Escalation/);
   assert.doesNotMatch(body, /Verdict: PASS \/ FAIL/);
 }
@@ -432,7 +432,7 @@ test("auto-setup reconstructs customized finalizer on current skeleton", () => {
     assert.match(currentFinalizer, /Files left alone \(intentionally\)/);
     assert.match(currentFinalizer, /Status: PASS \/ FAIL/);
     assert.match(currentFinalizer, /Self-verification:/);
-    assert.match(currentFinalizer, /Remaining items: \[\{items not yet done\}\]/);
+    assert.match(currentFinalizer, /Blocked or out-of-scope items: \[\{item, reason\}\]/);
     assert.match(currentFinalizer, /## Structural Issue/);
     assert.match(currentFinalizer, /Suspected upstream stage:\s*planner/i);
     assert.doesNotMatch(currentFinalizer, /^(Suggested next-work|Advisory-next|Regression gate|Escalation):/m);

--- a/tests/finalizer-install.test.mjs
+++ b/tests/finalizer-install.test.mjs
@@ -138,6 +138,8 @@ test("installed harness-finalizer body exposes the load-bearing contract section
     // for the Finalizer turn).
     assert.match(body, /Status:\s*PASS\s*\/\s*FAIL/);
     assert.match(body, /Self-verification:/);
+    assert.match(body, /Blocked or out-of-scope items:\s*\[\{item, reason\}\]/);
+    assert.doesNotMatch(body, /Remaining items:/);
 
     // Structural Issue block with planner upstream stage — the Finalizer's
     // only retreat trigger.

--- a/tests/role-output-surface-anchors.test.mjs
+++ b/tests/role-output-surface-anchors.test.mjs
@@ -48,7 +48,7 @@ const PRODUCER_BLOCK = [
   "Files modified: [{file path}]",
   'Diff summary: {sections changed vs baseline, or "N/A"}',
   "Self-verification: {issues found and resolved during this cycle}",
-  "Remaining items: [{items not yet done}]",
+  "Blocked or out-of-scope items: [{item, reason}]",
 ].join("\n");
 
 const REVIEWER_BLOCK = [
@@ -144,6 +144,16 @@ test("agent authoring guidance pins reduced pair surfaces and role exceptions", 
   assert.equal(codeBlockAfter(rules, "**Reviewer variant**"), REVIEWER_BLOCK);
   assert.match(rules, /A pair producer's `Status` is self-report only/);
   assert.match(rules, /The paired reviewer `Verdict` is the Pair turn's load-bearing verdict source/);
+  assert.match(
+    rules,
+    /must not defer in-scope acceptance, verification, or evidence/,
+    "producer blocked/out-of-scope field must not authorize self-deferral",
+  );
+  assert.match(
+    rules,
+    /returns `Status: FAIL` or `## Structural Issue`; it does not PASS by listing the blocker there/,
+    "producer authoring rules must fail or structurally escalate required-scope blockers",
+  );
   assert.match(rules, /Planner agents do not emit `Status` or `Escalation`/);
   assert.match(rules, /`next-action` field on a meta-role is load-bearing/);
   assert.match(rules, /Its own `Status: PASS \| FAIL` plus `Self-verification` block is the verdict/);
@@ -168,7 +178,7 @@ test("planner and finalizer templates preserve load-bearing fields and omit lega
 
   assert.match(finalizerBlock, /^Status: PASS \/ FAIL$/m);
   assert.match(finalizerBlock, /^Self-verification:/m);
-  assert.match(finalizerBlock, /^Remaining items:/m);
+  assert.match(finalizerBlock, /^Blocked or out-of-scope items:/m);
   assert.doesNotMatch(finalizerBlock, /^Verdict:|^Criteria:|^FAIL items:|^Escalation:/m);
   assert.match(finalizer, /Optional line: inside the fenced block, include `Files left alone \(intentionally\)/);
 
@@ -189,7 +199,7 @@ test("runtime contracts reject advisory routing fields and keep Structural Issue
   assert.match(orchestrate, /synthesizes the real `Next` from reviewer verdicts, planner `next-action`, finalizer `Status`, and `## Structural Issue`/);
   assert.match(orchestrate, /`## Structural Issue` is the only structural escalation surface/);
   assert.match(context, /Add advisory or escalation routing fields/);
-  assert.match(context, /use `Remaining items`, `Feedback`, or `## Structural Issue` according to role/);
+  assert.match(context, /use `Blocked or out-of-scope items`, `Feedback`, or `## Structural Issue` according to role/);
 
   assertNoLegacyFieldLines(orchestrate, "orchestrate template");
   assertNoLegacyFieldLines(context, "context template");

--- a/tests/runtime-template-anchors.test.mjs
+++ b/tests/runtime-template-anchors.test.mjs
@@ -296,6 +296,16 @@ test("dispatch envelope defines role-specific minimum fields without forwarding 
     assert.ok(pair.includes(token), `pair envelope must include ${token}`);
   }
   assert.match(pair, /reviewer-only `Axis`/);
+  assert.match(
+    pair,
+    /upstream dependency evidence/,
+    "pair envelope must treat prior artifacts as upstream dependency evidence",
+  );
+  assert.match(
+    pair,
+    /producers must carry forward those decisions/,
+    "pair envelope must tell producers to reuse supplied upstream artifacts",
+  );
 
   for (const token of [
     "`Existing EPICs`",
@@ -333,6 +343,35 @@ test("harness-context stays subagent-facing and omits orchestrator routing law",
   assert.doesNotMatch(body, /planner-continuation:/);
 });
 
+test("pair context forbids producer self-deferral and requires upstream artifact use", () => {
+  const body = readFileSync(CONTEXT_TEMPLATE, "utf8");
+  assert.match(
+    body,
+    /attempt-to-completion/,
+    "producer context must require attempt-to-completion inside scope",
+  );
+  assert.match(
+    body,
+    /`Blocked or out-of-scope items` may record only external blockers or work outside the current scope/,
+    "producer context must forbid self-deferral through blocked/out-of-scope items",
+  );
+  assert.match(
+    body,
+    /return `Status: FAIL` or `## Structural Issue`; do not PASS by listing the blocker/,
+    "producer context must not allow PASS when a blocker prevents required scope work",
+  );
+  assert.match(
+    body,
+    /When `Prior tasks` or `Prior reviews` are supplied, read them before editing/,
+    "producer context must require reading prior dependency artifacts",
+  );
+  assert.match(
+    body,
+    /FAIL a producer that ignores supplied upstream EPIC artifacts/,
+    "reviewer context must fail ignored upstream artifacts",
+  );
+});
+
 test("orchestrate template gates dispatch through a ready set at the same global roster position", () => {
   const body = readFileSync(ORCHESTRATE_TEMPLATE, "utf8");
   assert.ok(
@@ -342,6 +381,11 @@ test("orchestrate template gates dispatch through a ready set at the same global
   assert.ok(
     body.includes("same global roster position"),
     "orchestrate template must state upstream gating happens at the same global roster position",
+  );
+  assert.match(
+    body,
+    /upstream EPIC task\/review artifacts/,
+    "orchestrate template must attach upstream task/review artifacts to ready pair dispatches",
   );
 });
 
@@ -368,6 +412,21 @@ test("planning template teaches global roster subsequence and next-action gramma
     /defer-to-end|after .* terminal/i,
     "planning template must describe continue as defer-to-end, not immediate recall",
   );
+  assert.match(
+    body,
+    /producer-completable/,
+    "planning template must size EPICs for producer-completable outcomes",
+  );
+  assert.match(
+    body,
+    /without planned self-deferral/,
+    "planning template must reject planned producer self-deferral",
+  );
+  assert.match(
+    body,
+    /home-layout-foundation/,
+    "planning examples must show dependent Home slices instead of one broad Home EPIC",
+  );
 });
 
 test("planning template distinguishes structural-issue recall from defer-to-end recall", () => {
@@ -393,6 +452,16 @@ test("planner agent template exposes next-action as load-bearing", () => {
     body.includes("defer-to-end"),
     "planner description must mention defer-to-end so authors do not expect next-turn recall",
   );
+  assert.match(
+    body,
+    /producer-completable outcome EPICs/,
+    "planner agent must name producer-completable EPICs",
+  );
+  assert.match(
+    body,
+    /producer-completion sizing test/,
+    "planner agent must apply the producer-completion sizing test",
+  );
 });
 
 test("finalizer template is a safe-no-op cycle-end agent with Status + Structural Issue", () => {
@@ -416,6 +485,7 @@ test("finalizer template is a safe-no-op cycle-end agent with Status + Structura
   // Output Format must carry Status + Self-verification.
   assert.match(body, /Status:\s*PASS\s*\/\s*FAIL/);
   assert.match(body, /Self-verification:/);
+  assert.match(body, /Blocked or out-of-scope items:\s*\[\]/);
   // Structural Issue block retreats to planner — finalizer's only retreat target.
   assert.match(body, /## Structural Issue/);
   assert.match(body, /Suspected upstream stage:\s*planner/i);


### PR DESCRIPTION
## Summary

- size planner EPICs around producer-completable outcome slices and carry upstream task/review evidence through pair dispatch
- replace producer/finalizer `Remaining items` with `Blocked or out-of-scope items` and forbid PASS-by-blocker self-deferral
- shorten `harness-pair-dev` trigger metadata and move auto-setup snapshot schema details into a dedicated reference

## Issues

- Closes #23
- Refs #21 as an incremental cold-read mitigation; this PR does not implement EPIC-per-turn execution.

## Validation

- `node --test tests/runtime-template-anchors.test.mjs tests/role-output-surface-anchors.test.mjs tests/finalizer-install.test.mjs tests/auto-setup.test.mjs tests/install.test.mjs tests/pair-dev.test.mjs tests/auto-setup-skill-anchors.test.mjs`
- `git diff --check`

## Notes

- `.harness` live staging was intentionally left untouched for separate adjustment.
- Existing local `.gitignore` and `request.md` changes were not included in this PR.