### PR TITLE
fix(pair-dev): anchor helper script paths to skill directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,8 +16,7 @@
 # target root (`docs/`, `*.md`) — not under `.harness/` — and are committed
 # to the target repo, not ignored there.
 # None of the `.harness/` paths should land in factory commits.
-.harness/
-
+.harness
 # Pointer docs the factory tracks as source-of-truth (authored by humans). They
 # are listed here so that a Finalizer write from a self-install run does NOT
 # silently overwrite the committed version; the committed files stay tracked

--- a/plugins/harness-loom/skills/harness-pair-dev/SKILL.md
+++ b/plugins/harness-loom/skills/harness-pair-dev/SKILL.md
@@ -15,7 +15,7 @@ Write only in canonical staging under `<target>/.harness/loom/`. Pair files live
 
 Cycle task and review history under `.harness/cycle/` is runtime evidence, not pair-authoring state. Pair authoring may inspect active-cycle references for safety, but it must not edit or delete cycle history.
 
-Use `scripts/pair-dev.ts` for deterministic command validation, registered-pair source preparation, and guarded removal. The helper returns preparation JSON for `--add` and `--improve`; it does not claim to author pair bodies unless files are actually written.
+Use `./scripts/pair-dev.ts` (resolved from this skill's directory) for deterministic command validation, registered-pair source preparation, and guarded removal. The helper returns preparation JSON for `--add` and `--improve`; it does not claim to author pair bodies unless files are actually written.
 
 ## Methodology
 
@@ -23,7 +23,7 @@ Use `scripts/pair-dev.ts` for deterministic command validation, registered-pair 
 
 - Target is always the current working directory.
 - Read the target codebase before authoring. The pair must fit the real repo, not a stock template.
-- Normalize user-facing bare names into canonical `harness-*` slugs before invoking `scripts/pair-dev.ts`; the helper accepts canonical slugs only.
+- Normalize user-facing bare names into canonical `harness-*` slugs before invoking `./scripts/pair-dev.ts`; the helper accepts canonical slugs only.
 - Keep reviewer coverage explicit. Every pair is 1:1 or 1:M. Reviewer-less work belongs in a finalizer, not in `## Registered pairs`.
 - Treat roster placement as execution order. Appending is correct only when the pair truly belongs at the end of the project-global workflow.
 - Treat legacy `--split` and `--hint` as unsupported v0.3.0 surface. Split is a manual sequence of `--add`, `--improve`, and `--remove`; intent is passed as positional `<purpose>`.
@@ -54,7 +54,7 @@ All slug-bearing arguments must be canonical before the deterministic helper or 
    - repeated `--reviewer <slug>` -> 1:M pair
 7. Read the authoring references, current roster, and relevant target code before writing anything.
 8. Author the producer, reviewer(s), and shared pair skill from templates. Without `--from`, ground them directly in repo evidence; with `--from`, apply template-first overlay.
-9. Run `register-pair.ts` to update `## Registered pairs` in `.harness/loom/registry.md`. Pass `--before <slug>` or `--after <slug>` whenever the right workflow position is known; omit anchors only when a true append is intended.
+9. Run `./scripts/register-pair.ts` to update `## Registered pairs` in `.harness/loom/registry.md`. Pass `--before <slug>` or `--after <slug>` whenever the right workflow position is known; omit anchors only when a true append is intended.
 
 ### 4. `--improve`
 
@@ -72,7 +72,7 @@ All slug-bearing arguments must be canonical before the deterministic helper or 
 2. Reject removal of the planner, finalizer, foundation runtime skills, `registry.md`, missing pairs, and anything outside `.harness/loom/agents/` or `.harness/loom/skills/`.
 3. Inspect `.harness/cycle/state.md` when it exists. If `## Next` references the pair, or if any non-terminal EPIC roster/current field references the pair, abort before mutating files.
 4. Treat unparsable active-cycle state as unsafe and abort. The default contract has no force flag.
-5. Run `register-pair.ts --unregister --target <target> --pair <pair-slug>` to remove only the roster entry from `## Registered pairs`.
+5. Run `./scripts/register-pair.ts --unregister --target <target> --pair <pair-slug>` to remove only the roster entry from `## Registered pairs`.
 6. Delete the pair-owned producer agent, reviewer agent(s), and pair skill directory from `.harness/loom/` after unregistering.
 7. Do not delete an agent or skill path that is still referenced by another remaining registry entry; abort or preserve it with an explicit warning rather than breaking another pair.
 8. Never delete or rewrite `.harness/cycle/`, `.harness/cycle/epics/`, task files, review files, or `events.md`. Historical task/review evidence stays intact after pair removal.
@@ -125,8 +125,8 @@ Treat that section as workflow order, not as a changelog.
 
 ## References
 
-- `scripts/pair-dev.ts` — deterministic command helper for validation, `--from` source preparation, and guarded `--remove`
-- `scripts/register-pair.ts` — deterministic registration helper (writes `.harness/loom/registry.md`)
+- `./scripts/pair-dev.ts` — deterministic command helper for validation, `--from` source preparation, and guarded `--remove`
+- `./scripts/register-pair.ts` — deterministic registration helper (writes `.harness/loom/registry.md`)
 - `templates/producer-agent.md`, `templates/reviewer-agent.md`, `templates/pair-skill.md` — skeletons copied and filled in for each new pair
 - `examples/agents/` — completed producer/reviewer exemplars to reference for tone and structure
 - `references/authoring/agent-authoring.md` — agent frontmatter, five principles, Task shape, Output Format rubric

--- a/plugins/harness-loom/skills/harness-pair-dev/references/authoring/from-overlay.md
+++ b/plugins/harness-loom/skills/harness-pair-dev/references/authoring/from-overlay.md
@@ -20,7 +20,7 @@ Live registered pairs are the strongest source because they already reflect the 
 
 ### 1. Template-first sequence
 
-1. Run `scripts/pair-dev.ts --add <new-pair> "<purpose>" --from <source>` and confirm it returns preparation JSON.
+1. Run `./scripts/pair-dev.ts --add <new-pair> "<purpose>" --from <source>` (resolved from the harness-pair-dev skill directory) and confirm it returns preparation JSON.
 2. Read the source pair skill and source producer/reviewer agents from the resolved live or non-live source root.
 3. Create the new pair from the current templates:
    - `templates/pair-skill.md`
@@ -28,7 +28,7 @@ Live registered pairs are the strongest source because they already reflect the 
    - `templates/reviewer-agent.md`
 4. Fill every mandatory runtime field for the new pair first.
 5. Overlay source-pair material only after the new template shape is valid.
-6. Register the new pair with `register-pair.ts`.
+6. Register the new pair with `./scripts/register-pair.ts`.
 7. Tell the user to run `node .harness/loom/sync.ts --provider <list>`.
 
 ### 2. Mandatory new shape


### PR DESCRIPTION
## Summary
- Anchor pair-dev helper script paths (`pair-dev.ts`, `register-pair.ts`) with `./` prefix across execution-intent and reference-list contexts in `harness-pair-dev/SKILL.md` and `references/authoring/from-overlay.md` (8 sites total).
- Unblocks Codex CLI, which was failing to resolve bare `scripts/pair-dev.ts` inside plugin-installed skills and instead guessing `<target>/.harness/loom/scripts/...`.
- Minor `.gitignore` tweak for the `.harness` rule.

## Context
- Claude Code provides `${CLAUDE_SKILL_DIR}` and tolerates bare `scripts/...`; Codex has no equivalent placeholder and the public skills docs do not specify path resolution (see openai/codex#13074).
- Agent Skills open standard recommends `./scripts/...` as the portable skill-directory-relative form.
- Role-description sentences that only *name* the helpers (e.g. "`register-pair.ts` updates…") are left as-is — only execution-intent and reference-list contexts were prefixed.

## Test plan
- [ ] `grep -rn "scripts/pair-dev\|scripts/register-pair" plugins/harness-loom/skills/harness-pair-dev/` shows only `./scripts/...` forms in execution/reference-list contexts.
- [ ] Run `/harness-pair-dev --improve <pair> "<purpose>"` in a Codex-backed target project and confirm the helper resolves on first try.
- [ ] Run the same in a Claude Code target project and confirm nothing regressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)