### PR TITLE
[codex] Split auto-setup modes and sync docs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Weave Producer-Reviewer agent harnesses with auto-execution hooks and self-improving skill loops.",
-    "version": "0.3.0"
+    "version": "0.3.1"
   },
   "plugins": [
     {
       "name": "harness-loom",
       "source": "./plugins/harness-loom",
       "description": "Producer-Reviewer harness generator for Claude Code, Codex CLI, and Gemini CLI.",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "tags": ["harness", "agent-team", "producer-reviewer", "orchestration", "multi-platform"],
       "category": "productivity"
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,25 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.3.1] — 2026-04-24
+
 ### Changed
 
+- **`/harness-auto-setup` now splits setup from migration.** The
+  command accepts `--setup` (default) for author-first bootstrap and
+  intentional improvement, and `--migration` for minimal-delta upgrades
+  of an existing harness. Setup mode now authors repo-grounded starter
+  pairs/finalizer work in one run when signals exist; migration mode
+  preserves pair/finalizer guidance where possible while refreshing
+  contract-owned runtime surfaces such as frontmatter, required
+  `skills:`, Output Format blocks, and the finalizer Structural Issue
+  contract.
+- **`/harness-pair-dev --add --from` now accepts non-live source
+  locators.** In addition to a current live pair slug, `--from` now
+  accepts target-local `snapshot:<ts>/<pair>` and
+  `archive:<ts>/<pair>` locators so migration flows can reuse preserved
+  pair intent without routing arbitrary filesystem paths through the
+  pair-authoring surface.
 - **Planner EPIC sizing now targets producer-completable outcome
   slices.** `harness-planning` now tells the planner to split broad
   surfaces into dependency-bearing EPICs when one producer would
@@ -648,7 +665,8 @@ First public release.
 - **Repo scaffolding** — README, CONTRIBUTING, SECURITY,
   CODE_OF_CONDUCT, PRIVACY, TERMS, and `.github/` issue + PR templates.
 
-[Unreleased]: https://github.com/KingGyuSuh/harness-loom/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/KingGyuSuh/harness-loom/compare/v0.3.1...HEAD
+[0.3.1]: https://github.com/KingGyuSuh/harness-loom/releases/tag/v0.3.1
 [0.3.0]: https://github.com/KingGyuSuh/harness-loom/releases/tag/v0.3.0
 [0.2.2]: https://github.com/KingGyuSuh/harness-loom/releases/tag/v0.2.2
 [0.2.1]: https://github.com/KingGyuSuh/harness-loom/releases/tag/v0.2.1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,10 @@ To use the plugin against a scratch project:
 mkdir /tmp/scratch && cd /tmp/scratch
 claude --plugin-dir /absolute/path/to/harness-loom
 # then in Claude Code:
-/harness-init
+/harness-auto-setup --setup --provider claude
+# then in the shell at the same target root:
+node .harness/loom/sync.ts --provider claude
+# then back in Claude Code if you want to grow the harness:
 /harness-pair-dev --add harness-sample "scratch test"
 ```
 
@@ -40,6 +43,7 @@ plugins/
     assets/                         # logos referenced by plugin.json
     skills/
       harness-init/                 # /harness-init (user-invocable)
+      harness-auto-setup/           # /harness-auto-setup (user-invocable)
       harness-pair-dev/             # /harness-pair-dev (user-invocable)
       harness-init/references/runtime/   # target-side runtime templates (`*.template.md`)
 tests/                              # node:test integration suite
@@ -80,7 +84,7 @@ project it initializes, and `gemini` auto-loads that workspace-scope tree.
 1. **Fork and branch.** Follow the naming rules above (e.g. `feat/pair-hint-flag`, `fix/codex-toml-schema`).
 2. **Run the test suite.**
    ```bash
-   node --test tests/*.test.mjs
+   node --test tests/*.mjs
    ```
    The suite spins up temp directories, runs `install.ts` / `sync.ts` /
    `register-pair.ts` / `hook.sh` against them, and asserts on the

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [English](README.md) | [한국어](docs/README.ko.md) | [日本語](docs/README.ja.md) | [简体中文](docs/README.zh-CN.md) | [Español](docs/README.es.md)
 
-[![Version](https://img.shields.io/badge/version-0.3.0-blue.svg)](./CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.3.1-blue.svg)](./CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](./LICENSE)
 [![Platforms](https://img.shields.io/badge/platforms-Claude%20Code%20%7C%20Codex%20%7C%20Gemini-purple.svg)](#multi-platform)
 
@@ -67,7 +67,7 @@ target project
 
 Project documentation (target-root `*.md` files, `docs/`) is authored **directly in the target**, not inside `.harness/`. You then derive at least one platform tree with `node .harness/loom/sync.ts --provider claude` (and add `codex,gemini` for multi-platform), then add domain-specific pairs with `/harness-pair-dev`. The install scaffold does not create request snapshots. On direct `/harness-orchestrate <file.md>` entry, the orchestrator preserves the full request body in `.harness/cycle/user-request-snapshot.md` and keeps `state.md`'s `Goal` header as a compact summary. The orchestrator runs as a four-state DFA — `Planner | Pair | Finalizer | Halt`. When every EPIC reaches terminal and no planner continuation remains, it enters the **Finalizer state** and dispatches the singleton `harness-finalizer` agent before halting. The seeded `harness-finalizer` agent is a generic skeleton; you replace its body with the concrete cycle-end work this project needs — documentation refresh (`CLAUDE.md`, `AGENTS.md`, `docs/`), request-coverage inspection against `events.md` and the user request snapshot, release prep, audit output, etc. You do not invoke the finalizer directly; the orchestrator dispatches it as the cycle-end turn before halting.
 
-`/harness-auto-setup` is the safer entry point for first setup or refresh. On a fresh target it seeds the foundation and emits repo-grounded pair/finalizer recommendations. On an existing target it snapshots live `.harness/loom/` and `.harness/cycle/` state under `.harness/_snapshots/auto-setup/<timestamp>/`, warns when the cycle looks active or unknown, refreshes the foundation, reconstructs valid registered pairs and customized finalizer intent on current templates, and stops with an explicit sync command. It never writes `.claude/`, `.codex/`, or `.gemini/` itself.
+`/harness-auto-setup` is the safer entry point for first setup, improvement, or migration. `--setup` (the default) bootstraps a fresh target or intentionally improves an existing harness; when repo signals exist, it authors usable starter pairs/finalizer work in one run instead of stopping at recommendations. `--migration` is for minimal-delta upgrades: it snapshots live `.harness/loom/` and `.harness/cycle/`, refreshes the foundation, preserves pair/finalizer guidance where possible, and rewrites only the contract-owned runtime surface. It never writes `.claude/`, `.codex/`, or `.gemini/` itself.
 
 ## Requirements
 
@@ -83,7 +83,7 @@ Project documentation (target-root `*.md` files, `docs/`) is authored **directly
 There are two installs in practice:
 
 1. Install the **factory plugin** into Claude Code or Codex CLI.
-2. Inside each target repository, run `/harness-auto-setup` to seed or converge `.harness/`, then `node .harness/loom/sync.ts --provider <list>` to deploy the assistant-specific runtime trees you actually want to use.
+2. Inside each target repository, run `/harness-auto-setup --setup` (or `--migration` for minimal-delta upgrades of an existing harness) to seed or converge `.harness/`, then `node .harness/loom/sync.ts --provider <list>` to deploy the assistant-specific runtime trees you actually want to use.
 
 The factory ships in the standard `plugins/<name>/` monorepo layout — the repo root holds `.claude-plugin/marketplace.json` and `.agents/plugins/marketplace.json`, and the actual plugin tree lives under `plugins/harness-loom/`.
 
@@ -139,7 +139,7 @@ Then, inside the Codex TUI, run `/plugins`, open the `Harness Loom` marketplace 
 
 Use Claude Code or Codex CLI to install the factory, then derive `.gemini/` inside the target project:
 
-1. From Claude Code or Codex CLI, install the factory and run `/harness-auto-setup --provider gemini`, then `node .harness/loom/sync.ts --provider gemini` inside your target project. This deploys the target-side runtime (`.harness/loom/`, `.harness/cycle/`, `.gemini/agents/`, `.gemini/skills/`, `.gemini/settings.json` with `AfterAgent` hook).
+1. From Claude Code or Codex CLI, install the factory and run `/harness-auto-setup --setup --provider gemini`, then `node .harness/loom/sync.ts --provider gemini` inside your target project. This deploys the target-side runtime (`.harness/loom/`, `.harness/cycle/`, `.gemini/agents/`, `.gemini/skills/`, `.gemini/settings.json` with `AfterAgent` hook).
 2. `cd` into that target project and run `gemini`. The CLI auto-loads workspace-scope `.gemini/agents/*.md`, `.gemini/skills/<slug>/SKILL.md`, and the `AfterAgent` hook from `.gemini/settings.json`.
 3. Your orchestrator cycle runs on Gemini end-to-end — factory authoring remains on Claude/Codex, execution can be any of the three.
 
@@ -147,7 +147,7 @@ Use Claude Code or Codex CLI to install the factory, then derive `.gemini/` insi
 
 Once the factory is installed in your assistant, the usual target-repo flow is:
 
-1. Seed or converge `.harness/` with `/harness-auto-setup`.
+1. Seed, improve, or migrate `.harness/` with `/harness-auto-setup --setup` or `/harness-auto-setup --migration`.
 2. Deploy at least one assistant runtime tree with `sync.ts`.
 3. Add the first producer-reviewer pairs for your repo.
 4. Optionally customize the cycle-end finalizer.
@@ -158,16 +158,24 @@ Once the factory is installed in your assistant, the usual target-repo flow is:
 Open the target repository in Claude Code or Codex CLI and run:
 
 ```text
-/harness-auto-setup --provider claude
+/harness-auto-setup --setup --provider claude
 ```
 
 Use a comma-separated provider list when you know the platform trees you will refresh:
 
 ```text
-/harness-auto-setup --provider claude,codex,gemini
+/harness-auto-setup --setup --provider claude,codex,gemini
 ```
 
-This seeds a fresh target through the foundation installer. If the target already has `.harness/loom/` or `.harness/cycle/`, it snapshots those namespaces before refresh, preserves active or unparsable cycle state in the snapshot before discard/reseed, rebuilds valid registered pair files and customized finalizer intent from current templates, and prints the exact `node .harness/loom/sync.ts --provider <list>` command to run next. The snapshot is machine provenance and convergence evidence, not a restored source of truth.
+`--setup` seeds a fresh target through the foundation installer and, when repo signals exist, authors a usable starter pair roster/finalizer instead of leaving only recommendations. If the target already has `.harness/loom/` or `.harness/cycle/`, it snapshots those namespaces before refresh, preserves active or unparsable cycle state in the snapshot before discard/reseed, rebuilds valid registered pair files and customized finalizer intent from current templates, and prints the exact `node .harness/loom/sync.ts --provider <list>` command to run next.
+
+When you want a minimal-delta upgrade of an existing harness instead of author-first improvement, run:
+
+```text
+/harness-auto-setup --migration --provider claude
+```
+
+Migration mode preserves user-authored pair/finalizer guidance where possible and refreshes contract-owned surfaces such as required frontmatter, `skills:`, Output Format blocks, and the finalizer Structural Issue contract. The snapshot remains machine provenance and migration evidence, not a restored source of truth.
 
 If you only want a foundation reset with no convergence, run:
 
@@ -177,7 +185,7 @@ If you only want a foundation reset with no convergence, run:
 
 This writes the canonical staging tree under `.harness/loom/` and the runtime state scaffold under `.harness/cycle/`. It seeds `state.md`, `events.md`, `epics/`, and `finalizer/tasks/`; it does not create goal/request snapshot placeholders, `.claude/`, `.codex/`, or `.gemini/`.
 
-If you rerun `/harness-init` later, treat it as a reset of the target-side harness scaffolding: pair-authored `.harness/loom/` content and the current `.harness/cycle/` state are reseeded rather than preserved. Use `/harness-auto-setup` for existing targets when you want snapshot-first refresh and current-contract reconstruction.
+If you rerun `/harness-init` later, treat it as a reset of the target-side harness scaffolding: pair-authored `.harness/loom/` content and the current `.harness/cycle/` state are reseeded rather than preserved. Use `/harness-auto-setup --setup` when you want author-first refresh or improvement, and `/harness-auto-setup --migration` when you want snapshot-first minimal-delta contract refresh.
 
 ### 2. Deploy The Assistant Runtime You Actually Want To Use
 
@@ -270,9 +278,9 @@ A few terms recur across commands, files, and state. Knowing these is enough to 
 | Command | Purpose |
 |---------|---------|
 | `/harness-init` | Scaffold the canonical `.harness/loom/` staging tree plus the `.harness/cycle/` runtime state into the current working directory. Writes runtime skills, the `harness-planner` agent, the generic `harness-finalizer` cycle-end skeleton, and the `hook.sh` + `sync.ts` self-contained copies under `.harness/loom/`. Seeds `state.md`, `events.md`, `epics/`, and `finalizer/tasks/`, but no goal or request snapshot placeholder. Rerunning install reseeds both namespaces. Touches no platform tree. |
-| `/harness-auto-setup [--provider <list>]` | Safely set up or refresh the current working directory's harness. Fresh targets receive the foundation plus repo-grounded pair/finalizer recommendations. Existing targets are snapshotted under `.harness/_snapshots/auto-setup/`, active or unknown cycles are warned and preserved in the snapshot before discard/reseed, registered pairs and customized finalizer intent are reconstructed on current templates, and the command stops with an explicit sync handoff. Touches no platform tree. |
+| `/harness-auto-setup [--setup \| --migration] [--provider <list>]` | Safely set up, improve, or migrate the current working directory's harness. `--setup` (default) bootstraps fresh targets and intentionally improves existing harnesses, authoring repo-grounded starter pairs/finalizer work in one run when signals exist. `--migration` performs a minimal-delta upgrade for existing harnesses: snapshot first, refresh the foundation, then preserve pair/finalizer guidance while rewriting only contract-owned runtime surfaces. Both modes stop with an explicit sync handoff and touch no platform tree. |
 | `node .harness/loom/sync.ts --provider <list>` | Deploy canonical `.harness/loom/` into platform trees (`.claude/`, `.codex/`, `.gemini/`). One-way; never writes back into `.harness/loom/`. Provider selection is explicit: a bare invocation with no provider flags is an error. Claude keeps agent `skills:` frontmatter; Codex and Gemini receive required skill-loading prompts in generated agent bodies. |
-| `/harness-pair-dev --add <slug> "<purpose>" [--from <existing-pair>] [--reviewer <slug> ...] [--before <slug> \| --after <slug>]` | Author a new producer-reviewer pair anchored to the current codebase. `<purpose>` is required. `--from` accepts only a currently registered pair as a template-first overlay source: current harness shape stays fixed while compatible source domain guidance is preserved. It is not a snapshot, filesystem path, or provider-tree import. Default is 1:1; repeat `--reviewer` for 1:N reviewer topology. Authoring writes only into `.harness/loom/`; re-run `node .harness/loom/sync.ts --provider <list>` afterward. |
+| `/harness-pair-dev --add <slug> "<purpose>" [--from <source>] [--reviewer <slug> ...] [--before <slug> \| --after <slug>]` | Author a new producer-reviewer pair anchored to the current codebase. `<purpose>` is required. `--from` accepts either a currently registered live pair slug or a target-local `snapshot:<ts>/<pair>` / `archive:<ts>/<pair>` locator as the template-first overlay source: current harness shape stays fixed while compatible source domain guidance is preserved. It is not an arbitrary filesystem path or provider-tree import. Default is 1:1; repeat `--reviewer` for 1:N reviewer topology. Authoring writes only into `.harness/loom/`; re-run `node .harness/loom/sync.ts --provider <list>` afterward. |
 | `/harness-pair-dev --improve <slug> "<purpose>" [--before <slug> \| --after <slug>]` | Improve an existing registered pair with positional `<purpose>` as the primary revision axis, then fold in rubric hygiene and current repo evidence. If a pair has become two different jobs, use explicit add/improve/remove steps. Re-run sync afterward to refresh platform trees. |
 | `/harness-pair-dev --remove <slug>` | Safely unregister a pair and delete only pair-owned `.harness/loom/` files. Removal refuses foundation/singleton targets and active-cycle references in `## Next` or live EPIC roster/current fields before mutating, preserves `.harness/cycle/` task/review history, and touches no provider tree; re-run sync afterward. |
 | `/harness-orchestrate <file.md>` | Target-side runtime entry point. Reads the request file, preserves its full body in `.harness/cycle/user-request-snapshot.md`, and runs a four-state DFA (`Planner | Pair | Finalizer | Halt`) dispatching exactly one producer per response; hook re-entry advances the cycle from `state.md` and the existing snapshot path. When every EPIC reaches terminal and planner continuation is clear, the orchestrator enters the Finalizer state and dispatches the singleton `harness-finalizer` before halting. |

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -4,7 +4,7 @@
 
 [English](../README.md) | [한국어](README.ko.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md) | [Español](README.es.md)
 
-[![Version](https://img.shields.io/badge/version-0.3.0-blue.svg)](../CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.3.1-blue.svg)](../CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](../LICENSE)
 [![Platforms](https://img.shields.io/badge/platforms-Claude%20Code%20%7C%20Codex%20%7C%20Gemini-purple.svg)](../README.md#multi-platform)
 
@@ -12,7 +12,7 @@
 
 <br clear="left" />
 
-> **Estado:** 0.3.0
+> **Estado:** 0.3.1
 
 ## Resumen actual
 
@@ -24,14 +24,14 @@
 
 ## Comandos principales
 
-- `/harness-auto-setup [--provider <list>]`
-  Configura por primera vez el directorio de trabajo actual o actualiza un harness existente después de tomar un snapshot.
+- `/harness-auto-setup [--setup | --migration] [--provider <list>]`
+  Configura, mejora o migra de forma segura el harness del directorio actual. `--setup` (por defecto) sirve para bootstrap de un fresh target o para intentional improvement de un harness existente; `--migration` sirve para una actualización snapshot-first minimal-delta sobre un harness existente.
 - `/harness-init`
   Instala o reinicia el runtime base de `.harness/loom/` y `.harness/cycle/` dentro del directorio de trabajo actual.
 - `node .harness/loom/sync.ts --provider claude,codex,gemini`
   Despliega el canonical staging hacia los árboles de plataforma necesarios.
-- `/harness-pair-dev --add <slug> "<purpose>" [--from <existing-pair>] [--reviewer <slug> ...]`
-  Usa sólo un pair actualmente registrado como overlay source de `--from` y crea el nuevo pair en `.harness/loom/` preservando el conocimiento compatible sobre el template actual.
+- `/harness-pair-dev --add <slug> "<purpose>" [--from <source>] [--reviewer <slug> ...]`
+  `--from` acepta un live pair slug actualmente registrado o un locator target-local `snapshot:<ts>/<pair>` / `archive:<ts>/<pair>` como overlay source, y crea el nuevo pair en `.harness/loom/` preservando el conocimiento compatible sobre el template actual.
 - `/harness-pair-dev --improve <slug> "<purpose>"`
   Mejora un pair registrado usando el purpose posicional como eje principal.
 - `/harness-pair-dev --remove <slug>`

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -4,7 +4,7 @@
 
 [English](../README.md) | [한국어](README.ko.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md) | [Español](README.es.md)
 
-[![Version](https://img.shields.io/badge/version-0.3.0-blue.svg)](../CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.3.1-blue.svg)](../CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](../LICENSE)
 [![Platforms](https://img.shields.io/badge/platforms-Claude%20Code%20%7C%20Codex%20%7C%20Gemini-purple.svg)](../README.md#multi-platform)
 
@@ -12,7 +12,7 @@
 
 <br clear="left" />
 
-> **ステータス:** 0.3.0
+> **ステータス:** 0.3.1
 
 ## 現在の要点
 
@@ -24,14 +24,14 @@
 
 ## 主なコマンド
 
-- `/harness-auto-setup [--provider <list>]`
-  現在の作業ディレクトリを初期セットアップするか、既存 harness をスナップショットしてから現在の契約に合わせて更新します。
+- `/harness-auto-setup [--setup | --migration] [--provider <list>]`
+  現在の作業ディレクトリの harness を安全にセットアップ、改善、マイグレーションします。`--setup`（既定）は fresh target の bootstrap または既存 harness の intentional improvement 用で、`--migration` は既存 harness を snapshot-first minimal-delta で更新するためのモードです。
 - `/harness-init`
   現在の作業ディレクトリに `.harness/loom/` と `.harness/cycle/` ベースの基盤ランタイムを導入または再初期化します。
 - `node .harness/loom/sync.ts --provider claude,codex,gemini`
   canonical staging を必要なプラットフォームツリーへ配備します。
-- `/harness-pair-dev --add <slug> "<purpose>" [--from <existing-pair>] [--reviewer <slug> ...]`
-  現在登録されている pair だけを `--from` の overlay source として受け取り、最新 template 上で互換性のある元の知識を保ちながら `.harness/loom/` に作成します。
+- `/harness-pair-dev --add <slug> "<purpose>" [--from <source>] [--reviewer <slug> ...]`
+  `--from` は現在登録されている live pair slug または target-local `snapshot:<ts>/<pair>` / `archive:<ts>/<pair>` locator を overlay source として受け取り、最新 template 上で互換性のある元の知識を保ちながら `.harness/loom/` に作成します。
 - `/harness-pair-dev --improve <slug> "<purpose>"`
   positional purpose を主軸にして、既存の登録済み pair を改善します。
 - `/harness-pair-dev --remove <slug>`

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -4,7 +4,7 @@
 
 [English](../README.md) | [한국어](README.ko.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md) | [Español](README.es.md)
 
-[![Version](https://img.shields.io/badge/version-0.3.0-blue.svg)](../CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.3.1-blue.svg)](../CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](../LICENSE)
 [![Platforms](https://img.shields.io/badge/platforms-Claude%20Code%20%7C%20Codex%20%7C%20Gemini-purple.svg)](../README.md#multi-platform)
 
@@ -12,7 +12,7 @@
 
 <br clear="left" />
 
-> **상태:** 0.3.0
+> **상태:** 0.3.1
 
 ## 현재 기준 요약
 
@@ -24,14 +24,14 @@
 
 ## 핵심 명령
 
-- `/harness-auto-setup [--provider <list>]`
-  현재 작업 디렉터리를 처음 설정하거나, 기존 하네스를 스냅샷한 뒤 현재 계약에 맞게 갱신합니다.
+- `/harness-auto-setup [--setup | --migration] [--provider <list>]`
+  현재 작업 디렉터리의 하네스를 안전하게 설정, 향상, 마이그레이션합니다. `--setup`(기본값)은 fresh target bootstrap 또는 기존 하네스의 intentional improvement 용도이고, `--migration`은 기존 하네스를 snapshot-first minimal-delta 방식으로 올리는 용도입니다.
 - `/harness-init`
   현재 작업 디렉터리에 `.harness/loom/` 과 `.harness/cycle/` 기반 foundation runtime을 설치하거나 재설정합니다.
 - `node .harness/loom/sync.ts --provider claude,codex,gemini`
   canonical staging을 원하는 플랫폼 트리로 배포합니다.
-- `/harness-pair-dev --add <slug> "<purpose>" [--from <existing-pair>] [--reviewer <slug> ...]`
-  현재 등록된 pair만 `--from` overlay source로 받아 최신 template 위에 호환되는 원본 지식을 보존해 `.harness/loom/`에 작성합니다.
+- `/harness-pair-dev --add <slug> "<purpose>" [--from <source>] [--reviewer <slug> ...]`
+  `--from` 은 현재 등록된 live pair slug 또는 target-local `snapshot:<ts>/<pair>` / `archive:<ts>/<pair>` locator 를 overlay source 로 받아, 최신 template 위에 호환되는 원본 지식을 보존해 `.harness/loom/`에 작성합니다.
 - `/harness-pair-dev --improve <slug> "<purpose>"`
   positional purpose를 기준으로 기존 등록 pair를 개선합니다.
 - `/harness-pair-dev --remove <slug>`

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -4,7 +4,7 @@
 
 [English](../README.md) | [한국어](README.ko.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md) | [Español](README.es.md)
 
-[![Version](https://img.shields.io/badge/version-0.3.0-blue.svg)](../CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.3.1-blue.svg)](../CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](../LICENSE)
 [![Platforms](https://img.shields.io/badge/platforms-Claude%20Code%20%7C%20Codex%20%7C%20Gemini-purple.svg)](../README.md#multi-platform)
 
@@ -12,7 +12,7 @@
 
 <br clear="left" />
 
-> **状态：** 0.3.0
+> **状态：** 0.3.1
 
 ## 当前要点
 
@@ -24,14 +24,14 @@
 
 ## 关键命令
 
-- `/harness-auto-setup [--provider <list>]`
-  对当前工作目录做首次设置，或先快照已有 harness 再按当前契约刷新。
+- `/harness-auto-setup [--setup | --migration] [--provider <list>]`
+  安全地对当前工作目录的 harness 进行设置、增强或迁移。`--setup`（默认）用于 fresh target bootstrap 或现有 harness 的 intentional improvement，`--migration` 用于对现有 harness 做 snapshot-first minimal-delta 升级。
 - `/harness-init`
   在当前工作目录中安装或重置基于 `.harness/loom/` 与 `.harness/cycle/` 的基础运行时。
 - `node .harness/loom/sync.ts --provider claude,codex,gemini`
   将 canonical staging 部署到所需的平台树。
-- `/harness-pair-dev --add <slug> "<purpose>" [--from <existing-pair>] [--reviewer <slug> ...]`
-  只接受当前已注册的 pair 作为 `--from` overlay source，在最新 template 上保留兼容的原始知识并写入 `.harness/loom/`。
+- `/harness-pair-dev --add <slug> "<purpose>" [--from <source>] [--reviewer <slug> ...]`
+  `--from` 接受当前已注册的 live pair slug，或 target-local `snapshot:<ts>/<pair>` / `archive:<ts>/<pair>` locator 作为 overlay source，在最新 template 上保留兼容的原始知识并写入 `.harness/loom/`。
 - `/harness-pair-dev --improve <slug> "<purpose>"`
   以 positional purpose 为主轴改进已注册的 pair。
 - `/harness-pair-dev --remove <slug>`

--- a/plugins/harness-loom/.claude-plugin/plugin.json
+++ b/plugins/harness-loom/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "harness-loom",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Seed a planner + producer-reviewer pair harness into any repository, then grow it pair by pair.",
   "author": {
     "name": "KingGyuSuh",

--- a/plugins/harness-loom/.codex-plugin/plugin.json
+++ b/plugins/harness-loom/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "harness-loom",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Install and grow producer-reviewer harnesses for repository work.",
   "author": {
     "name": "KingGyuSuh",

--- a/plugins/harness-loom/skills/harness-auto-setup/SKILL.md
+++ b/plugins/harness-loom/skills/harness-auto-setup/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: harness-auto-setup
-description: "Use when `/harness-auto-setup` is invoked to safely install, refresh, or converge the current working directory's harness by snapshotting live `.harness/` state, preserving pair/finalizer intent as evidence, reseeding the foundation, and handing off explicit platform sync."
-argument-hint: "[--provider claude,codex,gemini]"
+description: "Use when `/harness-auto-setup` is invoked to safely bootstrap, improve, or migrate the current working directory's harness by snapshotting live `.harness/` state, reseeding the foundation, and handing off explicit platform sync."
+argument-hint: "[--setup | --migration] [--provider claude,codex,gemini]"
 user-invocable: true
 ---
 
@@ -24,15 +24,15 @@ Snapshots are machine provenance and convergence input, not restore sources. Old
 
 ### 1. Arguments
 
-`/harness-auto-setup [--provider <list>]`
+`/harness-auto-setup [--setup | --migration] [--provider <list>]`
 
-The workflow always targets the current working directory. Run `/harness-auto-setup` from the project root. `--provider` only shapes the printed sync handoff; sync itself is never run here.
+The workflow always targets the current working directory. Run `/harness-auto-setup` from the project root. `--setup` is the default mode and covers fresh bootstrap plus intentional improvement. `--migration` is for minimal-delta upgrades of an existing harness. `--provider` only shapes the printed sync handoff; sync itself is never run here.
 
 ### 2. Authority boundaries
 
 - `/harness-init` remains the foundation installer. Auto-setup may invoke it, but must not move pair/finalizer authoring into `harness-init`.
 - `/harness-pair-dev` remains the pair-authoring layer. Auto-setup may use existing pair files as evidence, but must author current pair outputs through the current templates, authoring rubric, and registry contract.
-- `/harness-pair-dev --add ... --from <existing-pair-slug>` is only for evidence from a pair already registered in the current target registry. Snapshot paths, agent/skill paths, and derived platform paths remain auto-setup convergence inputs, not pair-dev inputs.
+- `/harness-pair-dev --add ... --from <source>` remains the pair-source resolver. Live registered pair slugs, `snapshot:<ts>/<pair>`, and `archive:<ts>/<pair>` are valid sources; arbitrary filesystem paths and provider-tree paths are not.
 - `.harness/loom/registry.md` remains the pair roster SSOT. The planner and finalizer are never registry entries.
 - `harness-finalizer` remains a singleton cycle-end role. Reviewer-less cycle-end work belongs in `.harness/loom/agents/harness-finalizer.md`, not in `## Registered pairs`.
 - `node .harness/loom/sync.ts --provider <list>` remains an explicit user handoff after convergence. Auto-setup must not derive `.claude/`, `.codex/`, or `.gemini/` automatically.
@@ -73,7 +73,16 @@ For `active` or `unknown`, silent deletion is forbidden. The default policy is:
 
 This policy forbids silent destruction, not destruction itself.
 
-### 5. Existing target flow
+### 5. Mode split
+
+`harness-auto-setup` has two execution modes:
+
+- `--setup` — bootstrap a fresh target or intentionally improve an existing harness. This mode optimizes for "one run leaves a usable harness." It may author starter pairs/finalizer intent from repo signals, and it may rewrite pair/finalizer bodies on current templates when that improves harness usability.
+- `--migration` — upgrade an existing harness with the smallest reasonable blast radius. This mode optimizes for contract refresh and customization preservation. It updates contract-owned surfaces and reports manual-review ambiguity instead of aggressively rewriting user-authored guidance.
+
+Fresh targets may use only `--setup`. `--migration` requires existing `.harness/loom/` or `.harness/cycle/` state.
+
+### 6. Existing target flow
 
 When `.harness/loom/` exists, or `.harness/cycle/` exists without `.harness/loom/`:
 
@@ -82,47 +91,53 @@ When `.harness/loom/` exists, or `.harness/cycle/` exists without `.harness/loom
 3. Inspect pair agent/skill bodies when present and target repo evidence to infer current intent.
 4. Inspect snapshot `harness-finalizer.md` when present and decide whether it is missing, default no-op, or customized.
 5. Run `/harness-init` or its installer implementation to reseed the foundation.
-6. Reconstruct each known pair against the current pair templates and authoring rubric. Preserve topology and order from the old registry when valid.
-7. Preserve customized finalizer intent by rewriting it on the current finalizer skeleton and Output Format contract.
-8. Leave split/reorder decisions as recommendations unless the old registry already proves the intended topology.
-9. End with the exact sync handoff command the user should run from the target root.
+6. In `--setup`, reconstruct each known pair against the current pair templates and authoring rubric, or author fresh starter pairs if no pair roster exists.
+7. In `--migration`, preserve user-authored pair/finalizer bodies where possible while refreshing contract-owned surfaces such as runtime frontmatter, required `skills:`, and Output Format blocks.
+8. Preserve topology and order from the old registry when valid.
+9. Leave split/reorder decisions as recommendations unless the old registry already proves the intended topology.
+10. End with the exact sync handoff command the user should run from the target root.
 
 Old pair and finalizer files are evidence only. Do not blind-copy them over the refreshed foundation.
 
-If `.harness/cycle/` existed without `.harness/loom/`, there is no pair/finalizer source to converge; snapshot the cycle, reseed the foundation, then follow the fresh target repo-inspection rules.
+If `.harness/cycle/` existed without `.harness/loom/`, there is no pair/finalizer source to converge. Snapshot the cycle, reseed the foundation, then:
 
-### 6. Fresh target flow
+- in `--setup`, follow the fresh target repo-inspection rules
+- in `--migration`, preserve the cycle snapshot as evidence and report that no live loom source was available for pair/finalizer migration
+
+### 7. Fresh target flow
 
 When both `.harness/loom/` and `.harness/cycle/` are absent:
 
 1. Run `/harness-init` or its installer implementation to seed the foundation.
 2. Inspect the target repo before proposing project-specific harness work.
-3. Recommend or author an initial pair roster grounded in real repo surfaces.
-4. Recommend or author a concrete finalizer body when the repo has obvious cycle-end duties.
-5. Leave the finalizer as the safe no-op only when no concrete cycle-end duty is justified yet.
+3. In `--setup`, author an initial pair roster grounded in real repo surfaces when evidence exists; recommend only when the repo is effectively empty.
+4. In `--setup`, author a concrete finalizer body when the repo exposes a clear cycle-end duty; otherwise keep the safe no-op.
+5. `--migration` is invalid here because there is no existing harness state to preserve.
 6. End with the exact sync handoff command the user should run from the target root.
 
-Do not create generic stock pairs just to fill the registry. If repo evidence is insufficient, emit recommended `/harness-pair-dev --add` commands and leave the roster empty.
+Do not create evidence-free stock pairs just to fill the registry. If repo evidence is insufficient, emit recommended `/harness-pair-dev --add` commands and leave the roster empty.
 
-### 7. Pair convergence rules
+### 8. Pair convergence rules
 
 - Treat snapshot `registry.md` as a strong topology/order hint, not as immutable truth.
 - Registered producer, reviewer, and skill slugs should be preserved when they remain coherent with the target repo and current namespace rules.
 - Each pair must have at least one reviewer.
-- Missing or unparsable pair files do not block the whole workflow when registry intent plus repo evidence is enough to reconstruct the pair; record the gap in `manifest.json` and the user summary.
+- Missing or unparsable pair files do not block the whole workflow when registry intent plus repo evidence is enough to reconstruct or migrate the pair; record the gap in `manifest.json` and the user summary.
 - If a pair has clearly become two jobs, recommend a split instead of silently changing the roster.
 - If a pair belongs in a different global roster position, recommend a reorder instead of silently moving it unless the user supplied an explicit roster instruction.
-- Use `/harness-pair-dev --add ... --from <existing-pair-slug>` only after the source pair exists in the refreshed current registry. Use snapshot pair files directly as auto-setup evidence; do not pass snapshot or file paths through `--from`.
+- In `--migration`, use `/harness-pair-dev --add ... --from snapshot:<ts>/<pair>` (or `archive:` when appropriate) as the source-resolution path for preserved pair intent. Do not pass arbitrary file paths through `--from`.
+- In `--setup`, treat pair reconstruction as author-first: a usable draft should be written in one run unless repo grounding is genuinely absent.
 - Re-registration must preserve duplicate-free `## Registered pairs` order and use the registry helper rather than hand-editing the section.
 
-### 8. Finalizer convergence rules
+### 9. Finalizer convergence rules
 
 - The finalizer is customized when its body declares concrete cycle-end duties beyond the default no-op summary, writes out-of-cycle artifacts, performs coverage/release/docs/audit work, or changes the default Task section materially.
-- A customized finalizer's intent should be preserved, but its body must be rewritten against the current `harness-finalizer` skeleton, principles, Structural Issue shape, and Output Format.
-- A missing or no-op finalizer should trigger repo-grounded recommendations for concrete cycle-end work. Author it only when the target repo evidence makes the duty clear.
+- In `--setup`, a customized finalizer may be rewritten more aggressively onto the current skeleton when that yields a more usable starter harness.
+- In `--migration`, preserve the customized finalizer's intro, principles, and task where possible while refreshing contract-owned surfaces such as required skills, Output Format, and Structural Issue block.
+- A missing or no-op finalizer should trigger repo-grounded recommendations or authored cycle-end work according to mode.
 - Do not turn finalizer work into a pair, and do not add a finalizer line to `## Registered pairs`.
 
-### 9. Sync handoff
+### 10. Sync handoff
 
 Auto-setup must stop before platform derivation. The final user-facing summary must include a target-local command such as:
 
@@ -132,15 +147,15 @@ node .harness/loom/sync.ts --provider claude,codex,gemini
 
 Use any subset the user requested or that the workflow recommends, but never execute sync automatically.
 
-### 10. Execution
+### 11. Execution
 
 Run the script-owned execution path:
 
 ```bash
-node plugins/harness-loom/skills/harness-auto-setup/scripts/auto-setup.ts [--provider claude,codex,gemini]
+node plugins/harness-loom/skills/harness-auto-setup/scripts/auto-setup.ts [--setup | --migration] [--provider claude,codex,gemini]
 ```
 
-The script snapshots existing `.harness/loom/` / `.harness/cycle/`, classifies active-cycle risk, calls the `harness-init` installer for foundation refresh, reconstructs valid registered pairs and customized finalizer intent on current templates, and returns JSON. `--provider` only shapes the printed sync handoff; it never runs sync.
+The script snapshots existing `.harness/loom/` / `.harness/cycle/`, classifies active-cycle risk, calls the `harness-init` installer for foundation refresh, then either authors/reconstructs usable setup-mode outputs or applies migration-mode protected overlay. `--provider` only shapes the printed sync handoff; it never runs sync.
 
 ## Evaluation Criteria
 
@@ -148,16 +163,17 @@ The script snapshots existing `.harness/loom/` / `.harness/cycle/`, classifies a
 - Active or unparsable `.harness/cycle/` state is warned about and copied before discard/reseed.
 - Snapshot data is machine provenance with deterministic path and manifest shape, not a human-authored setup SSOT.
 - `/harness-init` remains foundation-only.
-- Pair convergence uses old files only as evidence and regenerates current pair outputs against current templates, rubric, and repo evidence.
+- Pair convergence distinguishes setup-mode author-first behavior from migration-mode minimal-delta overlay.
 - `registry.md` remains the sole pair roster source of truth and contains only executable producer-reviewer pairs.
 - Customized finalizer intent is preserved in the singleton finalizer body, not converted into a pair.
-- Fresh targets receive repo-grounded pair/finalizer recommendations or authored outputs, not stock generic harness content.
+- Fresh `--setup` targets receive repo-grounded authored outputs when signals exist, and only fall back to recommendations when repo grounding is too thin.
 - Derived platform trees are not modified; the result ends with an explicit `node .harness/loom/sync.ts --provider <list>` handoff.
 
 ## Taboos
 
 - Create a persistent human-edited `setup.md` or equivalent setup SSOT.
 - Restore stale pair or finalizer files by blind copy after foundation refresh.
+- Use `--migration` on a fresh target with no harness state to preserve.
 - Delete an active or unparsable cycle silently.
 - Treat snapshot content as canonical after convergence.
 - Register the planner or finalizer as a pair.

--- a/plugins/harness-loom/skills/harness-auto-setup/references/snapshot-provenance.md
+++ b/plugins/harness-loom/skills/harness-auto-setup/references/snapshot-provenance.md
@@ -40,6 +40,8 @@ Do not copy derived platform trees by default. `.claude/`, `.codex/`, and `.gemi
 9. `finalizerSummary`
 10. `nextAction`
 
+Mode-aware runs may append additional keys such as `runMode` and `targetState` after the ten load-bearing fields above.
+
 `copiedNamespaces` must be sorted and use target-relative namespace names such as `.harness/loom` and `.harness/cycle`.
 
 `activeCycle` must record both the classification and the parse reason so a later reviewer can tell whether the refresh discarded pristine, halted, active, or unknown cycle state.

--- a/plugins/harness-loom/skills/harness-auto-setup/scripts/auto-setup.ts
+++ b/plugins/harness-loom/skills/harness-auto-setup/scripts/auto-setup.ts
@@ -8,7 +8,7 @@
 import { spawnSync } from "node:child_process";
 import { constants as FS, readFileSync } from "node:fs";
 import { access, cp, mkdir, readFile, stat, writeFile } from "node:fs/promises";
-import { dirname, join, relative, resolve } from "node:path";
+import { basename, dirname, join, relative, resolve } from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
 
@@ -19,6 +19,7 @@ const FINALIZER_TEMPLATE = resolve(
   "../../harness-init/references/runtime/harness-finalizer.template.md",
 );
 const PAIR_DEV_DIR = resolve(SCRIPT_DIR, "../../harness-pair-dev");
+const PAIR_DEV_SCRIPT = resolve(PAIR_DEV_DIR, "scripts/pair-dev.ts");
 const REGISTER_PAIR_SCRIPT = resolve(PAIR_DEV_DIR, "scripts/register-pair.ts");
 const PRODUCER_TEMPLATE = resolve(PAIR_DEV_DIR, "templates/producer-agent.md");
 const REVIEWER_TEMPLATE = resolve(PAIR_DEV_DIR, "templates/reviewer-agent.md");
@@ -36,10 +37,13 @@ const FOUNDATION_SLUGS = new Set([
 type CycleClassification = "absent" | "pristine" | "active" | "halted" | "unknown";
 type RegistryStatus = "absent" | "present" | "unparsable";
 type FinalizerStatus = "absent" | "default-noop" | "customized" | "unreadable";
+type RunMode = "setup" | "migration";
+type TargetState = "fresh" | "existing";
 
 interface Args {
   target: string;
   providers: string[];
+  runMode: RunMode;
 }
 
 interface ActiveCycleSummary {
@@ -101,6 +105,8 @@ interface Manifest {
   registrySummary: RegistrySummary;
   finalizerSummary: FinalizerSummary;
   nextAction: string;
+  runMode?: RunMode;
+  targetState?: TargetState;
   recommendations: {
     mode: string;
     pairs: string[];
@@ -118,7 +124,7 @@ interface PairIntent {
 
 interface PairReconstruction {
   pair: string;
-  status: "reconstructed" | "skipped";
+  status: "authored" | "reconstructed" | "migrated" | "skipped";
   reason: string;
   producer: string;
   reviewers: string[];
@@ -126,6 +132,20 @@ interface PairReconstruction {
   filesWritten: string[];
   registry: unknown;
   evidenceLines: string[];
+  preserved: string[];
+  replaced: string[];
+  manualReview: string[];
+  source:
+    | {
+        kind: "repo-signals" | "live" | "snapshot" | "archive";
+        locator: string | null;
+      }
+    | null;
+  convergence: {
+    improvementPasses: number;
+    stopReason: string;
+    qualityVerdict: "acceptable" | "fallback" | "manual-review";
+  };
 }
 
 interface ArtifactUsage {
@@ -133,12 +153,29 @@ interface ArtifactUsage {
   skills: Map<string, string[]>;
 }
 
+interface SetupPairPlan {
+  pair: RegistryPair;
+  purpose: string;
+  designThinking: string;
+  methodology: string;
+  evaluationCriteria: string;
+  taboos: string;
+}
+
 interface FinalizerReconstruction {
-  status: "reconstructed" | "default-noop" | "missing" | "skipped";
+  status: "authored" | "reconstructed" | "migrated" | "default-noop" | "missing" | "skipped";
   reason: string;
   path: string | null;
   filesWritten: string[];
   evidenceLines: string[];
+  preserved: string[];
+  replaced: string[];
+  manualReview: string[];
+  convergence: {
+    improvementPasses: number;
+    stopReason: string;
+    qualityVerdict: "acceptable" | "fallback" | "manual-review";
+  };
 }
 
 function die(message: string, code = 1): never {
@@ -163,15 +200,23 @@ function parseProviders(raw: string): string[] {
 function parseArgs(argv: string[]): Args {
   const rest = argv.slice(2);
   let providers = ["claude", "codex", "gemini"];
+  let runMode: RunMode = "setup";
   for (let i = 0; i < rest.length; i++) {
     const arg = rest[i];
     if (arg === "--help" || arg === "-h") {
       process.stdout.write(
-        "Usage: node skills/harness-auto-setup/scripts/auto-setup.ts [--provider <claude,codex,gemini>]\n" +
+        "Usage: node skills/harness-auto-setup/scripts/auto-setup.ts [--setup | --migration] [--provider <claude,codex,gemini>]\n" +
           "  Target is always process.cwd(); run from the project root.\n" +
+          "  Default mode is --setup. Use --migration for minimal-delta upgrades of an existing harness.\n" +
           "  The provider list is only used to print the explicit sync handoff; sync is not run.\n",
       );
       process.exit(0);
+    } else if (arg === "--setup") {
+      if (runMode === "migration") die("use either --setup or --migration, not both");
+      runMode = "setup";
+    } else if (arg === "--migration") {
+      if (runMode === "setup" && rest.includes("--setup")) die("use either --setup or --migration, not both");
+      runMode = "migration";
     } else if (arg === "--provider") {
       const value = rest[++i];
       if (value === undefined || value.startsWith("--")) die("--provider requires a comma-separated list");
@@ -182,7 +227,7 @@ function parseArgs(argv: string[]): Args {
       die(`unexpected argument: ${arg}`);
     }
   }
-  return { target: process.cwd(), providers };
+  return { target: process.cwd(), providers, runMode };
 }
 
 async function exists(path: string): Promise<boolean> {
@@ -309,10 +354,275 @@ function titleFromSlug(slug: string): string {
     .join(" ");
 }
 
-function frontmatterDescription(body: string): string | null {
+function frontmatterBlock(body: string): string | null {
   const normalized = body.replace(/\r\n/g, "\n");
-  const match = normalized.match(/^---\n[\s\S]*?\ndescription:\s*"?([^"\n]+)"?[\s\S]*?\n---/);
+  const match = normalized.match(/^---\n([\s\S]*?)\n---(?:\n|$)/);
+  return match ? match[1] : null;
+}
+
+function leadingIndent(line: string): number {
+  const match = line.match(/^ */);
+  return match ? match[0].length : 0;
+}
+
+function stripYamlComment(value: string): string {
+  let quote: '"' | "'" | null = null;
+  let escape = false;
+  for (let i = 0; i < value.length; i += 1) {
+    const ch = value[i];
+    if (quote === '"') {
+      if (escape) {
+        escape = false;
+        continue;
+      }
+      if (ch === "\\") {
+        escape = true;
+        continue;
+      }
+      if (ch === '"') quote = null;
+      continue;
+    }
+    if (quote === "'") {
+      if (ch === "'" && value[i + 1] === "'") {
+        i += 1;
+        continue;
+      }
+      if (ch === "'") quote = null;
+      continue;
+    }
+    if (ch === '"') {
+      quote = '"';
+      continue;
+    }
+    if (ch === "'") {
+      quote = "'";
+      continue;
+    }
+    if (ch === "#" && (i === 0 || /\s/.test(value[i - 1]))) {
+      return value.slice(0, i).trimEnd();
+    }
+  }
+  return value.trimEnd();
+}
+
+function parseYamlScalar(value: string): string | null {
+  const trimmed = stripYamlComment(value).trim();
+  if (trimmed === "") return "";
+  if (trimmed.startsWith('"')) {
+    try {
+      const parsed = JSON.parse(trimmed);
+      return typeof parsed === "string" ? parsed : trimmed;
+    } catch {
+      return trimmed;
+    }
+  }
+  if (trimmed.startsWith("'") && trimmed.endsWith("'")) {
+    return trimmed.slice(1, -1).replace(/''/g, "'");
+  }
+  return trimmed;
+}
+
+function parseYamlInlineList(value: string): string[] | null {
+  const trimmed = stripYamlComment(value).trim();
+  if (!trimmed.startsWith("[") || !trimmed.endsWith("]")) return null;
+  const inner = trimmed.slice(1, -1);
+  const out: string[] = [];
+  let current = "";
+  let quote: '"' | "'" | null = null;
+  let escape = false;
+  for (let i = 0; i < inner.length; i += 1) {
+    const ch = inner[i];
+    current += ch;
+    if (quote === '"') {
+      if (escape) {
+        escape = false;
+        continue;
+      }
+      if (ch === "\\") {
+        escape = true;
+        continue;
+      }
+      if (ch === '"') quote = null;
+      continue;
+    }
+    if (quote === "'") {
+      if (ch === "'") quote = null;
+      continue;
+    }
+    if (ch === '"') {
+      quote = '"';
+      continue;
+    }
+    if (ch === "'") {
+      quote = "'";
+      continue;
+    }
+    if (ch === ",") {
+      current = current.slice(0, -1);
+      const parsed = parseYamlScalar(current);
+      if (parsed !== null && parsed !== "") out.push(parsed);
+      current = "";
+    }
+  }
+  if (quote || escape) return null;
+  const parsed = parseYamlScalar(current);
+  if (parsed !== null && parsed !== "") out.push(parsed);
+  return out;
+}
+
+function collectIndentedValue(lines: string[], start: number): { lines: string[]; next: number } {
+  let index = start;
+  while (index < lines.length && /^\s*$/.test(lines[index])) index += 1;
+  if (index >= lines.length) return { lines: [], next: index };
+  const firstIndent = leadingIndent(lines[index]);
+  if (firstIndent === 0) return { lines: [], next: index };
+  const out: string[] = [];
+  while (index < lines.length) {
+    const line = lines[index];
+    if (/^\s*$/.test(line)) {
+      out.push("");
+      index += 1;
+      continue;
+    }
+    const indent = leadingIndent(line);
+    if (indent < firstIndent) break;
+    out.push(line.slice(firstIndent));
+    index += 1;
+  }
+  return { lines: out, next: index };
+}
+
+function parseYamlBlockScalar(indicator: string, lines: string[]): string {
+  const style = indicator.trim()[0] === ">" ? ">" : "|";
+  const cleaned = lines.map((line) => line.replace(/[ \t]+$/g, ""));
+  if (style === "|") return cleaned.join("\n").replace(/\n+$/g, "");
+  let out = "";
+  let pendingBlankLines = 0;
+  for (const line of cleaned) {
+    if (line === "") {
+      pendingBlankLines += 1;
+      continue;
+    }
+    if (out) {
+      out += pendingBlankLines > 0 ? "\n".repeat(pendingBlankLines) : " ";
+    }
+    out += line;
+    pendingBlankLines = 0;
+  }
+  return out;
+}
+
+function isYamlBlockScalarIndicator(value: string): boolean {
+  return /^[>|](?:[1-9])?(?:[+-])?$/.test(value) || /^[>|][+-](?:[1-9])?$/.test(value);
+}
+
+function frontmatterValue(body: string, key: string): string | string[] | null {
+  const block = frontmatterBlock(body);
+  if (!block) return null;
+  const lines = block.split("\n");
+  const escaped = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  for (let i = 0; i < lines.length; i += 1) {
+    const match = lines[i].match(new RegExp(`^${escaped}:\\s*(.*)$`));
+    if (!match) continue;
+    const rawValue = match[1];
+    const trimmed = stripYamlComment(rawValue).trim();
+    if (isYamlBlockScalarIndicator(trimmed)) {
+      const nested = collectIndentedValue(lines, i + 1);
+      return parseYamlBlockScalar(trimmed, nested.lines);
+    }
+    const inlineList = parseYamlInlineList(rawValue);
+    if (inlineList) return inlineList;
+    if (trimmed === "") {
+      const nested = collectIndentedValue(lines, i + 1);
+      if (nested.lines.length === 0) return "";
+      if (nested.lines.every((line) => line === "" || /^\s*-\s+/.test(line))) {
+        return nested.lines
+          .filter((line) => /^\s*-\s+/.test(line))
+          .map((line) => parseYamlScalar(line.replace(/^\s*-\s+/, "")))
+          .filter((value): value is string => value !== null && value !== "");
+      }
+      return nested.lines.join("\n").trim();
+    }
+    return parseYamlScalar(rawValue);
+  }
+  return null;
+}
+
+function frontmatterScalar(body: string, key: string): string | null {
+  const value = frontmatterValue(body, key);
+  return typeof value === "string" ? value : null;
+}
+
+function frontmatterDescription(body: string): string | null {
+  return frontmatterScalar(body, "description");
+}
+
+function frontmatterSkills(body: string): string[] {
+  const value = frontmatterValue(body, "skills");
+  return Array.isArray(value) ? value : [];
+}
+
+function bodyWithoutFrontmatter(body: string): string {
+  const normalized = body.replace(/\r\n/g, "\n");
+  return normalized.replace(/^---\n[\s\S]*?\n---\n?/, "").trim();
+}
+
+function topHeading(body: string): string | null {
+  const content = bodyWithoutFrontmatter(body);
+  const match = content.match(/^#\s+([^\n]+)$/m);
   return match ? match[1].trim() : null;
+}
+
+function introAfterHeading(body: string): string | null {
+  const content = bodyWithoutFrontmatter(body);
+  const match = content.match(/^#\s+[^\n]+\n([\s\S]*)$/);
+  if (!match) return null;
+  const tail = match[1].trimStart();
+  const nextSection = tail.search(/(^|\n)## /);
+  const intro = (nextSection === -1 ? tail : tail.slice(0, nextSection)).trim();
+  return intro || null;
+}
+
+function quoteYaml(value: string): string {
+  return JSON.stringify(value);
+}
+
+function renderSkillFrontmatter(name: string, description: string): string {
+  return [
+    "---",
+    `name: ${name}`,
+    `description: ${quoteYaml(description)}`,
+    "user-invocable: false",
+    "---",
+  ].join("\n");
+}
+
+function renderAgentFrontmatter(
+  name: string,
+  description: string,
+  skills: string[],
+  model: string | null,
+): string {
+  const lines = [
+    "---",
+    `name: ${name}`,
+    `description: ${quoteYaml(description)}`,
+    "skills:",
+    ...skills.map((skill) => `  - ${skill}`),
+  ];
+  if (model) lines.push(`model: ${model}`);
+  lines.push("---");
+  return lines.join("\n");
+}
+
+function preservedExtraSkills(body: string, required: string[]): string[] {
+  const requiredSet = new Set(required);
+  const out: string[] = [];
+  for (const skill of frontmatterSkills(body)) {
+    if (requiredSet.has(skill) || !skill) continue;
+    if (!out.includes(skill)) out.push(skill);
+  }
+  return out;
 }
 
 function cleanEvidenceLine(line: string): string | null {
@@ -766,6 +1076,165 @@ function finalizerRecommendation(finalizer: FinalizerSummary, signals: RepoSigna
   return finalizer.recommendation;
 }
 
+function makeSetupPairPlan(
+  pair: string,
+  reviewers: string[],
+  purpose: string,
+  designThinking: string,
+  methodology: string,
+  evaluationCriteria: string,
+  taboos: string,
+): SetupPairPlan {
+  return {
+    pair: {
+      pair,
+      producer: `${pair}-producer`,
+      reviewers,
+      skill: pair,
+      sourceLine: "",
+      evidence: { skillPresent: false, producerPresent: false, reviewersPresent: [], missing: [] },
+    },
+    purpose,
+    designThinking,
+    methodology,
+    evaluationCriteria,
+    taboos,
+  };
+}
+
+function setupPairPlans(signals: RepoSignals): SetupPairPlan[] {
+  const out: SetupPairPlan[] = [];
+  if (signals.evidence.includes("implementation surface")) {
+    out.push(
+      makeSetupPairPlan(
+        "harness-implementation",
+        ["harness-implementation-reviewer"],
+        "Implement and review requested project changes in the main code surface.",
+        "This pair owns feature and bug-fix work in the repository's main implementation surface. Setup mode authors it by default when the repo shows real code ownership boundaries but no restored project-specific pair exists yet.",
+        "1. Read the orchestrator envelope and repo surface named in scope.\n2. Identify the smallest implementation slice that satisfies the current request.\n3. Change code, config, or tests only inside the declared ownership.\n4. Verify the user-visible or contract-level effect with the smallest relevant command.\n5. Report concrete files, verification, and blocked follow-up items.",
+        "- Scope stays inside the declared implementation surface.\n- Changed behavior is backed by concrete file edits and a verification step.\n- Review can trace user-facing impact or contract impact from the diff.\n- Regression-sensitive changes mention tests or why no automated check exists.\n- The pair does not silently broaden into docs/release ownership.",
+        "- Do not rewrite unrelated docs, release notes, or planner/runtime contracts from this pair.\n- Do not claim verification without a concrete command or file-backed reason.\n- Do not defer required in-scope acceptance work into blocked items.",
+      ),
+    );
+  }
+  if (signals.evidence.includes("test surface") || signals.evidence.includes("ci workflow surface")) {
+    out.push(
+      makeSetupPairPlan(
+        "harness-verification",
+        ["harness-verification-reviewer"],
+        "Maintain regression checks, smoke coverage, and verification evidence for the repository.",
+        "This pair owns the repository's regression and smoke-verification surface. Setup mode adds it when tests or CI workflows are present so the harness has a concrete place for verification work instead of pushing that responsibility into ad hoc producer turns.",
+        "1. Read the task scope and identify the affected regression surface.\n2. Inspect current tests, workflows, or smoke scripts before editing.\n3. Add or adjust the smallest verification artifact that protects the changed behavior.\n4. Run the narrowest relevant verification command.\n5. Record gaps, flaky surfaces, or blocked coverage honestly.",
+        "- Verification changes stay grounded in real tests, workflows, or smoke scripts already present.\n- Producer output cites the command or file proving the regression surface changed.\n- Reviewer can trace risk reduction from the edited artifact.\n- Missing automation is surfaced explicitly instead of hidden behind PASS.\n- Verification ownership does not drift into general implementation work.",
+        "- Do not invent fake coverage or green statuses.\n- Do not rewrite product implementation when the real gap is missing verification evidence.\n- Do not move cycle-end summary work into this pair; finalizer owns cycle-end synthesis.",
+      ),
+    );
+  }
+  if (signals.evidence.includes("documentation surface")) {
+    out.push(
+      makeSetupPairPlan(
+        "harness-document",
+        ["harness-document-reviewer"],
+        "Maintain user-facing docs, pointer docs, and explanation surfaces in sync with the implementation.",
+        "This pair owns user-facing documentation and explanation surfaces. Setup mode adds it when the repo exposes README/docs-style material so documentation work has a concrete producer-reviewer home rather than being folded into arbitrary implementation turns.",
+        "1. Read the envelope and identify which docs surface the task actually touches.\n2. Inspect implementation evidence before rewriting prose.\n3. Update only the docs files justified by changed behavior or structure.\n4. Keep pointer docs short and direct readers to the canonical source.\n5. Report exact files changed and any remaining doc debt that stayed out of scope.",
+        "- Documentation changes are tied to current implementation evidence.\n- Pointer docs stay lightweight and do not fork a second source of truth.\n- Reviewer can cite exact files/sections for drift or coverage gaps.\n- The pair leaves unrelated implementation files alone.\n- Follow-up doc debt is separated from in-scope corrections.",
+        "- Do not paraphrase code without checking the actual file surface.\n- Do not mirror dynamic runtime state into pointer docs.\n- Do not widen a narrow doc fix into a repo-wide rewrite without evidence.",
+      ),
+    );
+  }
+  return out;
+}
+
+function renderPlannedPairSkill(plan: SetupPairPlan): string {
+  return [
+    renderSkillFrontmatter(
+      plan.pair.skill,
+      `Use when \`/harness-orchestrate\` dispatches the \`${plan.pair.pair}\` pair in this project. Shared rubric for the producer and its reviewer(s).`,
+    ),
+    "",
+    `# ${titleFromSlug(plan.pair.pair)}`,
+    "",
+    "## Design Thinking",
+    "",
+    plan.designThinking,
+    "",
+    "## Methodology",
+    "",
+    plan.methodology,
+    "",
+    "## Evaluation Criteria",
+    "",
+    plan.evaluationCriteria,
+    "",
+    "## Taboos",
+    "",
+    plan.taboos,
+    "",
+  ].join("\n");
+}
+
+function renderGenericPairSkill(pair: RegistryPair, signals: RepoSignals): string {
+  const signalLine =
+    signals.evidence.length > 0 ? signals.evidence.join(", ") : "the repository's current visible work surface";
+  return [
+    renderSkillFrontmatter(
+      pair.skill,
+      `Use when \`/harness-orchestrate\` dispatches the \`${pair.pair}\` pair in this project. Shared rubric for the producer and its reviewer(s).`,
+    ),
+    "",
+    `# ${titleFromSlug(pair.pair)}`,
+    "",
+    "## Design Thinking",
+    "",
+    `${titleFromSlug(pair.pair)} owns a concrete project workstream inside the current repository. Migration keeps its user-authored guidance where possible while refreshing only the load-bearing runtime surface.`,
+    "",
+    "## Methodology",
+    "",
+    "1. Read the orchestrator envelope and current repo files before editing.\n" +
+      "2. Keep work inside the registered pair boundary and current project evidence.\n" +
+      `3. Use ${signalLine} as the current repo context for this pair.\n` +
+      "4. Surface ownership or contract ambiguity instead of widening the pair silently.\n" +
+      "5. Report concrete files, verification, and blocked follow-up.",
+    "",
+    "## Evaluation Criteria",
+    "",
+    "- The pair stays inside its declared ownership boundary.\n" +
+      "- Current files, tests, or docs are cited when behavior changes.\n" +
+      "- Producer and reviewer output follow the current runtime contract.\n" +
+      "- Structural uncertainty is surfaced rather than hidden in a PASS.",
+    "",
+    "## Taboos",
+    "",
+    "- Do not copy stale snapshot files over current templates.\n" +
+      "- Do not edit `.harness/cycle/` or derived provider trees.\n" +
+      "- Do not broaden this pair into unrelated repository ownership.",
+    "",
+  ].join("\n");
+}
+
+function renderSetupFinalizerFromSignals(signals: RepoSignals): string {
+  const template = loadTemplateSync(FINALIZER_TEMPLATE);
+  let task = "1. Emit the Output Format block below with `Status: PASS`, `Summary: no cycle-end work registered for this project`, empty `Files created` / `Files modified`, `Self-verification` citing that no cycle-end work was required, and `Blocked or out-of-scope items: []`. Do not touch any file.";
+  if (signals.evidence.length > 0) {
+    const docsStep = signals.evidence.includes("documentation surface")
+      ? "4. Refresh README, docs, or CHANGELOG only when the cycle goal or changed behavior justifies it.\n"
+      : "";
+    const verifyStep =
+      signals.evidence.includes("test surface") || signals.evidence.includes("ci workflow surface")
+        ? "3. Summarize concrete verification evidence from the cycle artifacts before deciding PASS or FAIL.\n"
+        : "3. Summarize concrete completion evidence from the cycle artifacts before deciding PASS or FAIL.\n";
+    task =
+      "1. Read the finalizer envelope, current goal, and prior task artifacts.\n" +
+      "2. Check whether the cycle left any required cycle-end outputs or follow-up notes.\n" +
+      verifyStep +
+      docsStep +
+      "5. Emit the Output Format block with concrete files touched, files intentionally left alone, and blocked out-of-scope items.\n" +
+      "6. If upstream planning or contract assumptions are broken, emit the Structural Issue block and return `Status: FAIL`.";
+  }
+  return replaceSection(template, "Task", task);
+}
+
 function addUsage(map: Map<string, string[]>, slug: string, owner: string): void {
   const current = map.get(slug) ?? [];
   current.push(owner);
@@ -994,6 +1463,186 @@ function renderReviewerAgent(pair: RegistryPair, reviewer: string): string {
   });
 }
 
+async function writePairArtifacts(
+  target: string,
+  pair: RegistryPair,
+  skillBody: string,
+  producerBody: string,
+  reviewerBodies: Record<string, string>,
+): Promise<string[]> {
+  const filesWritten: string[] = [];
+  const skillDir = join(target, ".harness", "loom", "skills", pair.skill);
+  const agentsDir = join(target, ".harness", "loom", "agents");
+  await mkdir(skillDir, { recursive: true });
+  await mkdir(agentsDir, { recursive: true });
+
+  const skillFile = join(skillDir, "SKILL.md");
+  await writeFile(skillFile, skillBody);
+  filesWritten.push(rel(target, skillFile));
+
+  const producerFile = join(agentsDir, `${pair.producer}.md`);
+  await writeFile(producerFile, producerBody);
+  filesWritten.push(rel(target, producerFile));
+
+  for (const reviewer of pair.reviewers) {
+    const reviewerFile = join(agentsDir, `${reviewer}.md`);
+    await writeFile(reviewerFile, reviewerBodies[reviewer]);
+    filesWritten.push(rel(target, reviewerFile));
+  }
+  return filesWritten;
+}
+
+function migratedSkillBody(pair: RegistryPair, sourceBody: string | null, signals: RepoSignals): string {
+  const base = renderGenericPairSkill(pair, signals);
+  const description = sourceBody ? frontmatterDescription(sourceBody) : null;
+  const title = sourceBody ? topHeading(sourceBody) : null;
+  return [
+    renderSkillFrontmatter(
+      pair.skill,
+      description ?? frontmatterDescription(base) ?? `Use when \`/harness-orchestrate\` dispatches the \`${pair.pair}\` pair in this project.`,
+    ),
+    "",
+    `# ${title ?? topHeading(base) ?? titleFromSlug(pair.pair)}`,
+    "",
+    "## Design Thinking",
+    "",
+    (sourceBody && section(sourceBody, "Design Thinking")) || section(base, "Design Thinking") || "",
+    "",
+    "## Methodology",
+    "",
+    (sourceBody && section(sourceBody, "Methodology")) || section(base, "Methodology") || "",
+    "",
+    "## Evaluation Criteria",
+    "",
+    (sourceBody && section(sourceBody, "Evaluation Criteria")) || section(base, "Evaluation Criteria") || "",
+    "",
+    "## Taboos",
+    "",
+    (sourceBody && section(sourceBody, "Taboos")) || section(base, "Taboos") || "",
+    "",
+  ].join("\n");
+}
+
+function migratedAgentBody(
+  pair: RegistryPair,
+  slug: string,
+  sourceBody: string | null,
+  templateBody: string,
+  role: "producer" | "reviewer",
+): string {
+  const requiredSkills = [pair.skill, "harness-context"];
+  const skills = [...requiredSkills, ...preservedExtraSkills(sourceBody ?? "", requiredSkills)];
+  const description =
+    (sourceBody && frontmatterDescription(sourceBody)) ||
+    frontmatterDescription(templateBody) ||
+    `Use when \`/harness-orchestrate\` dispatches the \`${pair.pair}\` ${role} turn.`;
+  const model = sourceBody ? frontmatterScalar(sourceBody, "model") : null;
+  const title = (sourceBody && topHeading(sourceBody)) || topHeading(templateBody) || titleFromSlug(slug);
+  const intro = (sourceBody && introAfterHeading(sourceBody)) || introAfterHeading(templateBody) || "";
+  const principles = (sourceBody && section(sourceBody, "Principles")) || section(templateBody, "Principles") || "";
+  const task = (sourceBody && section(sourceBody, "Task")) || section(templateBody, "Task") || "";
+  const outputFormat = section(templateBody, "Output Format") || "";
+  return [
+    renderAgentFrontmatter(slug, description, skills, model),
+    "",
+    `# ${title}`,
+    "",
+    intro,
+    "",
+    "## Principles",
+    "",
+    principles.trim(),
+    "",
+    "## Task",
+    "",
+    task.trim(),
+    "",
+    "## Output Format",
+    "",
+    outputFormat.trim(),
+    "",
+  ].join("\n");
+}
+
+function migratedFinalizerBody(sourceBody: string): string {
+  const template = loadTemplateSync(FINALIZER_TEMPLATE);
+  const description =
+    frontmatterDescription(sourceBody) ??
+    frontmatterDescription(template) ??
+    "Use when the orchestrator dispatches the cycle-end finalizer turn.";
+  const model = frontmatterScalar(sourceBody, "model");
+  const title = topHeading(sourceBody) ?? topHeading(template) ?? "Finalizer";
+  const intro = introAfterHeading(sourceBody) ?? introAfterHeading(template) ?? "";
+  const principles = section(sourceBody, "Principles") ?? section(template, "Principles") ?? "";
+  const task = section(sourceBody, "Task") ?? section(template, "Task") ?? "";
+  const outputFormat = section(template, "Output Format") ?? "";
+  const structuralIssue = (() => {
+    const marker = "If a structural issue is detected, include this block immediately before the Output Format block:";
+    const index = template.indexOf(marker);
+    return index === -1 ? "" : template.slice(index).trim();
+  })();
+  return [
+    renderAgentFrontmatter("harness-finalizer", description, ["harness-context"], model),
+    "",
+    `# ${title}`,
+    "",
+    intro,
+    "",
+    "## Principles",
+    "",
+    principles.trim(),
+    "",
+    "## Task",
+    "",
+    task.trim(),
+    "",
+    "## Output Format",
+    "",
+    outputFormat.trim(),
+    "",
+    structuralIssue,
+    "",
+  ].join("\n");
+}
+
+function snapshotLocator(snapshotPath: string, pair: string): string {
+  return `snapshot:${basename(snapshotPath)}/${pair}`;
+}
+
+function runPairDevPrepareAdd(
+  target: string,
+  pair: RegistryPair,
+  purpose: string,
+  fromLocator: string,
+): {
+  from: {
+    kind: "live" | "snapshot" | "archive";
+    locator: string;
+    registryPath: string;
+    pair: string;
+    producer: string;
+    reviewers: string[];
+    skill: string;
+    skillPath: string | null;
+    producerPath: string | null;
+    reviewerPaths: Record<string, string | null>;
+    missingArtifacts: string[];
+  };
+} {
+  const args = [PAIR_DEV_SCRIPT, "--add", pair.pair, purpose, "--from", fromLocator];
+  for (const reviewer of pair.reviewers) args.push("--reviewer", reviewer);
+  const result = spawnSync(process.execPath, args, { encoding: "utf8", cwd: target });
+  if (result.status !== 0) {
+    const detail = result.stderr.trim() || result.stdout.trim() || "pair-dev prepare-add failed";
+    die(`migration prepare failed for ${pair.pair}: ${detail}`);
+  }
+  try {
+    return JSON.parse(result.stdout);
+  } catch {
+    die(`migration prepare for ${pair.pair} did not return JSON`);
+  }
+}
+
 function loadTemplateSync(path: string): string {
   try {
     return readFileSync(path, "utf8");
@@ -1053,29 +1702,29 @@ async function reconstructPairs(
         filesWritten: [],
         registry: null,
         evidenceLines: [],
+        preserved: [],
+        replaced: [],
+        manualReview: [],
+        source: null,
+        convergence: {
+          improvementPasses: 0,
+          stopReason: "invalid snapshot registry entry",
+          qualityVerdict: "manual-review",
+        },
       });
       continue;
     }
     const intent = await collectPairIntent(target, snapshotPath, pair);
-    const filesWritten: string[] = [];
-    const skillDir = join(target, ".harness", "loom", "skills", pair.skill);
-    const agentsDir = join(target, ".harness", "loom", "agents");
-    await mkdir(skillDir, { recursive: true });
-    await mkdir(agentsDir, { recursive: true });
-
-    const skillFile = join(skillDir, "SKILL.md");
-    await writeFile(skillFile, renderPairSkill(pair, intent, signals));
-    filesWritten.push(rel(target, skillFile));
-
-    const producerFile = join(agentsDir, `${pair.producer}.md`);
-    await writeFile(producerFile, renderProducerAgent(pair));
-    filesWritten.push(rel(target, producerFile));
-
-    for (const reviewer of pair.reviewers) {
-      const reviewerFile = join(agentsDir, `${reviewer}.md`);
-      await writeFile(reviewerFile, renderReviewerAgent(pair, reviewer));
-      filesWritten.push(rel(target, reviewerFile));
-    }
+    const reviewerBodies = Object.fromEntries(
+      pair.reviewers.map((reviewer) => [reviewer, renderReviewerAgent(pair, reviewer)]),
+    );
+    const filesWritten = await writePairArtifacts(
+      target,
+      pair,
+      renderPairSkill(pair, intent, signals),
+      renderProducerAgent(pair),
+      reviewerBodies,
+    );
 
     const registration = runRegisterPair(target, pair);
     out.push({
@@ -1088,6 +1737,183 @@ async function reconstructPairs(
       filesWritten,
       registry: registration,
       evidenceLines: intent.evidenceLines,
+      preserved: ["registered pair topology", "snapshot intent evidence"],
+      replaced: ["skill body", "producer agent", "reviewer agent(s)", "current output contract"],
+      manualReview: [...pair.evidence.missing],
+      source: {
+        kind: "snapshot",
+        locator: snapshotLocator(snapshotPath, pair.pair),
+      },
+      convergence: {
+        improvementPasses: 0,
+        stopReason: "draft met setup reconstruction bar",
+        qualityVerdict: "acceptable",
+      },
+    });
+  }
+  return out;
+}
+
+async function authorSetupPairs(target: string, signals: RepoSignals): Promise<PairReconstruction[]> {
+  const plans = setupPairPlans(signals);
+  if (plans.length === 0) return [];
+  const out: PairReconstruction[] = [];
+  for (const plan of plans) {
+    const reviewerBodies = Object.fromEntries(
+      plan.pair.reviewers.map((reviewer) => [reviewer, renderReviewerAgent(plan.pair, reviewer)]),
+    );
+    const filesWritten = await writePairArtifacts(
+      target,
+      plan.pair,
+      renderPlannedPairSkill(plan),
+      renderProducerAgent(plan.pair),
+      reviewerBodies,
+    );
+    const registration = runRegisterPair(target, plan.pair);
+    out.push({
+      pair: plan.pair.pair,
+      status: "authored",
+      reason: "setup mode authored a repo-grounded starter pair",
+      producer: plan.pair.producer,
+      reviewers: plan.pair.reviewers,
+      skill: plan.pair.skill,
+      filesWritten,
+      registry: registration,
+      evidenceLines: [`Purpose: ${plan.purpose}`, ...signals.evidence.map((signal) => `Repo signal: ${signal}`)],
+      preserved: [],
+      replaced: ["new pair skill", "new producer agent", "new reviewer agent(s)"],
+      manualReview: [],
+      source: {
+        kind: "repo-signals",
+        locator: null,
+      },
+      convergence: {
+        improvementPasses: 0,
+        stopReason: "initial authored draft met setup quality bar",
+        qualityVerdict: "acceptable",
+      },
+    });
+  }
+  return out;
+}
+
+async function migratePairs(
+  target: string,
+  snapshotPath: string | null,
+  registry: RegistrySummary,
+  signals: RepoSignals,
+): Promise<PairReconstruction[]> {
+  if (!snapshotPath || registry.pairCount === 0) return [];
+  const out: PairReconstruction[] = [];
+  const seen = new Set<string>();
+  const basicInvalidReasons = registry.pairs.map((pair) => validatePairBasics(pair, seen));
+  const artifactUsage = collectArtifactUsage(registry.pairs.filter((_, index) => !basicInvalidReasons[index]));
+
+  for (const [index, pair] of registry.pairs.entries()) {
+    const invalidReason = basicInvalidReasons[index] ?? validatePairArtifacts(pair, artifactUsage);
+    if (invalidReason) {
+      out.push({
+        pair: pair.pair,
+        status: "skipped",
+        reason: invalidReason,
+        producer: pair.producer,
+        reviewers: pair.reviewers,
+        skill: pair.skill,
+        filesWritten: [],
+        registry: null,
+        evidenceLines: [],
+        preserved: [],
+        replaced: [],
+        manualReview: [],
+        source: null,
+        convergence: {
+          improvementPasses: 0,
+          stopReason: "invalid migration source",
+          qualityVerdict: "manual-review",
+        },
+      });
+      continue;
+    }
+
+    const prepared = runPairDevPrepareAdd(
+      target,
+      pair,
+      `Migrate ${pair.pair} to the current runtime contract while preserving project-specific guidance.`,
+      snapshotLocator(snapshotPath, pair.pair),
+    );
+    const sourceSkillBody =
+      prepared.from.skillPath ? await readOptional(join(target, prepared.from.skillPath)) : null;
+    const sourceProducerBody =
+      prepared.from.producerPath ? await readOptional(join(target, prepared.from.producerPath)) : null;
+    const sourceReviewerBodies = await Promise.all(
+      pair.reviewers.map(async (reviewer) => [
+        reviewer,
+        prepared.from.reviewerPaths[reviewer]
+          ? await readOptional(join(target, prepared.from.reviewerPaths[reviewer]!))
+          : null,
+      ] as const),
+    );
+    const reviewerBodies = Object.fromEntries(
+      sourceReviewerBodies.map(([reviewer, body]) => [
+        reviewer,
+        migratedAgentBody(pair, reviewer, body, renderReviewerAgent(pair, reviewer), "reviewer"),
+      ]),
+    );
+    const filesWritten = await writePairArtifacts(
+      target,
+      pair,
+      migratedSkillBody(pair, sourceSkillBody, signals),
+      migratedAgentBody(pair, pair.producer, sourceProducerBody, renderProducerAgent(pair), "producer"),
+      reviewerBodies,
+    );
+    const registration = runRegisterPair(target, pair);
+    const preserved = [
+      ...(sourceSkillBody && section(sourceSkillBody, "Design Thinking") ? ["skill Design Thinking"] : []),
+      ...(sourceSkillBody && section(sourceSkillBody, "Methodology") ? ["skill Methodology"] : []),
+      ...(sourceSkillBody && section(sourceSkillBody, "Evaluation Criteria") ? ["skill Evaluation Criteria"] : []),
+      ...(sourceSkillBody && section(sourceSkillBody, "Taboos") ? ["skill Taboos"] : []),
+      ...(sourceProducerBody && introAfterHeading(sourceProducerBody) ? ["producer identity paragraph"] : []),
+      ...(sourceProducerBody && section(sourceProducerBody, "Principles") ? ["producer Principles"] : []),
+      ...(sourceProducerBody && section(sourceProducerBody, "Task") ? ["producer Task"] : []),
+      ...sourceReviewerBodies.flatMap(([reviewer, body]) => (body && section(body, "Task") ? [`${reviewer} Task`] : [])),
+    ];
+    const manualReview = [...prepared.from.missingArtifacts];
+    if (!sourceSkillBody) manualReview.push(`missing migration source skill for ${pair.skill}`);
+    if (!sourceProducerBody) manualReview.push(`missing migration source producer for ${pair.producer}`);
+
+    out.push({
+      pair: pair.pair,
+      status: "migrated",
+      reason: "migration mode preserved source guidance while refreshing contract-owned surfaces",
+      producer: pair.producer,
+      reviewers: pair.reviewers,
+      skill: pair.skill,
+      filesWritten,
+      registry: registration,
+      evidenceLines: [
+        `Migration source: ${prepared.from.locator}`,
+        ...prepared.from.missingArtifacts.map((path) => `Missing source artifact: ${path}`),
+      ],
+      preserved,
+      replaced: [
+        "frontmatter name",
+        "frontmatter skills",
+        "current Output Format",
+        "current runtime trigger descriptions",
+      ],
+      manualReview: [...new Set(manualReview)],
+      source: {
+        kind: prepared.from.kind,
+        locator: prepared.from.locator,
+      },
+      convergence: {
+        improvementPasses: 0,
+        stopReason:
+          manualReview.length > 0
+            ? "migration completed with manual-review notes"
+            : "migration contract refreshed without extra improve pass",
+        qualityVerdict: manualReview.length > 0 ? "manual-review" : "acceptable",
+      },
     });
   }
   return out;
@@ -1135,6 +1961,14 @@ async function reconstructFinalizer(
       path: rel(target, finalizerPath),
       filesWritten: [],
       evidenceLines: [],
+      preserved: [],
+      replaced: [],
+      manualReview: [],
+      convergence: {
+        improvementPasses: 0,
+        stopReason: "default skeleton retained",
+        qualityVerdict: "fallback",
+      },
     };
   }
   if (summary.status !== "customized") {
@@ -1144,6 +1978,14 @@ async function reconstructFinalizer(
       path: rel(target, finalizerPath),
       filesWritten: [],
       evidenceLines: [],
+      preserved: [],
+      replaced: [],
+      manualReview: [],
+      convergence: {
+        improvementPasses: 0,
+        stopReason: "no customized finalizer intent to rebuild",
+        qualityVerdict: "acceptable",
+      },
     };
   }
   if (!snapshotPath) {
@@ -1153,6 +1995,14 @@ async function reconstructFinalizer(
       path: rel(target, finalizerPath),
       filesWritten: [],
       evidenceLines: [],
+      preserved: [],
+      replaced: [],
+      manualReview: ["missing snapshot path for customized finalizer"],
+      convergence: {
+        improvementPasses: 0,
+        stopReason: "customized finalizer could not be reconstructed without snapshot",
+        qualityVerdict: "manual-review",
+      },
     };
   }
   const snapshotFinalizer = join(snapshotPath, "loom", "agents", "harness-finalizer.md");
@@ -1164,6 +2014,14 @@ async function reconstructFinalizer(
       path: rel(target, finalizerPath),
       filesWritten: [],
       evidenceLines: [],
+      preserved: [],
+      replaced: [],
+      manualReview: [rel(target, snapshotFinalizer)],
+      convergence: {
+        improvementPasses: 0,
+        stopReason: "snapshot finalizer body missing",
+        qualityVerdict: "manual-review",
+      },
     };
   }
   const template = await readFile(FINALIZER_TEMPLATE, "utf8");
@@ -1175,12 +2033,160 @@ async function reconstructFinalizer(
     path: rel(target, finalizerPath),
     filesWritten: [rel(target, finalizerPath)],
     evidenceLines,
+    preserved: ["finalizer intent evidence"],
+    replaced: ["Task section", "Output Format", "current structural-issue contract"],
+    manualReview: [],
+    convergence: {
+      improvementPasses: 0,
+      stopReason: "setup reconstruction preserved intent evidence on the current skeleton",
+      qualityVerdict: "acceptable",
+    },
+  };
+}
+
+async function authorSetupFinalizer(
+  target: string,
+  signals: RepoSignals,
+): Promise<FinalizerReconstruction> {
+  const finalizerPath = join(target, ".harness", "loom", "agents", "harness-finalizer.md");
+  if (signals.evidence.length === 0) {
+    return {
+      status: "default-noop",
+      reason: "repo signals are too thin; installed default finalizer remains in place",
+      path: rel(target, finalizerPath),
+      filesWritten: [],
+      evidenceLines: [],
+      preserved: [],
+      replaced: [],
+      manualReview: [],
+      convergence: {
+        improvementPasses: 0,
+        stopReason: "no repo-grounded cycle-end duty detected",
+        qualityVerdict: "fallback",
+      },
+    };
+  }
+  await writeFile(finalizerPath, renderSetupFinalizerFromSignals(signals));
+  return {
+    status: "authored",
+    reason: "setup mode authored a concrete cycle-end finalizer from repo signals",
+    path: rel(target, finalizerPath),
+    filesWritten: [rel(target, finalizerPath)],
+    evidenceLines: signals.evidence.map((signal) => `Repo signal: ${signal}`),
+    preserved: [],
+    replaced: ["finalizer Task section"],
+    manualReview: [],
+    convergence: {
+      improvementPasses: 0,
+      stopReason: "initial authored finalizer met setup quality bar",
+      qualityVerdict: "acceptable",
+    },
+  };
+}
+
+async function migrateFinalizer(
+  target: string,
+  snapshotPath: string | null,
+  summary: FinalizerSummary,
+): Promise<FinalizerReconstruction> {
+  const finalizerPath = join(target, ".harness", "loom", "agents", "harness-finalizer.md");
+  if (summary.status === "absent") {
+    return {
+      status: "missing",
+      reason: "no prior finalizer existed; current default no-op remains",
+      path: rel(target, finalizerPath),
+      filesWritten: [],
+      evidenceLines: [],
+      preserved: [],
+      replaced: [],
+      manualReview: [],
+      convergence: {
+        improvementPasses: 0,
+        stopReason: "no prior finalizer to migrate",
+        qualityVerdict: "fallback",
+      },
+    };
+  }
+  if (summary.status === "default-noop") {
+    return {
+      status: "default-noop",
+      reason: "prior finalizer was already the safe no-op; current default remains",
+      path: rel(target, finalizerPath),
+      filesWritten: [],
+      evidenceLines: [],
+      preserved: [],
+      replaced: [],
+      manualReview: [],
+      convergence: {
+        improvementPasses: 0,
+        stopReason: "default no-op required no migration",
+        qualityVerdict: "acceptable",
+      },
+    };
+  }
+  if (!snapshotPath) {
+    return {
+      status: "skipped",
+      reason: "migration mode needs snapshot evidence to preserve the finalizer body",
+      path: rel(target, finalizerPath),
+      filesWritten: [],
+      evidenceLines: [],
+      preserved: [],
+      replaced: [],
+      manualReview: ["missing snapshot path for migration finalizer"],
+      convergence: {
+        improvementPasses: 0,
+        stopReason: "missing snapshot path",
+        qualityVerdict: "manual-review",
+      },
+    };
+  }
+  const snapshotFinalizer = join(snapshotPath, "loom", "agents", "harness-finalizer.md");
+  const sourceBody = await readOptional(snapshotFinalizer);
+  if (!sourceBody) {
+    return {
+      status: "skipped",
+      reason: "migration source finalizer body was not readable",
+      path: rel(target, finalizerPath),
+      filesWritten: [],
+      evidenceLines: [],
+      preserved: [],
+      replaced: [],
+      manualReview: [rel(target, snapshotFinalizer)],
+      convergence: {
+        improvementPasses: 0,
+        stopReason: "missing migration finalizer source body",
+        qualityVerdict: "manual-review",
+      },
+    };
+  }
+  await writeFile(finalizerPath, migratedFinalizerBody(sourceBody));
+  return {
+    status: "migrated",
+    reason: "migration mode preserved finalizer duties while refreshing contract-owned surfaces",
+    path: rel(target, finalizerPath),
+    filesWritten: [rel(target, finalizerPath)],
+    evidenceLines: finalizerEvidence(sourceBody, summary),
+    preserved: [
+      ...(introAfterHeading(sourceBody) ? ["finalizer intro"] : []),
+      ...(section(sourceBody, "Principles") ? ["finalizer Principles"] : []),
+      ...(section(sourceBody, "Task") ? ["finalizer Task"] : []),
+    ],
+    replaced: ["frontmatter skills", "current Output Format", "current Structural Issue block"],
+    manualReview: [],
+    convergence: {
+      improvementPasses: 0,
+      stopReason: "migration preserved finalizer body with current contract surfaces",
+      qualityVerdict: "acceptable",
+    },
   };
 }
 
 async function createSnapshot(
   target: string,
   createdAt: string,
+  runMode: RunMode,
+  targetState: TargetState,
   activeCycle: ActiveCycleSummary,
   registrySummary: RegistrySummary,
   finalizerSummary: FinalizerSummary,
@@ -1212,8 +2218,10 @@ async function createSnapshot(
     registrySummary,
     finalizerSummary,
     nextAction: "Foundation refresh will reseed .harness/loom and .harness/cycle; valid registered pairs and customized finalizer intent will be reconstructed after refresh, then explicit sync remains a user handoff.",
+    runMode,
+    targetState,
     recommendations: {
-      mode: "reconstruct-after-refresh",
+      mode: runMode,
       pairs: recommendations.pairs,
       finalizer: recommendations.finalizer,
       sync: recommendations.sync,
@@ -1254,7 +2262,10 @@ async function main() {
   const cycleDir = join(harnessDir, "cycle");
   const loomExists = await exists(loomDir);
   const cycleExists = await exists(cycleDir);
-  const mode = loomExists || cycleExists ? "existing" : "fresh";
+  const targetState: TargetState = loomExists || cycleExists ? "existing" : "fresh";
+  if (args.runMode === "migration" && targetState === "fresh") {
+    die("--migration requires existing .harness/loom or .harness/cycle state");
+  }
   const command = syncCommand(args.providers);
 
   const activeCycle = await classifyCycle(args.target, cycleDir);
@@ -1279,8 +2290,17 @@ async function main() {
   };
 
   const snapshot =
-    mode === "existing"
-      ? await createSnapshot(args.target, createdAt, activeCycle, registrySummary, finalizerSummary, recommendations)
+    targetState === "existing"
+      ? await createSnapshot(
+          args.target,
+          createdAt,
+          args.runMode,
+          targetState,
+          activeCycle,
+          registrySummary,
+          finalizerSummary,
+          recommendations,
+        )
       : { created: false, path: null, manifestPath: null, copiedNamespaces: [] };
 
   const warnings: string[] = [];
@@ -1300,24 +2320,43 @@ async function main() {
     die(`foundation refresh failed: ${detail}`);
   }
 
-  const pairReconstructions = await reconstructPairs(args.target, snapshot.path, registrySummary, signals);
-  const finalizerReconstruction = await reconstructFinalizer(args.target, snapshot.path, finalizerSummary);
+  let pairReconstructions: PairReconstruction[] = [];
+  let finalizerReconstruction: FinalizerReconstruction;
+  if (args.runMode === "migration") {
+    pairReconstructions = await migratePairs(args.target, snapshot.path, registrySummary, signals);
+    finalizerReconstruction = await migrateFinalizer(args.target, snapshot.path, finalizerSummary);
+  } else if (registrySummary.pairCount > 0) {
+    pairReconstructions = await reconstructPairs(args.target, snapshot.path, registrySummary, signals);
+    finalizerReconstruction =
+      finalizerSummary.status === "customized"
+        ? await reconstructFinalizer(args.target, snapshot.path, finalizerSummary)
+        : await authorSetupFinalizer(args.target, signals);
+  } else {
+    pairReconstructions = await authorSetupPairs(args.target, signals);
+    finalizerReconstruction =
+      finalizerSummary.status === "customized"
+        ? await reconstructFinalizer(args.target, snapshot.path, finalizerSummary)
+        : await authorSetupFinalizer(args.target, signals);
+  }
 
   const summary = {
     schemaVersion: 1,
     tool: "harness-auto-setup",
     targetPath: args.target,
     createdAt,
-    mode,
+    mode: args.runMode,
+    targetState,
     snapshot,
     activeCycle,
     registrySummary,
     finalizerSummary,
     repoSignals: signals,
     convergence: {
-      mode: "current-contract-reconstruction",
+      mode: args.runMode === "migration" ? "protected-migration-overlay" : "setup-author-first",
       note:
-        "Pair/finalizer files were not blind-copied. Valid registered pairs and customized finalizer intent were regenerated against current templates from snapshot evidence.",
+        args.runMode === "migration"
+          ? "Migration mode preserved user-authored pair/finalizer guidance where possible while refreshing contract-owned runtime surfaces."
+          : "Setup mode authors or reconstructs usable pair/finalizer outputs in one run, falling back to recommendations only when repo grounding is too thin.",
       pairReconstructions,
       finalizerReconstruction,
       pairRecommendations: recommendations.pairs,

--- a/plugins/harness-loom/skills/harness-pair-dev/SKILL.md
+++ b/plugins/harness-loom/skills/harness-pair-dev/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: harness-pair-dev
 description: "Use when `/harness-pair-dev` is invoked to author, revise, position, or remove a target project's producer-reviewer pair in `.harness/loom/`."
-argument-hint: "--add <pair-slug> \"<purpose>\" [--from <existing-pair-slug>] [--reviewer <slug> ...] [--before <pair-slug> | --after <pair-slug>] | --improve <pair-slug> \"<purpose>\" [--before <pair-slug> | --after <pair-slug>] | --remove <pair-slug>"
+argument-hint: "--add <pair-slug> \"<purpose>\" [--from <source>] [--reviewer <slug> ...] [--before <pair-slug> | --after <pair-slug>] | --improve <pair-slug> \"<purpose>\" [--before <pair-slug> | --after <pair-slug>] | --remove <pair-slug>"
 user-invocable: true
 ---
 
@@ -32,7 +32,7 @@ Use `scripts/pair-dev.ts` for deterministic command validation, registered-pair 
 ### 2. Command surface
 
 ```text
-/harness-pair-dev --add <pair-slug> "<purpose>" [--from <existing-pair-slug>] [--reviewer <slug> ...] [--before <pair-slug> | --after <pair-slug>]
+/harness-pair-dev --add <pair-slug> "<purpose>" [--from <source>] [--reviewer <slug> ...] [--before <pair-slug> | --after <pair-slug>]
 /harness-pair-dev --improve <pair-slug> "<purpose>" [--before <pair-slug> | --after <pair-slug>]
 /harness-pair-dev --remove <pair-slug>
 ```
@@ -42,8 +42,11 @@ All slug-bearing arguments must be canonical before the deterministic helper or 
 ### 3. `--add`
 
 1. Parse args and stop immediately if `<purpose>` is missing or the target does not yet contain the installed runtime foundation.
-2. If `--from <existing-pair-slug>` is present, resolve it only from the target's current `.harness/loom/registry.md` `## Registered pairs`.
-3. Reject `--from` values that are snapshot paths, agent paths, skill paths, derived platform paths, missing registry entries, planner/finalizer slugs, or foundation skill names.
+2. If `--from <source>` is present, resolve it from one of:
+   - a currently registered live pair slug in `.harness/loom/registry.md`
+   - `snapshot:<ts>/<pair-slug>` under `.harness/_snapshots/auto-setup/<ts>/loom/`
+   - `archive:<ts>/<pair-slug>` under `.harness/_archive/<ts>/loom/`
+3. Reject `--from` values that are arbitrary filesystem paths, derived platform paths, missing registry entries, planner/finalizer slugs, or foundation skill names.
 4. When `--from` is present, follow `references/authoring/from-overlay.md`: start from current templates, enforce current runtime shape, then overlay compatible source-pair domain material.
 5. Let `<purpose>` override the source pair's old intent whenever the two conflict. `<purpose>` remains required even with `--from`.
 6. Decide the reviewer shape:
@@ -93,7 +96,7 @@ Treat that section as workflow order, not as a changelog.
 ## Evaluation Criteria
 
 - `--add` receives a required positional `<purpose>` and uses it as the main axis for the pair.
-- `--add --from` accepts only a currently registered pair slug and applies template-first overlay, never snapshot/path/provider import or blind copy.
+- `--add --from` accepts a current live pair slug or a target-local `snapshot:` / `archive:` locator and applies template-first overlay, never arbitrary path/provider import or blind copy.
 - `--improve` receives a required positional `<purpose>` and uses it as the main axis for revision.
 - All authored files live under `.harness/loom/`.
 - `--add` and `--improve` start from actual codebase evidence.
@@ -113,7 +116,7 @@ Treat that section as workflow order, not as a changelog.
 - Rename slugs casually during `--improve`.
 - Accept `--hint`; intent belongs in positional `<purpose>`.
 - Accept `--split`; split is a user-directed multi-command sequence, not a single pair-dev command.
-- Accept `--from` as a snapshot path, file path, derived platform path, or blind-copy import.
+- Accept `--from` as an arbitrary snapshot path, file path, derived platform path, or blind-copy import.
 - Preserve source `skills:` wholesale during `--from`; the new pair skill plus `harness-context` are mandatory template authority, while extra domain skills are preservation candidates.
 - Remove a pair referenced by the active cycle's `Next` or live EPIC roster.
 - Delete `.harness/cycle/` history during pair removal.

--- a/plugins/harness-loom/skills/harness-pair-dev/references/authoring/from-overlay.md
+++ b/plugins/harness-loom/skills/harness-pair-dev/references/authoring/from-overlay.md
@@ -1,21 +1,27 @@
 ---
 name: from-overlay
-description: "Use when `/harness-pair-dev --add <pair> \"<purpose>\" --from <existing-pair>` authors a new pair from a currently registered source pair. Defines template-first overlay, mandatory runtime shape, and source material preservation rules."
+description: "Use when `/harness-pair-dev --add <pair> \"<purpose>\" --from <source>` authors a new pair from a live registered source pair or a target-local snapshot/archive locator. Defines template-first overlay, mandatory runtime shape, and source material preservation rules."
 user-invocable: false
 ---
 
 # From Overlay
 
-`--from` means "start from the current pair templates, then overlay compatible source-pair knowledge." It is not a blind copy, snapshot import, filesystem import, or provider-tree import.
+`--from` means "start from the current pair templates, then overlay compatible source-pair knowledge." It is not a blind copy, arbitrary filesystem import, or provider-tree import.
 
-The source pair must already be registered in the target's current `.harness/loom/registry.md`. A current registered pair is trusted more than an auto-setup snapshot, so preserve useful domain shape aggressively, but never let source text override current harness runtime contracts.
+Supported sources are:
+
+- a live registered pair slug from the target's current `.harness/loom/registry.md`
+- `snapshot:<ts>/<pair>` from `.harness/_snapshots/auto-setup/<ts>/loom/`
+- `archive:<ts>/<pair>` from `.harness/_archive/<ts>/loom/`
+
+Live registered pairs are the strongest source because they already reflect the current target harness. Snapshot/archive sources are migration evidence: preserve useful domain shape, but never let stale text override current harness runtime contracts.
 
 ## Methodology
 
 ### 1. Template-first sequence
 
-1. Run `scripts/pair-dev.ts --add <new-pair> "<purpose>" --from <source-pair>` and confirm it returns preparation JSON.
-2. Read the source pair skill and source producer/reviewer agents from `.harness/loom/`.
+1. Run `scripts/pair-dev.ts --add <new-pair> "<purpose>" --from <source>` and confirm it returns preparation JSON.
+2. Read the source pair skill and source producer/reviewer agents from the resolved live or non-live source root.
 3. Create the new pair from the current templates:
    - `templates/pair-skill.md`
    - `templates/producer-agent.md`
@@ -83,7 +89,7 @@ Do not preserve the source `skills:` list wholesale.
 ## Taboos
 
 - Blind-copy source pair files into the new pair.
-- Treat `--from` as a snapshot path, filesystem path, or derived provider-tree import.
+- Treat `--from` as an arbitrary snapshot path, filesystem path, or derived provider-tree import.
 - Preserve an old Output Format because the source used it.
 - Preserve source `skills:` wholesale.
 - Drop all source domain guidance and produce a generic pair despite `--from`.

--- a/plugins/harness-loom/skills/harness-pair-dev/scripts/pair-dev.ts
+++ b/plugins/harness-loom/skills/harness-pair-dev/scripts/pair-dev.ts
@@ -31,6 +31,22 @@ interface RegistryEntry {
   line: string;
 }
 
+type FromSourceKind = "live" | "snapshot" | "archive";
+
+interface FromSource {
+  kind: FromSourceKind;
+  locator: string;
+  registryPath: string;
+  pair: string;
+  producer: string;
+  reviewers: string[];
+  skill: string;
+  skillPath: string | null;
+  producerPath: string | null;
+  reviewerPaths: Record<string, string | null>;
+  missingArtifacts: string[];
+}
+
 interface Placement {
   mode: "append" | "before" | "after";
   anchor?: string;
@@ -74,7 +90,7 @@ function help(): never {
   process.stdout.write(
     [
       "Usage:",
-      '  node <harness-pair-dev>/scripts/pair-dev.ts --add <pair-slug> "<purpose>" [--from <existing-pair-slug>] [--reviewer <slug> ...] [--before <pair-slug> | --after <pair-slug>]',
+      '  node <harness-pair-dev>/scripts/pair-dev.ts --add <pair-slug> "<purpose>" [--from <source>] [--reviewer <slug> ...] [--before <pair-slug> | --after <pair-slug>]',
       '  node <harness-pair-dev>/scripts/pair-dev.ts --improve <pair-slug> "<purpose>" [--before <pair-slug> | --after <pair-slug>]',
       "  node <harness-pair-dev>/scripts/pair-dev.ts --remove <pair-slug>",
       "",
@@ -194,6 +210,10 @@ function normalizeCRLF(raw: string): string {
   return raw.replace(/\r\n/g, "\n");
 }
 
+function rel(target: string, path: string): string {
+  return relative(target, path).split("\\").join("/");
+}
+
 function extractSection(raw: string, heading: string): string | null {
   const headingLine = `## ${heading}`;
   const normalized = normalizeCRLF(raw);
@@ -248,6 +268,12 @@ function findEntry(entries: RegistryEntry[], pair: string): RegistryEntry | null
   return entries.find((entry) => entry.pair === pair) ?? null;
 }
 
+async function readRegistryAt(registryPath: string): Promise<RegistryEntry[]> {
+  if (!(await exists(registryPath))) die(`missing source registry: ${registryPath}`);
+  const raw = await readFile(registryPath, "utf8");
+  return parseRegistry(raw);
+}
+
 function placement(args: Args): Placement {
   if (args.before) return { mode: "before", anchor: args.before };
   if (args.after) return { mode: "after", anchor: args.after };
@@ -260,20 +286,106 @@ function assertAnchor(entries: RegistryEntry[], args: Args): void {
   if (!findEntry(entries, anchor)) die(`placement anchor is not a registered pair: ${anchor}`);
 }
 
-function validateFrom(entries: RegistryEntry[], from: string): RegistryEntry {
+function sourceBaseDir(target: string, kind: Exclude<FromSourceKind, "live">): string {
+  return kind === "snapshot"
+    ? join(target, ".harness", "_snapshots", "auto-setup")
+    : join(target, ".harness", "_archive");
+}
+
+function sourceArtifactPathSummary(
+  target: string,
+  entry: RegistryEntry,
+  loomRoot: string,
+  registryPath: string,
+  kind: FromSourceKind,
+  locator: string,
+  presence: { skill: boolean; producer: boolean; reviewers: Map<string, boolean> },
+): FromSource {
+  const skillPath = join(loomRoot, "skills", entry.skill, "SKILL.md");
+  const producerPath = join(loomRoot, "agents", `${entry.producer}.md`);
+  const reviewerPaths: Record<string, string | null> = {};
+  const missingArtifacts: string[] = [];
+
+  if (!presence.skill) missingArtifacts.push(rel(target, skillPath));
+  if (!presence.producer) missingArtifacts.push(rel(target, producerPath));
+  for (const reviewer of entry.reviewers) {
+    const reviewerPath = join(loomRoot, "agents", `${reviewer}.md`);
+    const present = presence.reviewers.get(reviewer) ?? false;
+    reviewerPaths[reviewer] = present ? rel(target, reviewerPath) : null;
+    if (!present) missingArtifacts.push(rel(target, reviewerPath));
+  }
+
+  return {
+    kind,
+    locator,
+    registryPath: rel(target, registryPath),
+    pair: entry.pair,
+    producer: entry.producer,
+    reviewers: entry.reviewers,
+    skill: entry.skill,
+    skillPath: presence.skill ? rel(target, skillPath) : null,
+    producerPath: presence.producer ? rel(target, producerPath) : null,
+    reviewerPaths,
+    missingArtifacts,
+  };
+}
+
+async function resolveSourceSummary(
+  target: string,
+  entry: RegistryEntry,
+  loomRoot: string,
+  registryPath: string,
+  kind: FromSourceKind,
+  locator: string,
+): Promise<FromSource> {
+  const skillPath = join(loomRoot, "skills", entry.skill, "SKILL.md");
+  const producerPath = join(loomRoot, "agents", `${entry.producer}.md`);
+  const reviewerPresence = new Map<string, boolean>();
+  for (const reviewer of entry.reviewers) {
+    reviewerPresence.set(reviewer, await exists(join(loomRoot, "agents", `${reviewer}.md`)));
+  }
+  return sourceArtifactPathSummary(target, entry, loomRoot, registryPath, kind, locator, {
+    skill: await exists(skillPath),
+    producer: await exists(producerPath),
+    reviewers: reviewerPresence,
+  });
+}
+
+async function validateFrom(target: string, entries: RegistryEntry[], from: string): Promise<FromSource> {
+  const locator = from.match(/^(snapshot|archive):([^/]+)\/(harness-[a-z0-9]+(?:-[a-z0-9]+)*)$/);
+  if (locator) {
+    const kind = locator[1] as Exclude<FromSourceKind, "live">;
+    const stamp = locator[2];
+    const pair = locator[3];
+    if (FOUNDATION_SLUGS.has(pair)) die(`--from ${pair} is a foundation or singleton role, not a registered pair`);
+    const baseDir = sourceBaseDir(target, kind);
+    const loomRoot = safeResolve(baseDir, stamp, "loom");
+    const registryPath = safeResolve(loomRoot, "registry.md");
+    const sourceEntries = await readRegistryAt(registryPath);
+    const entry = findEntry(sourceEntries, pair);
+    if (!entry) die(`--from pair is not registered in ${kind} source: ${pair}`);
+    return resolveSourceSummary(target, entry, loomRoot, registryPath, kind, from);
+  }
   if (
     from.includes("/") ||
     from.includes("\\") ||
     from.startsWith(".") ||
     from.endsWith(".md")
   ) {
-    die("--from accepts a registered pair slug, not a file, snapshot, or platform path");
+    die("--from accepts a registered pair slug or snapshot:/archive: locator, not a file or platform path");
   }
   if (FOUNDATION_SLUGS.has(from)) die(`--from ${from} is a foundation or singleton role, not a registered pair`);
-  if (!SLUG_RE.test(from)) die(`--from must be a registered harness pair slug (got: ${from})`);
+  if (!SLUG_RE.test(from)) die(`--from must be a registered harness pair slug or snapshot:/archive: locator (got: ${from})`);
   const entry = findEntry(entries, from);
   if (!entry) die(`--from pair is not registered: ${from}`);
-  return entry;
+  return resolveSourceSummary(
+    target,
+    entry,
+    join(target, ".harness", "loom"),
+    join(target, ".harness", "loom", "registry.md"),
+    "live",
+    from,
+  );
 }
 
 function extractHarnessSlugs(text: string): Set<string> {
@@ -464,7 +576,7 @@ async function prepareAdd(target: string, args: Args): Promise<unknown> {
   const registry = await readRegistry(target);
   if (findEntry(registry.entries, args.pair)) die(`${args.pair} is already registered; use --improve`);
   assertAnchor(registry.entries, args);
-  const from = args.from ? validateFrom(registry.entries, args.from) : null;
+  const from = args.from ? await validateFrom(target, registry.entries, args.from) : null;
   const reviewers = args.reviewers.length > 0 ? args.reviewers : [`${args.pair}-reviewer`];
   return {
     action: "prepare-add",

--- a/tests/auto-setup.test.mjs
+++ b/tests/auto-setup.test.mjs
@@ -120,17 +120,30 @@ test("auto-setup fresh target installs foundation and prints explicit sync hando
   try {
     writeFileSync(join(target, "README.md"), "# Demo\n");
 
-    const { summary } = runAutoSetup(target, ["--provider", "codex"]);
+    const { summary } = runAutoSetup(target, ["--setup", "--provider", "codex"]);
 
-    assert.equal(summary.mode, "fresh");
+    assert.equal(summary.mode, "setup");
+    assert.equal(summary.targetState, "fresh");
     assert.equal(summary.snapshot.created, false);
     assert.equal(summary.activeCycle.classification, "absent");
     assert.equal(summary.install.summary.verification.ok, true);
     assert.equal(summary.syncCommand, "node .harness/loom/sync.ts --provider codex");
     assert.deepEqual(summary.providerTreesWritten, []);
-    assert.match(summary.convergence.pairRecommendations.join("\n"), /documentation evidence/);
+    assert.equal(summary.convergence.pairReconstructions.length, 1);
+    assert.equal(summary.convergence.pairReconstructions[0].status, "authored");
+    assert.equal(summary.convergence.pairReconstructions[0].pair, "harness-document");
+    assert.equal(summary.convergence.finalizerReconstruction.status, "authored");
     assert.ok(existsSync(join(target, ".harness/loom/sync.ts")));
     assert.ok(existsSync(join(target, ".harness/cycle/state.md")));
+    assert.ok(existsSync(join(target, ".harness/loom/agents/harness-document-producer.md")));
+    assert.match(
+      readFileSync(join(target, ".harness/loom/registry.md"), "utf8"),
+      /^- harness-document:/m,
+    );
+    assert.match(
+      readFileSync(join(target, ".harness/loom/agents/harness-finalizer.md"), "utf8"),
+      /Refresh README, docs, or CHANGELOG/,
+    );
     assertNoProviderTrees(target);
   } finally {
     cleanupDir(target);
@@ -171,9 +184,10 @@ test("auto-setup preserves pre-existing provider trees and only prints sync hand
       [".gemini", snapshotTree(join(target, ".gemini"))],
     ]);
 
-    const { summary } = runAutoSetup(target, ["--provider", "claude,gemini"]);
+    const { summary } = runAutoSetup(target, ["--setup", "--provider", "claude,gemini"]);
 
-    assert.equal(summary.mode, "existing");
+    assert.equal(summary.mode, "setup");
+    assert.equal(summary.targetState, "existing");
     assert.equal(summary.syncCommand, "node .harness/loom/sync.ts --provider claude,gemini");
     assert.equal(
       summary.nextAction,
@@ -247,10 +261,11 @@ test("auto-setup reconstructs registered pair files and registry after refresh",
       ].join("\n"),
     );
 
-    const { summary } = runAutoSetup(target);
+    const { summary } = runAutoSetup(target, ["--setup"]);
     const manifest = readJson(summary.snapshot.manifestPath);
 
-    assert.equal(summary.mode, "existing");
+    assert.equal(summary.mode, "setup");
+    assert.equal(summary.targetState, "existing");
     assert.equal(summary.snapshot.created, true);
     assert.deepEqual(summary.snapshot.copiedNamespaces, [".harness/cycle", ".harness/loom"]);
     assertManifestShape(manifest);
@@ -292,6 +307,804 @@ test("auto-setup reconstructs registered pair files and registry after refresh",
     );
     assert.equal(registry.match(/^- harness-demo:/gm).length, 1);
     assertNoProviderTrees(target);
+  } finally {
+    cleanupDir(target);
+  }
+});
+
+test("auto-setup migration preserves custom pair and finalizer bodies while refreshing contract surfaces", () => {
+  const target = makeTempDir();
+  try {
+    installTo(target);
+    const oldSkill = [
+      "---",
+      "name: harness-demo",
+      'description: "Use when maintaining custom demo build scripts."',
+      "user-invocable: false",
+      "---",
+      "",
+      "# Old Demo",
+      "",
+      "## Design Thinking",
+      "",
+      "Own custom demo release packaging.",
+      "",
+      "## Methodology",
+      "",
+      "Keep custom build scripts and fixture snapshots aligned.",
+      "",
+      "## Evaluation Criteria",
+      "",
+      "- Old criterion.",
+      "",
+      "## Taboos",
+      "",
+      "- Old taboo.",
+      "",
+    ].join("\n");
+    mkdirSync(join(target, ".harness/loom/skills/harness-demo"), { recursive: true });
+    writeFileSync(join(target, ".harness/loom/skills/harness-demo/SKILL.md"), oldSkill);
+    writeFileSync(
+      join(target, ".harness/loom/agents/harness-demo-producer.md"),
+      [
+        "---",
+        "name: harness-demo-producer",
+        'description: "Use when maintaining custom demo producer work."',
+        "skills:",
+        "  - harness-demo",
+        "  - harness-context",
+        "  - demo-domain",
+        "---",
+        "",
+        "# Demo Producer",
+        "",
+        "Producer identity that should survive migration.",
+        "",
+        "## Principles",
+        "",
+        "1. Preserve demo packaging context.",
+        "",
+        "## Task",
+        "",
+        "1. Maintain custom build scripts.",
+        "",
+        "## Output Format",
+        "",
+        "Status: PASS / FAIL",
+        "Summary: legacy block",
+        "",
+      ].join("\n"),
+    );
+    writeFileSync(
+      join(target, ".harness/loom/agents/harness-demo-reviewer.md"),
+      [
+        "---",
+        "name: harness-demo-reviewer",
+        'description: "Use when auditing demo reviewer work."',
+        "skills:",
+        "  - harness-demo",
+        "  - harness-context",
+        "---",
+        "",
+        "# Demo Reviewer",
+        "",
+        "Reviewer identity that should survive migration.",
+        "",
+        "## Principles",
+        "",
+        "1. Check fixture snapshots carefully.",
+        "",
+        "## Task",
+        "",
+        "1. Audit fixture snapshots.",
+        "",
+      ].join("\n"),
+    );
+    writeFileSync(
+      join(target, ".harness/loom/agents/harness-finalizer.md"),
+      [
+        "---",
+        "name: harness-finalizer",
+        "skills:",
+        "  - harness-context",
+        "---",
+        "",
+        "# Finalizer",
+        "",
+        "Finalizer intro that should survive migration.",
+        "",
+        "## Principles",
+        "",
+        "1. Keep release notes coherent.",
+        "",
+        "## Task",
+        "",
+        "1. Refresh docs/ and CHANGELOG.md after verified release work.",
+        "",
+      ].join("\n"),
+    );
+    writeFileSync(
+      join(target, ".harness/loom/registry.md"),
+      [
+        "# Registry",
+        "",
+        "## Registered pairs",
+        "",
+        "- harness-demo: producer `harness-demo-producer` ↔ reviewer `harness-demo-reviewer`, skill `harness-demo`",
+        "",
+      ].join("\n"),
+    );
+
+    const { summary } = runAutoSetup(target, ["--migration"]);
+
+    assert.equal(summary.mode, "migration");
+    assert.equal(summary.targetState, "existing");
+    assert.equal(summary.convergence.pairReconstructions[0].status, "migrated");
+    assert.equal(summary.convergence.pairReconstructions[0].source.kind, "snapshot");
+    assert.match(summary.convergence.pairReconstructions[0].replaced.join("\n"), /frontmatter skills/);
+    const currentSkill = readFileSync(join(target, ".harness/loom/skills/harness-demo/SKILL.md"), "utf8");
+    assert.match(currentSkill, /Own custom demo release packaging/);
+    assert.match(currentSkill, /Keep custom build scripts and fixture snapshots aligned/);
+    assert.doesNotMatch(currentSkill, /### Preserved Snapshot Intent/);
+
+    const currentProducer = readFileSync(join(target, ".harness/loom/agents/harness-demo-producer.md"), "utf8");
+    assert.match(currentProducer, /Producer identity that should survive migration/);
+    assert.match(currentProducer, /1\. Maintain custom build scripts\./);
+    assert.match(currentProducer, /^skills:\n  - harness-demo\n  - harness-context\n  - demo-domain$/m);
+    assert.match(currentProducer, /^Status: PASS \/ FAIL$/m);
+
+    const currentReviewer = readFileSync(join(target, ".harness/loom/agents/harness-demo-reviewer.md"), "utf8");
+    assert.match(currentReviewer, /Reviewer identity that should survive migration/);
+    assert.match(currentReviewer, /1\. Audit fixture snapshots\./);
+    assert.match(currentReviewer, /^Verdict: PASS \/ FAIL$/m);
+
+    assert.equal(summary.convergence.finalizerReconstruction.status, "migrated");
+    const currentFinalizer = readFileSync(join(target, ".harness/loom/agents/harness-finalizer.md"), "utf8");
+    assert.match(currentFinalizer, /Finalizer intro that should survive migration/);
+    assert.match(currentFinalizer, /Refresh docs\/ and CHANGELOG\.md after verified release work/);
+    assert.match(currentFinalizer, /^Status: PASS \/ FAIL$/m);
+    assert.match(currentFinalizer, /## Structural Issue/);
+    assertNoProviderTrees(target);
+  } finally {
+    cleanupDir(target);
+  }
+});
+
+test("auto-setup migration handles source agents and finalizer without intro paragraphs", () => {
+  const target = makeTempDir();
+  try {
+    installTo(target);
+    mkdirSync(join(target, ".harness/loom/skills/harness-demo"), { recursive: true });
+    writeFileSync(
+      join(target, ".harness/loom/skills/harness-demo/SKILL.md"),
+      [
+        "---",
+        "name: harness-demo",
+        'description: "Use when maintaining custom demo build scripts."',
+        "user-invocable: false",
+        "---",
+        "",
+        "# Old Demo",
+        "",
+        "## Design Thinking",
+        "",
+        "Own custom demo release packaging.",
+        "",
+        "## Methodology",
+        "",
+        "Keep custom build scripts and fixture snapshots aligned.",
+        "",
+      ].join("\n"),
+    );
+    writeFileSync(
+      join(target, ".harness/loom/agents/harness-demo-producer.md"),
+      [
+        "---",
+        "name: harness-demo-producer",
+        'description: "Use when maintaining custom demo producer work."',
+        "skills:",
+        "  - harness-demo",
+        "  - harness-context",
+        "---",
+        "",
+        "# Demo Producer",
+        "## Principles",
+        "",
+        "1. Preserve demo packaging context.",
+        "",
+        "## Task",
+        "",
+        "1. Maintain custom build scripts.",
+        "",
+      ].join("\n"),
+    );
+    writeFileSync(
+      join(target, ".harness/loom/agents/harness-demo-reviewer.md"),
+      [
+        "---",
+        "name: harness-demo-reviewer",
+        'description: "Use when auditing demo reviewer work."',
+        "skills:",
+        "  - harness-demo",
+        "  - harness-context",
+        "---",
+        "",
+        "# Demo Reviewer",
+        "",
+        "Reviewer identity that should survive migration.",
+        "",
+        "## Principles",
+        "",
+        "1. Check fixture snapshots carefully.",
+        "",
+        "## Task",
+        "",
+        "1. Audit fixture snapshots.",
+        "",
+      ].join("\n"),
+    );
+    writeFileSync(
+      join(target, ".harness/loom/agents/harness-finalizer.md"),
+      [
+        "---",
+        "name: harness-finalizer",
+        "skills:",
+        "  - harness-context",
+        "---",
+        "",
+        "# Finalizer",
+        "## Principles",
+        "",
+        "1. Keep release notes coherent.",
+        "",
+        "## Task",
+        "",
+        "1. Refresh docs/ and CHANGELOG.md after verified release work.",
+        "",
+      ].join("\n"),
+    );
+    writeFileSync(
+      join(target, ".harness/loom/registry.md"),
+      [
+        "# Registry",
+        "",
+        "## Registered pairs",
+        "",
+        "- harness-demo: producer `harness-demo-producer` ↔ reviewer `harness-demo-reviewer`, skill `harness-demo`",
+        "",
+      ].join("\n"),
+    );
+
+    runAutoSetup(target, ["--migration"]);
+
+    const currentProducer = readFileSync(join(target, ".harness/loom/agents/harness-demo-producer.md"), "utf8");
+    assert.equal((currentProducer.match(/^## Principles$/gm) ?? []).length, 1);
+    assert.equal((currentProducer.match(/^## Task$/gm) ?? []).length, 1);
+
+    const currentFinalizer = readFileSync(join(target, ".harness/loom/agents/harness-finalizer.md"), "utf8");
+    assert.equal((currentFinalizer.match(/^## Principles$/gm) ?? []).length, 1);
+    assert.equal((currentFinalizer.match(/^## Task$/gm) ?? []).length, 1);
+  } finally {
+    cleanupDir(target);
+  }
+});
+
+test("auto-setup migration preserves escaped quotes in frontmatter descriptions", () => {
+  const target = makeTempDir();
+  try {
+    installTo(target);
+    mkdirSync(join(target, ".harness/loom/skills/harness-demo"), { recursive: true });
+    writeFileSync(
+      join(target, ".harness/loom/skills/harness-demo/SKILL.md"),
+      [
+        "---",
+        "name: harness-demo",
+        'description: "Use when handling \\"demo\\" work." # preserve this note',
+        "user-invocable: false",
+        "---",
+        "",
+        "# Demo Skill",
+        "",
+        "## Design Thinking",
+        "",
+        "Own custom demo release packaging.",
+        "",
+      ].join("\n"),
+    );
+    writeFileSync(
+      join(target, ".harness/loom/agents/harness-demo-producer.md"),
+      [
+        "---",
+        "name: harness-demo-producer",
+        'description: "Use when handling \\"demo\\" producer work." # preserve this note',
+        "skills:",
+        "  - harness-demo",
+        "  - harness-context",
+        "---",
+        "",
+        "# Demo Producer",
+        "",
+        "Producer identity.",
+        "",
+        "## Principles",
+        "",
+        "1. Preserve demo packaging context.",
+        "",
+        "## Task",
+        "",
+        "1. Maintain custom build scripts.",
+        "",
+      ].join("\n"),
+    );
+    writeFileSync(
+      join(target, ".harness/loom/agents/harness-demo-reviewer.md"),
+      [
+        "---",
+        "name: harness-demo-reviewer",
+        'description: "Use when auditing demo reviewer work."',
+        "skills:",
+        "  - harness-demo",
+        "  - harness-context",
+        "---",
+        "",
+        "# Demo Reviewer",
+        "",
+        "Reviewer identity.",
+        "",
+        "## Principles",
+        "",
+        "1. Check fixture snapshots carefully.",
+        "",
+        "## Task",
+        "",
+        "1. Audit fixture snapshots.",
+        "",
+      ].join("\n"),
+    );
+    writeFileSync(
+      join(target, ".harness/loom/agents/harness-finalizer.md"),
+      [
+        "---",
+        "name: harness-finalizer",
+        'description: "Use when closing \\"demo\\" cycles." # preserve this note',
+        "skills:",
+        "  - harness-context",
+        "---",
+        "",
+        "# Finalizer",
+        "",
+        "Finalizer intro.",
+        "",
+        "## Principles",
+        "",
+        "1. Keep release notes coherent.",
+        "",
+        "## Task",
+        "",
+        "1. Refresh docs/ and CHANGELOG.md after verified release work.",
+        "",
+      ].join("\n"),
+    );
+    writeFileSync(
+      join(target, ".harness/loom/registry.md"),
+      [
+        "# Registry",
+        "",
+        "## Registered pairs",
+        "",
+        "- harness-demo: producer `harness-demo-producer` ↔ reviewer `harness-demo-reviewer`, skill `harness-demo`",
+        "",
+      ].join("\n"),
+    );
+
+    runAutoSetup(target, ["--migration"]);
+
+    const currentSkill = readFileSync(join(target, ".harness/loom/skills/harness-demo/SKILL.md"), "utf8");
+    assert.match(currentSkill, /^description: "Use when handling \\"demo\\" work\."$/m);
+
+    const currentProducer = readFileSync(join(target, ".harness/loom/agents/harness-demo-producer.md"), "utf8");
+    assert.match(currentProducer, /^description: "Use when handling \\"demo\\" producer work\."$/m);
+
+    const currentFinalizer = readFileSync(join(target, ".harness/loom/agents/harness-finalizer.md"), "utf8");
+    assert.match(currentFinalizer, /^description: "Use when closing \\"demo\\" cycles\."$/m);
+  } finally {
+    cleanupDir(target);
+  }
+});
+
+test("auto-setup migration preserves multiline block-scalar descriptions", () => {
+  const target = makeTempDir();
+  try {
+    installTo(target);
+    mkdirSync(join(target, ".harness/loom/skills/harness-demo"), { recursive: true });
+    writeFileSync(
+      join(target, ".harness/loom/skills/harness-demo/SKILL.md"),
+      [
+        "---",
+        "name: harness-demo",
+        "description: >",
+        "  Use when handling demo work",
+        "  across multiple migrations.",
+        "user-invocable: false",
+        "---",
+        "",
+        "# Demo Skill",
+        "",
+        "## Design Thinking",
+        "",
+        "Own custom demo release packaging.",
+        "",
+      ].join("\n"),
+    );
+    writeFileSync(
+      join(target, ".harness/loom/agents/harness-demo-producer.md"),
+      [
+        "---",
+        "name: harness-demo-producer",
+        "description: |",
+        "  Use when handling demo producer work.",
+        "  Preserve current contracts.",
+        "skills:",
+        "  - harness-demo",
+        "  - harness-context",
+        "---",
+        "",
+        "# Demo Producer",
+        "",
+        "Producer identity.",
+        "",
+        "## Principles",
+        "",
+        "1. Preserve demo packaging context.",
+        "",
+        "## Task",
+        "",
+        "1. Maintain custom build scripts.",
+        "",
+      ].join("\n"),
+    );
+    writeFileSync(
+      join(target, ".harness/loom/agents/harness-demo-reviewer.md"),
+      [
+        "---",
+        "name: harness-demo-reviewer",
+        'description: "Use when auditing demo reviewer work."',
+        "skills:",
+        "  - harness-demo",
+        "  - harness-context",
+        "---",
+        "",
+        "# Demo Reviewer",
+        "",
+        "Reviewer identity.",
+        "",
+        "## Principles",
+        "",
+        "1. Check fixture snapshots carefully.",
+        "",
+        "## Task",
+        "",
+        "1. Audit fixture snapshots.",
+        "",
+      ].join("\n"),
+    );
+    writeFileSync(
+      join(target, ".harness/loom/agents/harness-finalizer.md"),
+      [
+        "---",
+        "name: harness-finalizer",
+        "description: >",
+        "  Use when closing demo cycles",
+        "  after verified release work.",
+        "skills:",
+        "  - harness-context",
+        "---",
+        "",
+        "# Finalizer",
+        "",
+        "Finalizer intro.",
+        "",
+        "## Principles",
+        "",
+        "1. Keep release notes coherent.",
+        "",
+        "## Task",
+        "",
+        "1. Refresh docs/ and CHANGELOG.md after verified release work.",
+        "",
+      ].join("\n"),
+    );
+    writeFileSync(
+      join(target, ".harness/loom/registry.md"),
+      [
+        "# Registry",
+        "",
+        "## Registered pairs",
+        "",
+        "- harness-demo: producer `harness-demo-producer` ↔ reviewer `harness-demo-reviewer`, skill `harness-demo`",
+        "",
+      ].join("\n"),
+    );
+
+    runAutoSetup(target, ["--migration"]);
+
+    const currentSkill = readFileSync(join(target, ".harness/loom/skills/harness-demo/SKILL.md"), "utf8");
+    assert.match(
+      currentSkill,
+      /^description: "Use when handling demo work across multiple migrations\."$/m,
+    );
+
+    const currentProducer = readFileSync(join(target, ".harness/loom/agents/harness-demo-producer.md"), "utf8");
+    assert.ok(
+      currentProducer.includes('description: "Use when handling demo producer work.\\nPreserve current contracts."'),
+    );
+
+    const currentFinalizer = readFileSync(join(target, ".harness/loom/agents/harness-finalizer.md"), "utf8");
+    assert.match(
+      currentFinalizer,
+      /^description: "Use when closing demo cycles after verified release work\."$/m,
+    );
+  } finally {
+    cleanupDir(target);
+  }
+});
+
+test("auto-setup migration preserves block-scalar descriptions with indentation indicators", () => {
+  const target = makeTempDir();
+  try {
+    installTo(target);
+    mkdirSync(join(target, ".harness/loom/skills/harness-demo"), { recursive: true });
+    writeFileSync(
+      join(target, ".harness/loom/skills/harness-demo/SKILL.md"),
+      [
+        "---",
+        "name: harness-demo",
+        "description: >2",
+        "  Use when handling demo work",
+        "  across indentation-aware migrations.",
+        "user-invocable: false",
+        "---",
+        "",
+        "# Demo Skill",
+        "",
+        "## Design Thinking",
+        "",
+        "Own custom demo release packaging.",
+        "",
+      ].join("\n"),
+    );
+    writeFileSync(
+      join(target, ".harness/loom/agents/harness-demo-producer.md"),
+      [
+        "---",
+        "name: harness-demo-producer",
+        'description: "Use when handling demo producer work."',
+        "skills:",
+        "  - harness-demo",
+        "  - harness-context",
+        "---",
+        "",
+        "# Demo Producer",
+        "",
+        "Producer identity.",
+        "",
+        "## Principles",
+        "",
+        "1. Preserve demo packaging context.",
+        "",
+        "## Task",
+        "",
+        "1. Maintain custom build scripts.",
+        "",
+      ].join("\n"),
+    );
+    writeFileSync(
+      join(target, ".harness/loom/agents/harness-demo-reviewer.md"),
+      [
+        "---",
+        "name: harness-demo-reviewer",
+        'description: "Use when auditing demo reviewer work."',
+        "skills:",
+        "  - harness-demo",
+        "  - harness-context",
+        "---",
+        "",
+        "# Demo Reviewer",
+        "",
+        "Reviewer identity.",
+        "",
+        "## Principles",
+        "",
+        "1. Check fixture snapshots carefully.",
+        "",
+        "## Task",
+        "",
+        "1. Audit fixture snapshots.",
+        "",
+      ].join("\n"),
+    );
+    writeFileSync(
+      join(target, ".harness/loom/agents/harness-finalizer.md"),
+      [
+        "---",
+        "name: harness-finalizer",
+        "description: |1-",
+        " Use when closing demo cycles.",
+        " Keep release notes coherent.",
+        "skills:",
+        "  - harness-context",
+        "---",
+        "",
+        "# Finalizer",
+        "",
+        "Finalizer intro.",
+        "",
+        "## Principles",
+        "",
+        "1. Keep release notes coherent.",
+        "",
+        "## Task",
+        "",
+        "1. Refresh docs/ and CHANGELOG.md after verified release work.",
+        "",
+      ].join("\n"),
+    );
+    writeFileSync(
+      join(target, ".harness/loom/registry.md"),
+      [
+        "# Registry",
+        "",
+        "## Registered pairs",
+        "",
+        "- harness-demo: producer `harness-demo-producer` ↔ reviewer `harness-demo-reviewer`, skill `harness-demo`",
+        "",
+      ].join("\n"),
+    );
+
+    runAutoSetup(target, ["--migration"]);
+
+    const currentSkill = readFileSync(join(target, ".harness/loom/skills/harness-demo/SKILL.md"), "utf8");
+    assert.match(
+      currentSkill,
+      /^description: "Use when handling demo work across indentation-aware migrations\."$/m,
+    );
+
+    const currentFinalizer = readFileSync(join(target, ".harness/loom/agents/harness-finalizer.md"), "utf8");
+    assert.ok(
+      currentFinalizer.includes('description: "Use when closing demo cycles.\\nKeep release notes coherent."'),
+    );
+  } finally {
+    cleanupDir(target);
+  }
+});
+
+test("auto-setup migration preserves inline extra skills in source agent frontmatter", () => {
+  const target = makeTempDir();
+  try {
+    installTo(target);
+    mkdirSync(join(target, ".harness/loom/skills/harness-demo"), { recursive: true });
+    writeFileSync(
+      join(target, ".harness/loom/skills/harness-demo/SKILL.md"),
+      [
+        "---",
+        "name: harness-demo",
+        'description: "Use when maintaining custom demo build scripts."',
+        "user-invocable: false",
+        "---",
+        "",
+        "# Demo Skill",
+        "",
+        "## Design Thinking",
+        "",
+        "Own custom demo release packaging.",
+        "",
+      ].join("\n"),
+    );
+    writeFileSync(
+      join(target, ".harness/loom/agents/harness-demo-producer.md"),
+      [
+        "---",
+        "name: harness-demo-producer",
+        'description: "Use when handling demo producer work."',
+        "skills: [harness-demo, harness-context, demo-domain] # keep extra skill",
+        "---",
+        "",
+        "# Demo Producer",
+        "",
+        "Producer identity.",
+        "",
+        "## Principles",
+        "",
+        "1. Preserve demo packaging context.",
+        "",
+        "## Task",
+        "",
+        "1. Maintain custom build scripts.",
+        "",
+      ].join("\n"),
+    );
+    writeFileSync(
+      join(target, ".harness/loom/agents/harness-demo-reviewer.md"),
+      [
+        "---",
+        "name: harness-demo-reviewer",
+        'description: "Use when auditing demo reviewer work."',
+        "skills:",
+        "  - harness-demo",
+        "  - harness-context",
+        "---",
+        "",
+        "# Demo Reviewer",
+        "",
+        "Reviewer identity.",
+        "",
+        "## Principles",
+        "",
+        "1. Check fixture snapshots carefully.",
+        "",
+        "## Task",
+        "",
+        "1. Audit fixture snapshots.",
+        "",
+      ].join("\n"),
+    );
+    writeFileSync(
+      join(target, ".harness/loom/agents/harness-finalizer.md"),
+      [
+        "---",
+        "name: harness-finalizer",
+        'description: "Use when closing demo cycles."',
+        "skills:",
+        "  - harness-context",
+        "---",
+        "",
+        "# Finalizer",
+        "",
+        "Finalizer intro.",
+        "",
+        "## Principles",
+        "",
+        "1. Keep release notes coherent.",
+        "",
+        "## Task",
+        "",
+        "1. Refresh docs/ and CHANGELOG.md after verified release work.",
+        "",
+      ].join("\n"),
+    );
+    writeFileSync(
+      join(target, ".harness/loom/registry.md"),
+      [
+        "# Registry",
+        "",
+        "## Registered pairs",
+        "",
+        "- harness-demo: producer `harness-demo-producer` ↔ reviewer `harness-demo-reviewer`, skill `harness-demo`",
+        "",
+      ].join("\n"),
+    );
+
+    runAutoSetup(target, ["--migration"]);
+
+    const currentProducer = readFileSync(join(target, ".harness/loom/agents/harness-demo-producer.md"), "utf8");
+    assert.match(
+      currentProducer,
+      /^skills:\n  - harness-demo\n  - harness-context\n  - demo-domain$/m,
+    );
+  } finally {
+    cleanupDir(target);
+  }
+});
+
+test("auto-setup migration rejects a fresh target", () => {
+  const target = makeTempDir();
+  try {
+    writeFileSync(join(target, "README.md"), "# Demo\n");
+
+    const result = runNode(AUTO_SETUP_SCRIPT, ["--migration"], { cwd: target });
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /--migration requires existing \.harness\/loom or \.harness\/cycle state/);
+    assert.equal(existsSync(join(target, ".harness")), false);
   } finally {
     cleanupDir(target);
   }

--- a/tests/pair-dev.test.mjs
+++ b/tests/pair-dev.test.mjs
@@ -222,7 +222,7 @@ test("pair-dev SKILL anchors the v0.3.0 clean-break command surface", () => {
 
   assert.match(
     commandSurface,
-    /^\/harness-pair-dev --add <pair-slug> "<purpose>" \[--from <existing-pair-slug>\] \[--reviewer <slug> \.\.\.\] \[--before <pair-slug> \| --after <pair-slug>\]$/m,
+    /^\/harness-pair-dev --add <pair-slug> "<purpose>" \[--from <source>\] \[--reviewer <slug> \.\.\.\] \[--before <pair-slug> \| --after <pair-slug>\]$/m,
   );
   assert.match(
     commandSurface,
@@ -588,7 +588,7 @@ test("pair-dev --remove does not treat a colliding pair identifier as shared-fil
   }
 });
 
-test("pair-dev --add --from accepts only currently registered pair slugs as evidence", () => {
+test("pair-dev --add --from accepts live slugs plus snapshot/archive locators as evidence", () => {
   const target = makeTempDir();
   try {
     installTo(target);
@@ -613,19 +613,74 @@ test("pair-dev --add --from accepts only currently registered pair slugs as evid
     const summary = JSON.parse(accepted.stdout);
     assert.equal(summary.action, "prepare-add");
     assert.equal(summary.authored, false);
+    assert.equal(summary.from.kind, "live");
     assert.equal(summary.from.pair, "harness-source");
     assert.deepEqual(summary.writes, []);
     assert.deepEqual(summary.providerTreesWritten, []);
     assert.doesNotMatch(registryBody(target), /^- harness-target:/m);
     assertTreesUnchanged(acceptedSnapshot);
 
+    const snapshotRoot = join(target, ".harness/_snapshots/auto-setup/20260423T000000Z/loom");
+    mkdirSync(join(snapshotRoot, "agents"), { recursive: true });
+    mkdirSync(join(snapshotRoot, "skills/harness-source"), { recursive: true });
+    writeFileSync(join(snapshotRoot, "registry.md"), registryBody(target));
+    writeFileSync(
+      join(snapshotRoot, "agents/harness-source-producer.md"),
+      "---\nname: harness-source-producer\n---\n\n# Producer\n",
+    );
+    writeFileSync(
+      join(snapshotRoot, "agents/harness-source-reviewer.md"),
+      "---\nname: harness-source-reviewer\n---\n\n# Reviewer\n",
+    );
+    writeFileSync(
+      join(snapshotRoot, "skills/harness-source/SKILL.md"),
+      "---\nname: harness-source\nuser-invocable: false\n---\n\n# harness-source\n",
+    );
+
+    const snapshotAccepted = runPairDev(target, [
+      "--add", "harness-target", "Use snapshot evidence.",
+      "--from", "snapshot:20260423T000000Z/harness-source",
+    ]);
+    assert.equal(snapshotAccepted.status, 0, snapshotAccepted.stderr);
+    const snapshotSummary = JSON.parse(snapshotAccepted.stdout);
+    assert.equal(snapshotSummary.from.kind, "snapshot");
+    assert.equal(snapshotSummary.from.locator, "snapshot:20260423T000000Z/harness-source");
+    assert.equal(snapshotSummary.from.skillPath, ".harness/_snapshots/auto-setup/20260423T000000Z/loom/skills/harness-source/SKILL.md");
+
+    const archiveRoot = join(target, ".harness/_archive/20260423T000100Z/loom");
+    mkdirSync(join(archiveRoot, "agents"), { recursive: true });
+    mkdirSync(join(archiveRoot, "skills/harness-source"), { recursive: true });
+    writeFileSync(join(archiveRoot, "registry.md"), registryBody(target));
+    writeFileSync(
+      join(archiveRoot, "agents/harness-source-producer.md"),
+      "---\nname: harness-source-producer\n---\n\n# Producer\n",
+    );
+    writeFileSync(
+      join(archiveRoot, "agents/harness-source-reviewer.md"),
+      "---\nname: harness-source-reviewer\n---\n\n# Reviewer\n",
+    );
+    writeFileSync(
+      join(archiveRoot, "skills/harness-source/SKILL.md"),
+      "---\nname: harness-source\nuser-invocable: false\n---\n\n# harness-source\n",
+    );
+
+    const archiveAccepted = runPairDev(target, [
+      "--add", "harness-target", "Use archive evidence.",
+      "--from", "archive:20260423T000100Z/harness-source",
+    ]);
+    assert.equal(archiveAccepted.status, 0, archiveAccepted.stderr);
+    const archiveSummary = JSON.parse(archiveAccepted.stdout);
+    assert.equal(archiveSummary.from.kind, "archive");
+    assert.equal(archiveSummary.from.locator, "archive:20260423T000100Z/harness-source");
+
     const rejected = [
-      [".harness/_archive/snapshots/demo", /not a file, snapshot, or platform path/],
-      [".codex/agents/harness-source.md", /not a file, snapshot, or platform path/],
+      [".harness/_archive/snapshots/demo", /not a file or platform path/],
+      [".codex/agents/harness-source.md", /not a file or platform path/],
       ["harness-planner", /foundation or singleton/],
       ["harness-finalizer", /foundation or singleton/],
       ["harness-orchestrate", /foundation or singleton/],
       ["harness-missing", /not registered/],
+      ["snapshot:missing/harness-source", /missing source registry/],
     ];
     for (const [from, pattern] of rejected) {
       const rejectedSnapshot = snapshotTrees(noWriteSnapshotRoots(target));


### PR DESCRIPTION
## Summary
- split `/harness-auto-setup` into explicit `--setup` and `--migration` modes and implement mode-aware reconstruction behavior
- extend `/harness-pair-dev --add --from` to accept live pair slugs plus `snapshot:` / `archive:` locators
- sync the canonical docs, translated READMEs, version metadata, and tests with the new command surface

## Why
The previous auto-setup flow collapsed bootstrap, improvement, and migration into one path. That made minimal-delta migration hard to reason about and left setup quality too recommendation-heavy. The pair import surface also only described live registered pairs, which did not match the new migration path.

## Impact
- fresh setup now leaves a usable harness more often in one run
- migration can preserve user-authored pair/finalizer intent while refreshing contract-owned surfaces
- docs and examples now match the implemented command surface and test entrypoints

## Validation
- `node --test tests/*.mjs`
- `git diff --check`

Closes #17
Closes #18
