### PR TITLE
[codex] Refine auto-setup setup and migration semantics

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Weave Producer-Reviewer agent harnesses with auto-execution hooks and self-improving skill loops.",
-    "version": "0.3.1"
+    "version": "0.3.2"
   },
   "plugins": [
     {
       "name": "harness-loom",
       "source": "./plugins/harness-loom",
       "description": "Producer-Reviewer harness generator for Claude Code, Codex CLI, and Gemini CLI.",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "tags": ["harness", "agent-team", "producer-reviewer", "orchestration", "multi-platform"],
       "category": "productivity"
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,34 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.3.2] — 2026-04-24
+
+### Changed
+
+- **`/harness-auto-setup --setup` now separates foundation refresh from
+  project-shaped authoring.** Fresh targets are still bootstrapped through
+  the foundation installer, while existing `.harness/loom/` /
+  `.harness/cycle/` foundation state is not snapshotted, reseeded,
+  restored, or migrated. Existing foundation refresh now belongs to
+  `--migration`; setup continues with repo/user analysis and additive
+  pair/finalizer authoring.
+- **`/harness-auto-setup` setup authoring is now project-grounded.**
+  Fresh setup no longer authors `harness-document`, `harness-verification`,
+  or generic implementation pairs solely because docs, tests, CI, or code
+  directories exist. The script now emits an analysis-needed summary, and the
+  skill expects assistant-side LLM project analysis or concise user
+  clarification before concrete pair/finalizer files are authored.
+- **`/harness-auto-setup --migration` now preserves compatible custom
+  sections.** Migration refreshes frontmatter, required `skills:`, role
+  Output Format blocks, and the finalizer Structural Issue contract while
+  keeping renamed or additional H2 sections such as `## Approach` and
+  `## Rollout Plan`. The JSON summary includes
+  `convergence.migrationPlan` for source/target overlay review.
+- **Migration restores non-pair custom loom entries after foundation
+  reseed.** Custom `loom/skills/*` directories and `loom/agents/*.md`
+  files that are not foundation or registered-pair artifacts are copied
+  back from the auto-setup snapshot during `--migration`.
+
 ## [0.3.1] — 2026-04-24
 
 ### Changed
@@ -67,7 +95,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   discarding active or unknown cycle state, reseed the foundation,
   reconstruct valid registered pairs and customized finalizer intent
   against current templates, and stop with an explicit
-  `node .harness/loom/sync.ts --provider <list>` handoff. Auto-setup
+  `node .harness/loom/sync.ts --provider <list>` next action. Auto-setup
   never writes `.claude/`, `.codex/`, or `.gemini/` directly.
 - **`/harness-pair-dev --remove <pair-slug>` guarded removal.**
   Safely unregisters a pair and deletes only pair-owned `.harness/loom/`
@@ -665,7 +693,8 @@ First public release.
 - **Repo scaffolding** — README, CONTRIBUTING, SECURITY,
   CODE_OF_CONDUCT, PRIVACY, TERMS, and `.github/` issue + PR templates.
 
-[Unreleased]: https://github.com/KingGyuSuh/harness-loom/compare/v0.3.1...HEAD
+[Unreleased]: https://github.com/KingGyuSuh/harness-loom/compare/v0.3.2...HEAD
+[0.3.2]: https://github.com/KingGyuSuh/harness-loom/releases/tag/v0.3.2
 [0.3.1]: https://github.com/KingGyuSuh/harness-loom/releases/tag/v0.3.1
 [0.3.0]: https://github.com/KingGyuSuh/harness-loom/releases/tag/v0.3.0
 [0.2.2]: https://github.com/KingGyuSuh/harness-loom/releases/tag/v0.2.2

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [English](README.md) | [한국어](docs/README.ko.md) | [日本語](docs/README.ja.md) | [简体中文](docs/README.zh-CN.md) | [Español](docs/README.es.md)
 
-[![Version](https://img.shields.io/badge/version-0.3.1-blue.svg)](./CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.3.2-blue.svg)](./CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](./LICENSE)
 [![Platforms](https://img.shields.io/badge/platforms-Claude%20Code%20%7C%20Codex%20%7C%20Gemini-purple.svg)](#multi-platform)
 
@@ -39,7 +39,7 @@ A target's `.harness/` is split into two sibling namespaces — `loom/` is the c
 
 ## What Gets Installed
 
-When you run `/harness-init` inside a target repository, `harness-loom` installs a runtime harness rather than a one-off prompt template. When you run `/harness-auto-setup`, it uses that same foundation installer inside a safer setup/refresh workflow.
+When you run `/harness-init` inside a target repository, `harness-loom` installs a runtime harness rather than a one-off prompt template. When you run `/harness-auto-setup`, it uses that same foundation installer inside a safer setup/migration workflow.
 
 ```text
 target project
@@ -67,7 +67,7 @@ target project
 
 Project documentation (target-root `*.md` files, `docs/`) is authored **directly in the target**, not inside `.harness/`. You then derive at least one platform tree with `node .harness/loom/sync.ts --provider claude` (and add `codex,gemini` for multi-platform), then add domain-specific pairs with `/harness-pair-dev`. The install scaffold does not create request snapshots. On direct `/harness-orchestrate <file.md>` entry, the orchestrator preserves the full request body in `.harness/cycle/user-request-snapshot.md` and keeps `state.md`'s `Goal` header as a compact summary. The orchestrator runs as a four-state DFA — `Planner | Pair | Finalizer | Halt`. When every EPIC reaches terminal and no planner continuation remains, it enters the **Finalizer state** and dispatches the singleton `harness-finalizer` agent before halting. The seeded `harness-finalizer` agent is a generic skeleton; you replace its body with the concrete cycle-end work this project needs — documentation refresh (`CLAUDE.md`, `AGENTS.md`, `docs/`), request-coverage inspection against `events.md` and the user request snapshot, release prep, audit output, etc. You do not invoke the finalizer directly; the orchestrator dispatches it as the cycle-end turn before halting.
 
-`/harness-auto-setup` is the safer entry point for first setup, improvement, or migration. `--setup` (the default) bootstraps a fresh target or intentionally improves an existing harness; when repo signals exist, it authors usable starter pairs/finalizer work in one run instead of stopping at recommendations. `--migration` is for minimal-delta upgrades: it snapshots live `.harness/loom/` and `.harness/cycle/`, refreshes the foundation, preserves pair/finalizer guidance where possible, and rewrites only the contract-owned runtime surface. It never writes `.claude/`, `.codex/`, or `.gemini/` itself.
+`/harness-auto-setup` is the safer entry point for first setup, project-shaped configuration, or existing-harness migration. `--setup` (the default) bootstraps a fresh target; when an existing `.harness/` is present, it leaves the foundation untouched and continues into additive pair/finalizer authoring after project analysis and any needed user clarification. `--migration` is the mode that handles existing foundations: it snapshots live `.harness/loom/` and `.harness/cycle/`, refreshes the foundation, restores non-pair custom loom entries, preserves compatible pair/finalizer guidance, and rewrites only the contract-owned runtime surface. It never writes `.claude/`, `.codex/`, or `.gemini/` itself.
 
 ## Requirements
 
@@ -83,7 +83,7 @@ Project documentation (target-root `*.md` files, `docs/`) is authored **directly
 There are two installs in practice:
 
 1. Install the **factory plugin** into Claude Code or Codex CLI.
-2. Inside each target repository, run `/harness-auto-setup --setup` (or `--migration` for minimal-delta upgrades of an existing harness) to seed or converge `.harness/`, then `node .harness/loom/sync.ts --provider <list>` to deploy the assistant-specific runtime trees you actually want to use.
+2. Inside each target repository, run `/harness-auto-setup --setup` (or `--migration` for minimal-delta upgrades of an existing harness) to seed, inspect, or migrate `.harness/`, then `node .harness/loom/sync.ts --provider <list>` to deploy the assistant-specific runtime trees you actually want to use.
 
 The factory ships in the standard `plugins/<name>/` monorepo layout — the repo root holds `.claude-plugin/marketplace.json` and `.agents/plugins/marketplace.json`, and the actual plugin tree lives under `plugins/harness-loom/`.
 
@@ -147,13 +147,13 @@ Use Claude Code or Codex CLI to install the factory, then derive `.gemini/` insi
 
 Once the factory is installed in your assistant, the usual target-repo flow is:
 
-1. Seed, improve, or migrate `.harness/` with `/harness-auto-setup --setup` or `/harness-auto-setup --migration`.
+1. Seed `.harness/`, configure project-shaped pairs/finalizer, or migrate it with `/harness-auto-setup --setup` or `/harness-auto-setup --migration`.
 2. Deploy at least one assistant runtime tree with `sync.ts`.
 3. Add the first producer-reviewer pairs for your repo.
 4. Optionally customize the cycle-end finalizer.
 5. Run `/harness-orchestrate <file.md>`.
 
-### 1. Setup Or Refresh The Target Repository
+### 1. Setup Or Migrate The Target Repository
 
 Open the target repository in Claude Code or Codex CLI and run:
 
@@ -167,15 +167,15 @@ Use a comma-separated provider list when you know the platform trees you will re
 /harness-auto-setup --setup --provider claude,codex,gemini
 ```
 
-`--setup` seeds a fresh target through the foundation installer and, when repo signals exist, authors a usable starter pair roster/finalizer instead of leaving only recommendations. If the target already has `.harness/loom/` or `.harness/cycle/`, it snapshots those namespaces before refresh, preserves active or unparsable cycle state in the snapshot before discard/reseed, rebuilds valid registered pair files and customized finalizer intent from current templates, and prints the exact `node .harness/loom/sync.ts --provider <list>` command to run next.
+`--setup` seeds a fresh target through the foundation installer and keeps the default finalizer until concrete cycle-end work is selected. Fresh targets require assistant-side LLM project analysis before pair/finalizer files are authored; docs/tests/CI presence alone no longer creates `harness-document` or `harness-verification`. If the target already has `.harness/loom/` or `.harness/cycle/`, `--setup` does not snapshot, reseed, restore, reconstruct, or migrate anything; it inspects the live harness and repo signals, then continues with project analysis, concise user questions when needed, and additive pair/finalizer authoring under `.harness/loom/`.
 
-When you want a minimal-delta upgrade of an existing harness instead of author-first improvement, run:
+When you want a minimal-delta upgrade of an existing harness instead of setup-mode convergence, run:
 
 ```text
 /harness-auto-setup --migration --provider claude
 ```
 
-Migration mode preserves user-authored pair/finalizer guidance where possible and refreshes contract-owned surfaces such as required frontmatter, `skills:`, Output Format blocks, and the finalizer Structural Issue contract. The snapshot remains machine provenance and migration evidence, not a restored source of truth.
+Migration mode preserves user-authored pair/finalizer guidance where possible, including compatible renamed or custom H2 sections, and refreshes contract-owned surfaces such as required frontmatter, `skills:`, Output Format blocks, and the finalizer Structural Issue contract. The JSON summary includes a `convergence.migrationPlan` source/target overlay plan. The snapshot remains machine provenance and migration evidence, not a restored source of truth.
 
 If you only want a foundation reset with no convergence, run:
 
@@ -185,7 +185,7 @@ If you only want a foundation reset with no convergence, run:
 
 This writes the canonical staging tree under `.harness/loom/` and the runtime state scaffold under `.harness/cycle/`. It seeds `state.md`, `events.md`, `epics/`, and `finalizer/tasks/`; it does not create goal/request snapshot placeholders, `.claude/`, `.codex/`, or `.gemini/`.
 
-If you rerun `/harness-init` later, treat it as a reset of the target-side harness scaffolding: pair-authored `.harness/loom/` content and the current `.harness/cycle/` state are reseeded rather than preserved. Use `/harness-auto-setup --setup` when you want author-first refresh or improvement, and `/harness-auto-setup --migration` when you want snapshot-first minimal-delta contract refresh.
+If you rerun `/harness-init` later, treat it as a reset of the target-side harness scaffolding: pair-authored `.harness/loom/` content and the current `.harness/cycle/` state are reseeded rather than preserved. Use `/harness-auto-setup --setup` for fresh bootstrap or additive project-shaped configuration, and `/harness-auto-setup --migration` when you want minimal-delta contract refresh of an existing foundation.
 
 ### 2. Deploy The Assistant Runtime You Actually Want To Use
 
@@ -278,7 +278,7 @@ A few terms recur across commands, files, and state. Knowing these is enough to 
 | Command | Purpose |
 |---------|---------|
 | `/harness-init` | Scaffold the canonical `.harness/loom/` staging tree plus the `.harness/cycle/` runtime state into the current working directory. Writes runtime skills, the `harness-planner` agent, the generic `harness-finalizer` cycle-end skeleton, and the `hook.sh` + `sync.ts` self-contained copies under `.harness/loom/`. Seeds `state.md`, `events.md`, `epics/`, and `finalizer/tasks/`, but no goal or request snapshot placeholder. Rerunning install reseeds both namespaces. Touches no platform tree. |
-| `/harness-auto-setup [--setup \| --migration] [--provider <list>]` | Safely set up, improve, or migrate the current working directory's harness. `--setup` (default) bootstraps fresh targets and intentionally improves existing harnesses, authoring repo-grounded starter pairs/finalizer work in one run when signals exist. `--migration` performs a minimal-delta upgrade for existing harnesses: snapshot first, refresh the foundation, then preserve pair/finalizer guidance while rewriting only contract-owned runtime surfaces. Both modes stop with an explicit sync handoff and touch no platform tree. |
+| `/harness-auto-setup [--setup \| --migration] [--provider <list>]` | Safely set up, configure, or migrate the current working directory's harness. `--setup` (default) bootstraps fresh targets and requires assistant-side project analysis before authoring pair/finalizer files instead of creating stock docs/tests pairs; on existing targets it leaves foundation files untouched and performs only additive project-shaped authoring unless the user asks for improvements. `--migration` performs a minimal-delta upgrade for existing harnesses: snapshot first, refresh the foundation, restore custom loom entries, then preserve pair/finalizer guidance while rewriting only contract-owned runtime surfaces and emitting a migration plan. Both modes stop with an explicit sync command and touch no platform tree. |
 | `node .harness/loom/sync.ts --provider <list>` | Deploy canonical `.harness/loom/` into platform trees (`.claude/`, `.codex/`, `.gemini/`). One-way; never writes back into `.harness/loom/`. Provider selection is explicit: a bare invocation with no provider flags is an error. Claude keeps agent `skills:` frontmatter; Codex and Gemini receive required skill-loading prompts in generated agent bodies. |
 | `/harness-pair-dev --add <slug> "<purpose>" [--from <source>] [--reviewer <slug> ...] [--before <slug> \| --after <slug>]` | Author a new producer-reviewer pair anchored to the current codebase. `<purpose>` is required. `--from` accepts either a currently registered live pair slug or a target-local `snapshot:<ts>/<pair>` / `archive:<ts>/<pair>` locator as the template-first overlay source: current harness shape stays fixed while compatible source domain guidance is preserved. It is not an arbitrary filesystem path or provider-tree import. Default is 1:1; repeat `--reviewer` for 1:N reviewer topology. Authoring writes only into `.harness/loom/`; re-run `node .harness/loom/sync.ts --provider <list>` afterward. |
 | `/harness-pair-dev --improve <slug> "<purpose>" [--before <slug> \| --after <slug>]` | Improve an existing registered pair with positional `<purpose>` as the primary revision axis, then fold in rubric hygiene and current repo evidence. If a pair has become two different jobs, use explicit add/improve/remove steps. Re-run sync afterward to refresh platform trees. |
@@ -293,8 +293,8 @@ factory (this repo)                            target project
 plugins/harness-loom/skills/harness-init/          installs ->      .harness/loom/{skills,agents,hook.sh,sync.ts}
 plugins/harness-loom/skills/harness-init/                            .harness/cycle/{state.md,events.md,epics/,finalizer/tasks/}
 plugins/harness-loom/skills/harness-init/references/runtime/ seeds -> .harness/loom/skills/<slug>/SKILL.md
-plugins/harness-loom/skills/harness-auto-setup/    converges ->     .harness/_snapshots/auto-setup/<timestamp>/
-                                                                    .harness/loom/ + .harness/cycle/ refreshed
+plugins/harness-loom/skills/harness-auto-setup/    migrates ->      .harness/_snapshots/auto-setup/<timestamp>/
+                                                                    .harness/loom/ + .harness/cycle/ refreshed in --migration
 plugins/harness-loom/skills/harness-pair-dev/      authors  ->      .harness/loom/agents/<slug>-producer.md
                                                                     .harness/loom/agents/<reviewer>.md
                                                                     .harness/loom/skills/<slug>/SKILL.md

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -4,7 +4,7 @@
 
 [English](../README.md) | [한국어](README.ko.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md) | [Español](README.es.md)
 
-[![Version](https://img.shields.io/badge/version-0.3.1-blue.svg)](../CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.3.2-blue.svg)](../CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](../LICENSE)
 [![Platforms](https://img.shields.io/badge/platforms-Claude%20Code%20%7C%20Codex%20%7C%20Gemini-purple.svg)](../README.md#multi-platform)
 
@@ -12,7 +12,7 @@
 
 <br clear="left" />
 
-> **Estado:** 0.3.1
+> **Estado:** 0.3.2
 
 ## Resumen actual
 

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -4,7 +4,7 @@
 
 [English](../README.md) | [한국어](README.ko.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md) | [Español](README.es.md)
 
-[![Version](https://img.shields.io/badge/version-0.3.1-blue.svg)](../CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.3.2-blue.svg)](../CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](../LICENSE)
 [![Platforms](https://img.shields.io/badge/platforms-Claude%20Code%20%7C%20Codex%20%7C%20Gemini-purple.svg)](../README.md#multi-platform)
 
@@ -12,7 +12,7 @@
 
 <br clear="left" />
 
-> **ステータス:** 0.3.1
+> **ステータス:** 0.3.2
 
 ## 現在の要点
 

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -4,7 +4,7 @@
 
 [English](../README.md) | [한국어](README.ko.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md) | [Español](README.es.md)
 
-[![Version](https://img.shields.io/badge/version-0.3.1-blue.svg)](../CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.3.2-blue.svg)](../CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](../LICENSE)
 [![Platforms](https://img.shields.io/badge/platforms-Claude%20Code%20%7C%20Codex%20%7C%20Gemini-purple.svg)](../README.md#multi-platform)
 
@@ -12,7 +12,7 @@
 
 <br clear="left" />
 
-> **상태:** 0.3.1
+> **상태:** 0.3.2
 
 ## 현재 기준 요약
 

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -4,7 +4,7 @@
 
 [English](../README.md) | [한국어](README.ko.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md) | [Español](README.es.md)
 
-[![Version](https://img.shields.io/badge/version-0.3.1-blue.svg)](../CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.3.2-blue.svg)](../CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](../LICENSE)
 [![Platforms](https://img.shields.io/badge/platforms-Claude%20Code%20%7C%20Codex%20%7C%20Gemini-purple.svg)](../README.md#multi-platform)
 
@@ -12,7 +12,7 @@
 
 <br clear="left" />
 
-> **状态：** 0.3.1
+> **状态：** 0.3.2
 
 ## 当前要点
 

--- a/plugins/harness-loom/.claude-plugin/plugin.json
+++ b/plugins/harness-loom/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "harness-loom",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Seed a planner + producer-reviewer pair harness into any repository, then grow it pair by pair.",
   "author": {
     "name": "KingGyuSuh",

--- a/plugins/harness-loom/.codex-plugin/plugin.json
+++ b/plugins/harness-loom/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "harness-loom",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Install and grow producer-reviewer harnesses for repository work.",
   "author": {
     "name": "KingGyuSuh",

--- a/plugins/harness-loom/skills/harness-auto-setup/SKILL.md
+++ b/plugins/harness-loom/skills/harness-auto-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: harness-auto-setup
-description: "Use when `/harness-auto-setup` is invoked to safely bootstrap, improve, or migrate the current working directory's harness by snapshotting live `.harness/` state, reseeding the foundation, and handing off explicit platform sync."
+description: "Use when `/harness-auto-setup` is invoked to bootstrap and configure a project-shaped harness, expand an existing harness without refreshing its foundation, or migrate an existing harness foundation with snapshot-first preservation."
 argument-hint: "[--setup | --migration] [--provider claude,codex,gemini]"
 user-invocable: true
 ---
@@ -9,7 +9,7 @@ user-invocable: true
 
 ## Design Thinking
 
-`harness-auto-setup` is the factory-side convergence workflow for a target harness. It exists because rerunning `/harness-init` is intentionally simple and destructive: it reseeds the foundation, but it does not preserve project-specific pairs, finalizer work, or active cycle state.
+`harness-auto-setup` is the factory-side setup and migration workflow for a target harness. `--setup` bootstraps fresh targets or expands an existing harness without changing its foundation, then the assistant continues with project analysis, concise user dialogue when needed, and actual pair/finalizer authoring. `--migration` exists because rerunning `/harness-init` is intentionally simple and destructive: it reseeds the foundation, but it does not preserve project-specific pairs, finalizer work, or active cycle state.
 
 This workflow does not introduce a second human-authored setup source of truth. The durable truth remains the target's live harness files:
 
@@ -26,7 +26,7 @@ Snapshots are machine provenance and convergence input, not restore sources. Old
 
 `/harness-auto-setup [--setup | --migration] [--provider <list>]`
 
-The workflow always targets the current working directory. Run `/harness-auto-setup` from the project root. `--setup` is the default mode and covers fresh bootstrap plus intentional improvement. `--migration` is for minimal-delta upgrades of an existing harness. `--provider` only shapes the printed sync handoff; sync itself is never run here.
+The workflow always targets the current working directory. Run `/harness-auto-setup` from the project root. `--setup` is the default mode and covers fresh bootstrap plus project-shaped authoring for fresh or existing harnesses. `--migration` is for snapshot-first foundation refresh of an existing harness. `--provider` only shapes the printed sync command; sync itself is never run here.
 
 ### 2. Authority boundaries
 
@@ -35,8 +35,8 @@ The workflow always targets the current working directory. Run `/harness-auto-se
 - `/harness-pair-dev --add ... --from <source>` remains the pair-source resolver. Live registered pair slugs, `snapshot:<ts>/<pair>`, and `archive:<ts>/<pair>` are valid sources; arbitrary filesystem paths and provider-tree paths are not.
 - `.harness/loom/registry.md` remains the pair roster SSOT. The planner and finalizer are never registry entries.
 - `harness-finalizer` remains a singleton cycle-end role. Reviewer-less cycle-end work belongs in `.harness/loom/agents/harness-finalizer.md`, not in `## Registered pairs`.
-- `node .harness/loom/sync.ts --provider <list>` remains an explicit user handoff after convergence. Auto-setup must not derive `.claude/`, `.codex/`, or `.gemini/` automatically.
-- Auto-setup may reseed `.harness/cycle/` only as setup-time discard/reseed through the foundation install path. It must not fabricate pair task or review history.
+- `node .harness/loom/sync.ts --provider <list>` remains an explicit user-run command after convergence. Auto-setup must not derive `.claude/`, `.codex/`, or `.gemini/` automatically.
+- Auto-setup may reseed `.harness/cycle/` only for fresh setup or migration-mode foundation refresh. Existing-target `--setup` must not reseed cycle state or fabricate pair task/review history.
 
 ### 3. Snapshot and provenance contract
 
@@ -50,7 +50,7 @@ The snapshot preserves pre-refresh `.harness/loom/` and `.harness/cycle/` when p
 
 Do not snapshot derived platform trees by default; they are deployment outputs and are refreshed only by explicit sync.
 
-If snapshot creation fails, stop before running install or deleting anything.
+If snapshot creation fails, stop before running install or deleting anything. Existing-target `--setup` does not refresh the foundation and therefore does not create a snapshot.
 
 ### 4. Active cycle policy
 
@@ -64,21 +64,21 @@ Classify the cycle as:
 - `halted` — `loop: false`, no runnable `Next`, and every EPIC is terminal or no EPIC exists
 - `unknown` — state cannot be parsed safely
 
-For `active` or `unknown`, silent deletion is forbidden. The default policy is:
+For `active` or `unknown`, silent deletion is forbidden. In `--migration`, the default policy is:
 
 1. emit a warning that the current cycle will be discarded after snapshot
 2. include `.harness/cycle/` in the snapshot
 3. run foundation refresh so `.harness/cycle/` is reseeded fresh
 4. report that old cycle state is preserved only in the snapshot, not restored
 
-This policy forbids silent destruction, not destruction itself.
+This policy forbids silent destruction, not destruction itself. Existing-target `--setup` reports the cycle classification but leaves cycle files untouched.
 
 ### 5. Mode split
 
 `harness-auto-setup` has two execution modes:
 
-- `--setup` — bootstrap a fresh target or intentionally improve an existing harness. This mode optimizes for "one run leaves a usable harness." It may author starter pairs/finalizer intent from repo signals, and it may rewrite pair/finalizer bodies on current templates when that improves harness usability.
-- `--migration` — upgrade an existing harness with the smallest reasonable blast radius. This mode optimizes for contract refresh and customization preservation. It updates contract-owned surfaces and reports manual-review ambiguity instead of aggressively rewriting user-authored guidance.
+- `--setup` — bootstrap a fresh target, or expand an existing harness with project-shaped pair/finalizer authoring. Existing-target `--setup` must not snapshot, reseed, restore, reconstruct, migrate, or otherwise refresh existing foundation files. It may add new pair files, register new pairs, and update the singleton finalizer after LLM project analysis and any necessary user clarification.
+- `--migration` — upgrade an existing harness foundation with the smallest reasonable blast radius. This mode optimizes for snapshot-first contract refresh and customization preservation. It refreshes contract-owned surfaces, preserves compatible user-authored H2 sections, restores non-pair custom loom entries, and emits an explicit migration plan for pair/finalizer overlay review.
 
 Fresh targets may use only `--setup`. `--migration` requires existing `.harness/loom/` or `.harness/cycle/` state.
 
@@ -86,58 +86,74 @@ Fresh targets may use only `--setup`. `--migration` requires existing `.harness/
 
 When `.harness/loom/` exists, or `.harness/cycle/` exists without `.harness/loom/`:
 
+In `--setup`:
+
+1. Run the script to inspect `.harness/loom/registry.md`, `harness-finalizer.md`, `.harness/cycle/`, and target repo signals.
+2. Do not snapshot, run install, reseed `.harness/cycle/`, restore snapshot files, reconstruct pairs, migrate finalizer text, or edit provider trees.
+3. Continue after the script: read README/pointer docs, source trees, scripts, tests, workflows, architecture notes, and any explicit user request.
+4. Ask the user at most three concise questions only when the project purpose, desired workflow boundary, or review axis is genuinely ambiguous; otherwise proceed from repo evidence.
+5. Author the actual additional pair/finalizer configuration rather than stopping at recommendations. Registered pairs are treated as existing coverage, not as rewrite targets.
+6. Report the exact sync command as a post-authoring next step; do not run sync automatically.
+
+In `--migration`:
+
 1. Snapshot `.harness/loom/` when present and `.harness/cycle/` when present per the snapshot contract.
 2. If the snapshot contains `loom/registry.md`, parse it for registered pair order, producer slug, reviewer slug(s), and skill slug.
 3. Inspect pair agent/skill bodies when present and target repo evidence to infer current intent.
 4. Inspect snapshot `harness-finalizer.md` when present and decide whether it is missing, default no-op, or customized.
 5. Run `/harness-init` or its installer implementation to reseed the foundation.
-6. In `--setup`, reconstruct each known pair against the current pair templates and authoring rubric, or author fresh starter pairs if no pair roster exists.
-7. In `--migration`, preserve user-authored pair/finalizer bodies where possible while refreshing contract-owned surfaces such as runtime frontmatter, required `skills:`, and Output Format blocks.
+6. Restore non-pair custom `loom/skills/*` and `loom/agents/*.md` entries that are not foundation or registered-pair artifacts.
+7. Preserve user-authored pair/finalizer bodies where possible while refreshing contract-owned surfaces such as runtime frontmatter, required `skills:`, and Output Format blocks.
 8. Preserve topology and order from the old registry when valid.
 9. Leave split/reorder decisions as recommendations unless the old registry already proves the intended topology.
-10. End with the exact sync handoff command the user should run from the target root.
+10. End with the exact sync command the user should run from the target root.
 
 Old pair and finalizer files are evidence only. Do not blind-copy them over the refreshed foundation.
 
-If `.harness/cycle/` existed without `.harness/loom/`, there is no pair/finalizer source to converge. Snapshot the cycle, reseed the foundation, then:
+If `.harness/cycle/` existed without `.harness/loom/`, there is no pair/finalizer source to converge:
 
-- in `--setup`, follow the fresh target repo-inspection rules
-- in `--migration`, preserve the cycle snapshot as evidence and report that no live loom source was available for pair/finalizer migration
+- in `--setup`, leave the cycle untouched and recommend `--migration` for foundation repair or refresh
+- in `--migration`, snapshot the cycle, reseed the foundation, and report that no live loom source was available for pair/finalizer migration
 
 ### 7. Fresh target flow
 
 When both `.harness/loom/` and `.harness/cycle/` are absent:
 
-1. Run `/harness-init` or its installer implementation to seed the foundation.
-2. Inspect the target repo before proposing project-specific harness work.
-3. In `--setup`, author an initial pair roster grounded in real repo surfaces when evidence exists; recommend only when the repo is effectively empty.
-4. In `--setup`, author a concrete finalizer body when the repo exposes a clear cycle-end duty; otherwise keep the safe no-op.
-5. `--migration` is invalid here because there is no existing harness state to preserve.
-6. End with the exact sync handoff command the user should run from the target root.
+1. Run the auto-setup script; on fresh `--setup` targets it invokes the foundation installer and collects script-level repository signals.
+2. After the script completes, inspect the target repo with LLM judgment before creating project-specific harness work: read README/pointer docs, source trees, scripts, tests, workflows, and any existing project architecture notes.
+3. Ask the user at most three concise questions only when project intent or desired harness workflow cannot be inferred safely from repo evidence.
+4. In `--setup`, author the initial pair roster from that project analysis and user clarification. Docs/tests/CI presence alone is not enough to author a stock pair.
+5. In `--setup`, update the singleton finalizer only when project analysis or user clarification identifies a concrete cycle-end duty; otherwise keep the safe no-op.
+6. `--migration` is invalid here because there is no existing harness state to preserve.
+7. End with the exact sync command the user should run from the target root after setup authoring is complete.
 
-Do not create evidence-free stock pairs just to fill the registry. If repo evidence is insufficient, emit recommended `/harness-pair-dev --add` commands and leave the roster empty.
+Do not create evidence-free stock pairs just to fill the registry. If repo evidence is insufficient, ask focused questions before authoring; leave the roster empty only when the project is effectively blank or the user declines to choose a workflow boundary.
 
 ### 8. Pair convergence rules
 
 - Treat snapshot `registry.md` as a strong topology/order hint, not as immutable truth.
 - Registered producer, reviewer, and skill slugs should be preserved when they remain coherent with the target repo and current namespace rules.
 - Each pair must have at least one reviewer.
-- Missing or unparsable pair files do not block the whole workflow when registry intent plus repo evidence is enough to reconstruct or migrate the pair; record the gap in `manifest.json` and the user summary.
+- Missing or unparsable pair files do not block migration when registry intent plus repo evidence is enough to migrate the pair; record the gap in `manifest.json` and the user summary.
 - If a pair has clearly become two jobs, recommend a split instead of silently changing the roster.
 - If a pair belongs in a different global roster position, recommend a reorder instead of silently moving it unless the user supplied an explicit roster instruction.
-- In `--migration`, use `/harness-pair-dev --add ... --from snapshot:<ts>/<pair>` (or `archive:` when appropriate) as the source-resolution path for preserved pair intent. Do not pass arbitrary file paths through `--from`.
-- In `--setup`, treat pair reconstruction as author-first: a usable draft should be written in one run unless repo grounding is genuinely absent.
-- Re-registration must preserve duplicate-free `## Registered pairs` order and use the registry helper rather than hand-editing the section.
+- In `--setup`, author concrete project-shaped pairs after analysis or user clarification. Do not stop after listing recommendations.
+- In existing-target `--setup`, do not rewrite or reconstruct registered pair files unless the user explicitly asks for an improvement pass. Registered pairs are current coverage; new setup work is additive.
+- In `--migration`, use `/harness-pair-dev --add ... --from snapshot:<ts>/<pair>` (or `archive:` when appropriate) as the source-resolution path for preserved pair intent. Do not pass arbitrary file paths through `--from`; record the resulting source/target overlay plan in `convergence.migrationPlan`.
+- In `--migration`, preserve compatible custom H2 sections instead of silently dropping renamed sections such as `## Approach` or extra sections such as `## Rollout Plan`.
+- In fresh `--setup`, do not author `harness-document`, `harness-verification`, or generic implementation pairs solely from docs/tests/CI/code-directory presence.
+- Migration re-registration must preserve duplicate-free `## Registered pairs` order and use the registry helper rather than hand-editing the section.
 
 ### 9. Finalizer convergence rules
 
 - The finalizer is customized when its body declares concrete cycle-end duties beyond the default no-op summary, writes out-of-cycle artifacts, performs coverage/release/docs/audit work, or changes the default Task section materially.
-- In `--setup`, a customized finalizer may be rewritten more aggressively onto the current skeleton when that yields a more usable starter harness.
-- In `--migration`, preserve the customized finalizer's intro, principles, and task where possible while refreshing contract-owned surfaces such as required skills, Output Format, and Structural Issue block.
-- A missing or no-op finalizer should trigger repo-grounded recommendations or authored cycle-end work according to mode.
+- In existing-target `--setup`, do not rewrite a customized `harness-finalizer.md` unless the user explicitly asks to change the cycle-end role.
+- In fresh `--setup`, keep the safe no-op until cycle-end work is selected through project analysis or user clarification.
+- In `--migration`, preserve the customized finalizer's intro, principles, task, and compatible custom H2 sections where possible while refreshing contract-owned surfaces such as required skills, Output Format, and Structural Issue block. Use `references/finalizer-overlay.md` for singleton finalizer overlay rules.
+- A missing or no-op finalizer should trigger repo-grounded recommendations, not script-authored cycle-end work.
 - Do not turn finalizer work into a pair, and do not add a finalizer line to `## Registered pairs`.
 
-### 10. Sync handoff
+### 10. Sync Next Action
 
 Auto-setup must stop before platform derivation. The final user-facing summary must include a target-local command such as:
 
@@ -155,24 +171,28 @@ Run the script-owned execution path:
 node plugins/harness-loom/skills/harness-auto-setup/scripts/auto-setup.ts [--setup | --migration] [--provider claude,codex,gemini]
 ```
 
-The script snapshots existing `.harness/loom/` / `.harness/cycle/`, classifies active-cycle risk, calls the `harness-init` installer for foundation refresh, then either authors/reconstructs usable setup-mode outputs or applies migration-mode protected overlay. `--provider` only shapes the printed sync handoff; it never runs sync.
+The script installs the foundation on fresh `--setup` targets. On existing `--setup` targets, it inspects the live harness and emits setup summary data without refreshing `.harness/`. Setup-mode JSON includes `convergence.setupAuthoring` so callers can tell that the script phase is not the end of the user-facing workflow. On `--migration`, it snapshots existing `.harness/loom/` / `.harness/cycle/`, classifies active-cycle risk, calls the `harness-init` installer for foundation refresh, restores non-pair custom loom entries, and applies protected overlay for pairs/finalizer. The script is only the mechanical phase of setup: the assistant must continue with LLM project analysis, ask focused questions when needed, then author actual pair/finalizer files under `.harness/loom/` before finishing. `--provider` only shapes the printed sync command; it never runs sync.
 
 ## Evaluation Criteria
 
-- Existing targets are snapshotted before any destructive refresh.
+- Existing targets are snapshotted before migration-mode destructive refresh.
+- Existing-target `--setup` leaves foundation and already-registered pair files untouched unless the user requests an improvement pass; additive pair/finalizer authoring is allowed.
 - Active or unparsable `.harness/cycle/` state is warned about and copied before discard/reseed.
 - Snapshot data is machine provenance with deterministic path and manifest shape, not a human-authored setup SSOT.
 - `/harness-init` remains foundation-only.
-- Pair convergence distinguishes setup-mode author-first behavior from migration-mode minimal-delta overlay.
+- Pair convergence distinguishes setup-mode project-shaped authoring from migration-mode minimal-delta overlay.
 - `registry.md` remains the sole pair roster source of truth and contains only executable producer-reviewer pairs.
 - Customized finalizer intent is preserved in the singleton finalizer body, not converted into a pair.
-- Fresh `--setup` targets receive repo-grounded authored outputs when signals exist, and only fall back to recommendations when repo grounding is too thin.
-- Derived platform trees are not modified; the result ends with an explicit `node .harness/loom/sync.ts --provider <list>` handoff.
+- Fresh `--setup` targets do not receive docs/tests-driven stock pairs; authored pairs come from assistant-side LLM project analysis and cite project-specific evidence when available.
+- Non-pair custom `loom/skills/*` and `loom/agents/*.md` entries survive migration refreshes.
+- Derived platform trees are not modified; the result includes an explicit `node .harness/loom/sync.ts --provider <list>` next action.
 
 ## Taboos
 
 - Create a persistent human-edited `setup.md` or equivalent setup SSOT.
+- Stop setup after recommendation text when enough repo/user evidence exists to author the harness.
 - Restore stale pair or finalizer files by blind copy after foundation refresh.
+- Refresh or repair existing `.harness/` foundation state in `--setup`; use `--migration` for that.
 - Use `--migration` on a fresh target with no harness state to preserve.
 - Delete an active or unparsable cycle silently.
 - Treat snapshot content as canonical after convergence.
@@ -186,5 +206,6 @@ The script snapshots existing `.harness/loom/` / `.harness/cycle/`, classifies a
 - `../harness-init/SKILL.md` — foundation installer boundary
 - `../harness-pair-dev/SKILL.md` — pair authoring and registry mutation boundary
 - `references/snapshot-provenance.md` — snapshot directory, manifest shape, and failure contract
+- `references/finalizer-overlay.md` — singleton finalizer migration overlay rules
 - `../harness-init/references/runtime/registry.md` — target-side pair roster contract
 - `../harness-init/references/runtime/harness-finalizer.template.md` — singleton finalizer skeleton and Output Format

--- a/plugins/harness-loom/skills/harness-auto-setup/references/finalizer-overlay.md
+++ b/plugins/harness-loom/skills/harness-auto-setup/references/finalizer-overlay.md
@@ -1,0 +1,32 @@
+---
+name: auto-setup-finalizer-overlay
+description: "Use when `/harness-auto-setup --migration` refreshes a customized singleton `harness-finalizer` from snapshot evidence while preserving compatible user-authored cycle-end guidance."
+user-invocable: false
+---
+
+# Finalizer Overlay
+
+This reference owns migration preservation rules for the singleton `harness-finalizer`. Pair overlay remains owned by `harness-pair-dev/references/authoring/from-overlay.md`; the finalizer is not a pair and has no reviewer or pair skill.
+
+## Methodology
+
+1. Start from the current `harness-finalizer.template.md` contract.
+2. Preserve compatible source intro text, `## Principles`, `## Task`, and custom H2 sections as user intent.
+3. Refresh contract-owned frontmatter: `name: harness-finalizer`, `skills: [harness-context]`, and any preserved `model`.
+4. Replace stale `## Output Format` content with the current finalizer Output Format contract.
+5. Preserve no old reviewer-style fields such as `Verdict`, `Criteria`, or `FAIL items`.
+6. Keep the Structural Issue contract current so finalizer FAIL/RETREAT routes back to the planner.
+
+## Evaluation Criteria
+
+- User-authored finalizer duties survive when they do not conflict with the current runtime contract.
+- Frontmatter and Output Format always match the current finalizer contract.
+- Custom H2 sections are not dropped silently.
+- Snapshot text is treated as migration evidence, not as a second source of truth.
+
+## Taboos
+
+- Do not register the finalizer as a pair.
+- Do not add a reviewer to finalizer work.
+- Do not blind-copy the snapshot finalizer over the current skeleton.
+- Do not preserve stale Output Format or reviewer verdict fields.

--- a/plugins/harness-loom/skills/harness-auto-setup/references/snapshot-provenance.md
+++ b/plugins/harness-loom/skills/harness-auto-setup/references/snapshot-provenance.md
@@ -48,4 +48,4 @@ Mode-aware runs may append additional keys such as `runMode` and `targetState` a
 
 ## Failure Contract
 
-If snapshot creation fails, stop before running install or deleting anything. Snapshot failure is a setup blocker, not a warning.
+If snapshot creation fails, stop before running install or deleting anything. Snapshot failure is a migration blocker, not a warning.

--- a/plugins/harness-loom/skills/harness-auto-setup/scripts/auto-setup.ts
+++ b/plugins/harness-loom/skills/harness-auto-setup/scripts/auto-setup.ts
@@ -1,13 +1,12 @@
 #!/usr/bin/env node
-// Purpose: Snapshot existing target harness state, classify cycle risk, then
-//          delegate foundation refresh to harness-init's installer. Valid
-//          registered pairs and customized finalizer intent are reconstructed
-//          from snapshot evidence on top of current templates; stale harness
-//          files are never blind-copied and platform sync is never run.
+// Purpose: Bootstrap fresh targets, recommend project-shaped additions for
+//          existing targets, or migrate existing harness foundations through a
+//          snapshot-first contract refresh. Stale harness files are never
+//          blind-copied and platform sync is never run.
 
 import { spawnSync } from "node:child_process";
 import { constants as FS, readFileSync } from "node:fs";
-import { access, cp, mkdir, readFile, stat, writeFile } from "node:fs/promises";
+import { access, cp, mkdir, readFile, readdir, stat, writeFile } from "node:fs/promises";
 import { basename, dirname, join, relative, resolve } from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
@@ -23,7 +22,6 @@ const PAIR_DEV_SCRIPT = resolve(PAIR_DEV_DIR, "scripts/pair-dev.ts");
 const REGISTER_PAIR_SCRIPT = resolve(PAIR_DEV_DIR, "scripts/register-pair.ts");
 const PRODUCER_TEMPLATE = resolve(PAIR_DEV_DIR, "templates/producer-agent.md");
 const REVIEWER_TEMPLATE = resolve(PAIR_DEV_DIR, "templates/reviewer-agent.md");
-const PAIR_SKILL_TEMPLATE = resolve(PAIR_DEV_DIR, "templates/pair-skill.md");
 const ALLOWED_PROVIDERS = new Set(["claude", "codex", "gemini"]);
 const HARNESS_SLUG_RE = /^harness-[a-z0-9]+(-[a-z0-9]+)*$/;
 const FOUNDATION_SLUGS = new Set([
@@ -115,16 +113,9 @@ interface Manifest {
   };
 }
 
-interface PairIntent {
-  skillPath: string | null;
-  producerPath: string | null;
-  reviewerPaths: Record<string, string | null>;
-  evidenceLines: string[];
-}
-
-interface PairReconstruction {
+interface PairOperation {
   pair: string;
-  status: "authored" | "reconstructed" | "migrated" | "skipped";
+  status: "migrated" | "skipped";
   reason: string;
   producer: string;
   reviewers: string[];
@@ -153,17 +144,8 @@ interface ArtifactUsage {
   skills: Map<string, string[]>;
 }
 
-interface SetupPairPlan {
-  pair: RegistryPair;
-  purpose: string;
-  designThinking: string;
-  methodology: string;
-  evaluationCriteria: string;
-  taboos: string;
-}
-
-interface FinalizerReconstruction {
-  status: "authored" | "reconstructed" | "migrated" | "default-noop" | "missing" | "skipped";
+interface FinalizerOperation {
+  status: "migrated" | "default-noop" | "missing" | "skipped";
   reason: string;
   path: string | null;
   filesWritten: string[];
@@ -176,6 +158,67 @@ interface FinalizerReconstruction {
     stopReason: string;
     qualityVerdict: "acceptable" | "fallback" | "manual-review";
   };
+}
+
+interface PairRecommendationDetail {
+  pair: string | null;
+  command: string | null;
+  rationale: string;
+  evidence: string[];
+}
+
+interface RestoredCustomEntries {
+  skills: string[];
+  agents: string[];
+  skipped: { path: string; reason: string }[];
+}
+
+interface MigrationPlanPair {
+  pair: string;
+  source: {
+    skillPath: string | null;
+    producerPath: string | null;
+    reviewerPaths: Record<string, string | null>;
+    missingArtifacts: string[];
+  };
+  target: {
+    skillPath: string;
+    producerPath: string;
+    reviewerPaths: Record<string, string>;
+  };
+  overlayMethodology: string;
+  contractSurfaces: string[];
+  userSurfaces: string[];
+  manualReviewNotes: string[];
+}
+
+interface MigrationPlanFinalizer {
+  required: boolean;
+  source: { agentPath: string | null };
+  target: { agentPath: string };
+  overlayMethodology: string;
+  contractSurfaces: string[];
+  userSurfaces: string[];
+  manualReviewNotes: string[];
+}
+
+interface MigrationPlan {
+  pairs: MigrationPlanPair[];
+  finalizer: MigrationPlanFinalizer | null;
+}
+
+interface PairMigrationResult {
+  operations: PairOperation[];
+  migrationPlanPairs: MigrationPlanPair[];
+}
+
+interface InstallResult {
+  status: number | null;
+  stdout: string;
+  stderr: string;
+  summary: unknown;
+  skipped?: boolean;
+  reason?: string;
 }
 
 function die(message: string, code = 1): never {
@@ -208,7 +251,7 @@ function parseArgs(argv: string[]): Args {
         "Usage: node skills/harness-auto-setup/scripts/auto-setup.ts [--setup | --migration] [--provider <claude,codex,gemini>]\n" +
           "  Target is always process.cwd(); run from the project root.\n" +
           "  Default mode is --setup. Use --migration for minimal-delta upgrades of an existing harness.\n" +
-          "  The provider list is only used to print the explicit sync handoff; sync is not run.\n",
+          "  The provider list is only used to print the explicit sync command; sync is not run.\n",
       );
       process.exit(0);
     } else if (arg === "--setup") {
@@ -249,6 +292,10 @@ function rel(target: string, path: string): string {
 
 function syncCommand(providers: string[]): string {
   return `node .harness/loom/sync.ts --provider ${providers.join(",")}`;
+}
+
+function autoSetupCommand(runMode: RunMode, providers: string[]): string {
+  return `/harness-auto-setup --${runMode} --provider ${providers.join(",")}`;
 }
 
 function snapshotStamp(date: Date): string {
@@ -311,25 +358,58 @@ function subsection(body: string, headingLine: string): string | null {
   return normalized.slice(bodyStart, bodyEnd);
 }
 
-function replaceSection(body: string, heading: string, replacement: string): string {
+function topLevelH2Bounds(body: string, heading: string): { headingStart: number; bodyStart: number; bodyEnd: number } | null {
   const normalized = body.replace(/\r\n/g, "\n");
-  const headingLine = `## ${heading}`;
-  const headingIdxLineStart = normalized.indexOf(`\n${headingLine}\n`);
-  const headingIdx =
-    headingIdxLineStart !== -1
-      ? headingIdxLineStart + 1
-      : normalized.startsWith(`${headingLine}\n`)
-      ? 0
-      : -1;
-  const sectionBody = replacement.trimEnd() + "\n";
-  if (headingIdx === -1) {
-    const sep = normalized.endsWith("\n") ? "" : "\n";
-    return `${normalized}${sep}\n${headingLine}\n\n${sectionBody}`;
+  const lines = normalized.split("\n");
+  let offset = 0;
+  let inFence = false;
+  let found: { headingStart: number; bodyStart: number } | null = null;
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (/^(```|~~~)/.test(trimmed)) {
+      inFence = !inFence;
+    } else if (!inFence && line === `## ${heading}`) {
+      found = { headingStart: offset, bodyStart: offset + line.length + 1 };
+      break;
+    }
+    offset += line.length + 1;
   }
-  const bodyStart = normalized.indexOf("\n", headingIdx) + 1;
-  const nextHeading = normalized.indexOf("\n## ", bodyStart);
-  const bodyEnd = nextHeading === -1 ? normalized.length : nextHeading;
-  return normalized.slice(0, bodyStart) + sectionBody + normalized.slice(bodyEnd);
+  if (!found) return null;
+
+  let bodyEnd = normalized.length;
+  offset = found.bodyStart;
+  inFence = false;
+  for (const line of normalized.slice(found.bodyStart).split("\n")) {
+    const trimmed = line.trim();
+    if (/^(```|~~~)/.test(trimmed)) {
+      inFence = !inFence;
+    } else if (!inFence && /^##\s+/.test(line)) {
+      bodyEnd = offset;
+      break;
+    }
+    offset += line.length + 1;
+  }
+  return { ...found, bodyEnd };
+}
+
+function replaceTopLevelSection(body: string, heading: string, replacement: string): string {
+  const normalized = body.replace(/\r\n/g, "\n");
+  const bounds = topLevelH2Bounds(normalized, heading);
+  const sectionBody = replacement.trim() + "\n";
+  if (!bounds) {
+    const sep = normalized.endsWith("\n") ? "" : "\n";
+    return `${normalized}${sep}\n## ${heading}\n\n${sectionBody}`;
+  }
+  return normalized.slice(0, bounds.bodyStart) + "\n" + sectionBody + normalized.slice(bounds.bodyEnd);
+}
+
+function removeTopLevelSection(body: string, heading: string): string {
+  const normalized = body.replace(/\r\n/g, "\n");
+  const bounds = topLevelH2Bounds(normalized, heading);
+  if (!bounds) return normalized;
+  const prefix = normalized.slice(0, bounds.headingStart).replace(/\n+$/g, "\n\n");
+  const suffix = normalized.slice(bounds.bodyEnd).replace(/^\n+/, "");
+  return `${prefix}${suffix}`.trimEnd() + "\n";
 }
 
 function field(body: string, name: string): string | null {
@@ -571,6 +651,37 @@ function topHeading(body: string): string | null {
   const content = bodyWithoutFrontmatter(body);
   const match = content.match(/^#\s+([^\n]+)$/m);
   return match ? match[1].trim() : null;
+}
+
+function bodyAfterTopHeading(body: string): string | null {
+  const content = bodyWithoutFrontmatter(body);
+  const match = content.match(/^#\s+[^\n]+\n([\s\S]*)$/);
+  return match ? match[1].trimStart() : null;
+}
+
+function h2Headings(body: string | null): string[] {
+  if (!body) return [];
+  const out: string[] = [];
+  for (const match of bodyWithoutFrontmatter(body).matchAll(/^##\s+([^\n]+)$/gm)) {
+    const heading = match[1].trim();
+    if (!out.includes(heading)) out.push(heading);
+  }
+  return out;
+}
+
+function finalizerOutputFormatContract(template: string): string {
+  const normalized = template.replace(/\r\n/g, "\n");
+  const heading = "## Output Format";
+  const headingIdxLineStart = normalized.indexOf(`\n${heading}\n`);
+  const headingIdx =
+    headingIdxLineStart !== -1
+      ? headingIdxLineStart + 1
+      : normalized.startsWith(`${heading}\n`)
+      ? 0
+      : -1;
+  if (headingIdx === -1) return section(template, "Output Format") ?? "";
+  const bodyStart = normalized.indexOf("\n", headingIdx) + 1;
+  return normalized.slice(bodyStart).trimEnd();
 }
 
 function introAfterHeading(body: string): string | null {
@@ -1028,7 +1139,45 @@ async function repoSignals(target: string): Promise<RepoSignals> {
   return { files, directories, evidence };
 }
 
-function pairRecommendations(registry: RegistrySummary, signals: RepoSignals): string[] {
+function pairRecommendationDetails(
+  registry: RegistrySummary,
+  signals: RepoSignals,
+  runMode: RunMode,
+  targetState: TargetState,
+  loomExists: boolean,
+): PairRecommendationDetail[] {
+  if (runMode === "setup" && targetState === "existing" && !loomExists) {
+    return [
+      {
+        pair: null,
+        command: null,
+        rationale:
+          "Existing .harness/cycle state was detected without .harness/loom; setup leaves it untouched. Run --migration to repair or refresh the foundation before pair/finalizer authoring or sync.",
+        evidence: [...signals.files, ...signals.directories, ...signals.evidence],
+      },
+    ];
+  }
+
+  if (runMode === "setup" && targetState === "existing") {
+    const roster =
+      registry.pairCount > 0
+        ? `Existing registry already contains ${registry.pairCount} pair(s); the script phase leaves them unchanged. Continue with LLM project analysis and author only additive pair/finalizer changes unless the user requests an improvement pass. Use --migration to refresh existing foundation contracts.`
+        : "Existing harness state was detected, but no registered pairs were found; the script phase leaves the foundation unchanged. Continue with LLM project analysis or focused user clarification, then author the needed pair/finalizer configuration. Use --migration to refresh or repair the existing foundation.";
+    return [
+      {
+        pair: null,
+        command: null,
+        rationale: roster,
+        evidence: [
+          ...registry.pairs.map((pair) => pair.sourceLine),
+          ...signals.files,
+          ...signals.directories,
+          ...signals.evidence,
+        ],
+      },
+    ];
+  }
+
   if (registry.pairCount > 0) {
     return registry.pairs.map((pair) => {
       const reviewers = pair.reviewers.map((reviewer) => ` --reviewer ${reviewer}`).join("");
@@ -1036,33 +1185,59 @@ function pairRecommendations(registry: RegistrySummary, signals: RepoSignals): s
         pair.evidence.missing.length > 0
           ? ` Missing evidence: ${pair.evidence.missing.join(", ")}.`
           : "";
-      return `Re-author ${pair.pair} from snapshot evidence with current templates: /harness-pair-dev --add ${pair.pair} "Refresh ${pair.pair} against current repo evidence and contracts"${reviewers}.${missing}`;
+      return {
+        pair: pair.pair,
+        command: `/harness-pair-dev --add ${pair.pair} "Refresh ${pair.pair} against current repo evidence and contracts"${reviewers}`,
+        rationale: `Registered pair topology was found in .harness/loom/registry.md.${missing}`,
+        evidence: [pair.sourceLine, ...pair.evidence.missing.map((path) => `missing: ${path}`)],
+      };
     });
   }
 
-  const out: string[] = [];
-  if (signals.evidence.includes("documentation surface")) {
-    out.push(
-      'Repo has documentation evidence; consider /harness-pair-dev --add harness-document "Maintain user-facing docs and pointer-doc alignment" --reviewer harness-document-reviewer.',
-    );
-  }
-  if (signals.evidence.includes("test surface") || signals.evidence.includes("ci workflow surface")) {
-    out.push(
-      'Repo has verification evidence; consider /harness-pair-dev --add harness-verification "Maintain regression tests and smoke checks" --reviewer harness-verification-reviewer.',
-    );
-  }
-  if (signals.evidence.includes("implementation surface")) {
-    out.push(
-      'Repo has implementation surfaces; inspect ownership boundaries before adding a producer-reviewer implementation pair.',
-    );
-  }
-  if (out.length === 0) {
-    out.push("No strong repo-grounded pair recommendation found; leave registry empty until concrete workstreams are identified.");
-  }
-  return out;
+  const supportSignals = signals.evidence.filter((signal) =>
+    ["documentation surface", "test surface", "ci workflow surface"].includes(signal),
+  );
+  return [
+    {
+      pair: null,
+      command: null,
+      rationale:
+        supportSignals.length > 0
+          ? `Only script-level support surfaces were detected (${supportSignals.join(", ")}); perform LLM project analysis or focused user clarification before authoring pair axes.`
+          : "No deterministic script signal can identify project-specific pair axes; perform LLM project analysis or focused user clarification before authoring pairs.",
+      evidence: [...signals.files, ...signals.directories, ...signals.evidence],
+    },
+  ];
 }
 
-function finalizerRecommendation(finalizer: FinalizerSummary, signals: RepoSignals): string {
+function pairRecommendations(
+  registry: RegistrySummary,
+  signals: RepoSignals,
+  runMode: RunMode,
+  targetState: TargetState,
+  loomExists: boolean,
+): string[] {
+  return pairRecommendationDetails(registry, signals, runMode, targetState, loomExists).map((detail) =>
+    detail.command ? `${detail.rationale} Suggested command: ${detail.command}` : detail.rationale,
+  );
+}
+
+function finalizerRecommendation(
+  finalizer: FinalizerSummary,
+  signals: RepoSignals,
+  runMode: RunMode,
+  targetState: TargetState,
+  loomExists: boolean,
+): string {
+  if (runMode === "setup" && targetState === "existing" && !loomExists) {
+    return "No .harness/loom foundation is present; run --migration to repair or refresh the foundation before authoring finalizer work or running sync.";
+  }
+  if (runMode === "setup" && targetState === "existing") {
+    if (finalizer.customized) {
+      return "Existing customized finalizer is left unchanged during the script phase; change it only if project analysis or the user selects new cycle-end work. Use --migration to refresh contract-owned finalizer surfaces.";
+    }
+    return "Existing finalizer is left unchanged during the script phase; author concrete cycle-end work during setup only after project analysis or user clarification. Use --migration to refresh the foundation.";
+  }
   if (finalizer.customized) return finalizer.recommendation;
   if (signals.evidence.includes("documentation surface") && signals.evidence.includes("test surface")) {
     return "Consider a finalizer that checks goal coverage, summarizes verification, and refreshes release/docs notes at cycle end.";
@@ -1074,104 +1249,6 @@ function finalizerRecommendation(finalizer: FinalizerSummary, signals: RepoSigna
     return "Consider a finalizer that performs a cycle-end verification summary only when the goal requires it.";
   }
   return finalizer.recommendation;
-}
-
-function makeSetupPairPlan(
-  pair: string,
-  reviewers: string[],
-  purpose: string,
-  designThinking: string,
-  methodology: string,
-  evaluationCriteria: string,
-  taboos: string,
-): SetupPairPlan {
-  return {
-    pair: {
-      pair,
-      producer: `${pair}-producer`,
-      reviewers,
-      skill: pair,
-      sourceLine: "",
-      evidence: { skillPresent: false, producerPresent: false, reviewersPresent: [], missing: [] },
-    },
-    purpose,
-    designThinking,
-    methodology,
-    evaluationCriteria,
-    taboos,
-  };
-}
-
-function setupPairPlans(signals: RepoSignals): SetupPairPlan[] {
-  const out: SetupPairPlan[] = [];
-  if (signals.evidence.includes("implementation surface")) {
-    out.push(
-      makeSetupPairPlan(
-        "harness-implementation",
-        ["harness-implementation-reviewer"],
-        "Implement and review requested project changes in the main code surface.",
-        "This pair owns feature and bug-fix work in the repository's main implementation surface. Setup mode authors it by default when the repo shows real code ownership boundaries but no restored project-specific pair exists yet.",
-        "1. Read the orchestrator envelope and repo surface named in scope.\n2. Identify the smallest implementation slice that satisfies the current request.\n3. Change code, config, or tests only inside the declared ownership.\n4. Verify the user-visible or contract-level effect with the smallest relevant command.\n5. Report concrete files, verification, and blocked follow-up items.",
-        "- Scope stays inside the declared implementation surface.\n- Changed behavior is backed by concrete file edits and a verification step.\n- Review can trace user-facing impact or contract impact from the diff.\n- Regression-sensitive changes mention tests or why no automated check exists.\n- The pair does not silently broaden into docs/release ownership.",
-        "- Do not rewrite unrelated docs, release notes, or planner/runtime contracts from this pair.\n- Do not claim verification without a concrete command or file-backed reason.\n- Do not defer required in-scope acceptance work into blocked items.",
-      ),
-    );
-  }
-  if (signals.evidence.includes("test surface") || signals.evidence.includes("ci workflow surface")) {
-    out.push(
-      makeSetupPairPlan(
-        "harness-verification",
-        ["harness-verification-reviewer"],
-        "Maintain regression checks, smoke coverage, and verification evidence for the repository.",
-        "This pair owns the repository's regression and smoke-verification surface. Setup mode adds it when tests or CI workflows are present so the harness has a concrete place for verification work instead of pushing that responsibility into ad hoc producer turns.",
-        "1. Read the task scope and identify the affected regression surface.\n2. Inspect current tests, workflows, or smoke scripts before editing.\n3. Add or adjust the smallest verification artifact that protects the changed behavior.\n4. Run the narrowest relevant verification command.\n5. Record gaps, flaky surfaces, or blocked coverage honestly.",
-        "- Verification changes stay grounded in real tests, workflows, or smoke scripts already present.\n- Producer output cites the command or file proving the regression surface changed.\n- Reviewer can trace risk reduction from the edited artifact.\n- Missing automation is surfaced explicitly instead of hidden behind PASS.\n- Verification ownership does not drift into general implementation work.",
-        "- Do not invent fake coverage or green statuses.\n- Do not rewrite product implementation when the real gap is missing verification evidence.\n- Do not move cycle-end summary work into this pair; finalizer owns cycle-end synthesis.",
-      ),
-    );
-  }
-  if (signals.evidence.includes("documentation surface")) {
-    out.push(
-      makeSetupPairPlan(
-        "harness-document",
-        ["harness-document-reviewer"],
-        "Maintain user-facing docs, pointer docs, and explanation surfaces in sync with the implementation.",
-        "This pair owns user-facing documentation and explanation surfaces. Setup mode adds it when the repo exposes README/docs-style material so documentation work has a concrete producer-reviewer home rather than being folded into arbitrary implementation turns.",
-        "1. Read the envelope and identify which docs surface the task actually touches.\n2. Inspect implementation evidence before rewriting prose.\n3. Update only the docs files justified by changed behavior or structure.\n4. Keep pointer docs short and direct readers to the canonical source.\n5. Report exact files changed and any remaining doc debt that stayed out of scope.",
-        "- Documentation changes are tied to current implementation evidence.\n- Pointer docs stay lightweight and do not fork a second source of truth.\n- Reviewer can cite exact files/sections for drift or coverage gaps.\n- The pair leaves unrelated implementation files alone.\n- Follow-up doc debt is separated from in-scope corrections.",
-        "- Do not paraphrase code without checking the actual file surface.\n- Do not mirror dynamic runtime state into pointer docs.\n- Do not widen a narrow doc fix into a repo-wide rewrite without evidence.",
-      ),
-    );
-  }
-  return out;
-}
-
-function renderPlannedPairSkill(plan: SetupPairPlan): string {
-  return [
-    renderSkillFrontmatter(
-      plan.pair.skill,
-      `Use when \`/harness-orchestrate\` dispatches the \`${plan.pair.pair}\` pair in this project. Shared rubric for the producer and its reviewer(s).`,
-    ),
-    "",
-    `# ${titleFromSlug(plan.pair.pair)}`,
-    "",
-    "## Design Thinking",
-    "",
-    plan.designThinking,
-    "",
-    "## Methodology",
-    "",
-    plan.methodology,
-    "",
-    "## Evaluation Criteria",
-    "",
-    plan.evaluationCriteria,
-    "",
-    "## Taboos",
-    "",
-    plan.taboos,
-    "",
-  ].join("\n");
 }
 
 function renderGenericPairSkill(pair: RegistryPair, signals: RepoSignals): string {
@@ -1213,28 +1290,6 @@ function renderGenericPairSkill(pair: RegistryPair, signals: RepoSignals): strin
   ].join("\n");
 }
 
-function renderSetupFinalizerFromSignals(signals: RepoSignals): string {
-  const template = loadTemplateSync(FINALIZER_TEMPLATE);
-  let task = "1. Emit the Output Format block below with `Status: PASS`, `Summary: no cycle-end work registered for this project`, empty `Files created` / `Files modified`, `Self-verification` citing that no cycle-end work was required, and `Blocked or out-of-scope items: []`. Do not touch any file.";
-  if (signals.evidence.length > 0) {
-    const docsStep = signals.evidence.includes("documentation surface")
-      ? "4. Refresh README, docs, or CHANGELOG only when the cycle goal or changed behavior justifies it.\n"
-      : "";
-    const verifyStep =
-      signals.evidence.includes("test surface") || signals.evidence.includes("ci workflow surface")
-        ? "3. Summarize concrete verification evidence from the cycle artifacts before deciding PASS or FAIL.\n"
-        : "3. Summarize concrete completion evidence from the cycle artifacts before deciding PASS or FAIL.\n";
-    task =
-      "1. Read the finalizer envelope, current goal, and prior task artifacts.\n" +
-      "2. Check whether the cycle left any required cycle-end outputs or follow-up notes.\n" +
-      verifyStep +
-      docsStep +
-      "5. Emit the Output Format block with concrete files touched, files intentionally left alone, and blocked out-of-scope items.\n" +
-      "6. If upstream planning or contract assumptions are broken, emit the Structural Issue block and return `Status: FAIL`.";
-  }
-  return replaceSection(template, "Task", task);
-}
-
 function addUsage(map: Map<string, string[]>, slug: string, owner: string): void {
   const current = map.get(slug) ?? [];
   current.push(owner);
@@ -1262,7 +1317,7 @@ function sharedArtifactReason(kind: "agent" | "skill", slug: string, owners: str
   const unique = uniqueOwners(owners);
   if (unique.length <= 1) return null;
   const scope = kind === "agent" ? "pair roles" : "pair entries";
-  return `${kind} slug is shared by multiple ${scope} and cannot be safely reconstructed: ${slug} (${unique.join(", ")})`;
+  return `${kind} slug is shared by multiple ${scope} and cannot be safely migrated: ${slug} (${unique.join(", ")})`;
 }
 
 function validatePairBasics(pair: RegistryPair, seen: Set<string>): string | null {
@@ -1309,106 +1364,6 @@ async function readOptional(path: string): Promise<string | null> {
   }
 }
 
-async function collectPairIntent(target: string, snapshotPath: string, pair: RegistryPair): Promise<PairIntent> {
-  const snapshotLoom = join(snapshotPath, "loom");
-  const skillPath = join(snapshotLoom, "skills", pair.skill, "SKILL.md");
-  const producerPath = join(snapshotLoom, "agents", `${pair.producer}.md`);
-  const reviewerPaths: Record<string, string | null> = {};
-  const evidenceLines: string[] = [];
-
-  const skillBody = await readOptional(skillPath);
-  const skillMarkedEvidence = skillBody ? markedEvidence(skillBody) : null;
-  if (skillMarkedEvidence && skillMarkedEvidence.length > 0) {
-    for (const reviewer of pair.reviewers) {
-      const reviewerPath = join(snapshotLoom, "agents", `${reviewer}.md`);
-      reviewerPaths[reviewer] = (await exists(reviewerPath)) ? reviewerPath : null;
-    }
-    return {
-      skillPath,
-      producerPath: (await exists(producerPath)) ? producerPath : null,
-      reviewerPaths,
-      evidenceLines: skillMarkedEvidence,
-    };
-  }
-  if (skillBody) {
-    evidenceLines.push(...evidenceFromMarkdown(skillBody, ["Design Thinking", "Methodology", "Task"], "Prior skill"));
-  } else {
-    evidenceLines.push(`Prior skill missing: ${rel(target, skillPath)}`);
-  }
-
-  const producerBody = await readOptional(producerPath);
-  if (producerBody) {
-    evidenceLines.push(...evidenceFromMarkdown(producerBody, ["Task", "Principles"], "Prior producer"));
-  } else {
-    evidenceLines.push(`Prior producer missing: ${rel(target, producerPath)}`);
-  }
-
-  for (const reviewer of pair.reviewers) {
-    const reviewerPath = join(snapshotLoom, "agents", `${reviewer}.md`);
-    reviewerPaths[reviewer] = (await exists(reviewerPath)) ? reviewerPath : null;
-    const reviewerBody = await readOptional(reviewerPath);
-    if (reviewerBody) {
-      evidenceLines.push(
-        ...evidenceFromMarkdown(reviewerBody, ["Task", "Principles"], `Prior reviewer ${reviewer}`),
-      );
-    } else {
-      evidenceLines.push(`Prior reviewer missing: ${rel(target, reviewerPath)}`);
-    }
-  }
-
-  return {
-    skillPath: skillBody ? skillPath : null,
-    producerPath: producerBody ? producerPath : null,
-    reviewerPaths,
-    evidenceLines: uniqueCapped(evidenceLines, 10),
-  };
-}
-
-function evidenceBulletBlock(lines: string[]): string {
-  const body = lines.length > 0 ? lines : ["No readable prior body evidence; preserve only registry topology."];
-  return body.map((line) => `- ${line}`).join("\n");
-}
-
-function renderPairSkill(pair: RegistryPair, intent: PairIntent, signals: RepoSignals): string {
-  const evidence = evidenceBulletBlock(intent.evidenceLines);
-  const signalLine =
-    signals.evidence.length > 0
-      ? signals.evidence.join(", ")
-      : "no strong repo surface signal beyond the preserved harness registry";
-  return renderTemplate(
-    // The current pair-dev template owns section order and frontmatter shape.
-    // Auto-setup only fills it with conservative convergence prose.
-    loadTemplateSync(PAIR_SKILL_TEMPLATE).replace("name: {{PAIR_SLUG}}", "name: {{SKILL_SLUG}}"),
-    {
-      PAIR_SLUG: pair.pair,
-      SKILL_SLUG: pair.skill,
-      PAIR_TITLE: titleFromSlug(pair.pair),
-      DESIGN_THINKING_PARAGRAPH:
-        `${titleFromSlug(pair.pair)} preserves the target's registered producer-reviewer responsibility while refreshing the body against the current harness contract. The snapshot evidence below is intent input, not restored runtime law.`,
-      METHODOLOGY_BODY:
-        `### Preserved Snapshot Intent\n\n${evidence}\n\n` +
-        `### Repo Evidence\n\n- Detected surfaces: ${signalLine}.\n\n` +
-        "### Convergence Workflow\n\n" +
-        "1. Read the orchestrator envelope and the shared `harness-context` law before touching files.\n" +
-        "2. Use the preserved snapshot intent to identify the workstream this pair owns.\n" +
-        "3. Inspect current project files instead of assuming the snapshot body is still correct.\n" +
-        "4. Keep writes inside the envelope `Scope` and report every changed path.\n" +
-        "5. Treat split, reorder, or ownership ambiguity as a structural issue for planning.",
-      EVAL_CRITERIA_BULLETS:
-        "- The producer output satisfies the envelope goal and stays inside the declared scope.\n" +
-        "- Snapshot intent is used as evidence, not as a copied contract.\n" +
-        "- Current project files and tests are cited when behavior changes.\n" +
-        "- The reviewer can verify filesystem effects and regression evidence.\n" +
-        "- Structural ambiguity is surfaced instead of hidden in a PASS.",
-      TABOO_BULLETS:
-        "- Do not restore stale snapshot files by copying them over current templates.\n" +
-        "- Do not edit `.harness/cycle/`; only the orchestrator owns runtime state.\n" +
-        "- Do not write derived provider trees; use explicit sync after convergence.\n" +
-        "- Do not broaden this pair into unrelated repository ownership.",
-    },
-  );
-}
-
 function renderProducerAgent(pair: RegistryPair): string {
   const raw = loadTemplateSync(PRODUCER_TEMPLATE).replace(
     "name: {{PAIR_SLUG}}-producer",
@@ -1450,7 +1405,7 @@ function renderReviewerAgent(pair: RegistryPair, reviewer: string): string {
       `${titleFromSlug(reviewer)} is a reviewer for the registered \`${pair.pair}\` harness pair. It grades the paired producer artifact against the shared skill, current contracts, and concrete filesystem evidence.`,
     PRINCIPLE_1: "Review by evidence. Reason: verdicts must cite concrete files, lines, diffs, or command results.",
     PRINCIPLE_2: "Preserve the pair boundary. Reason: this reviewer grades its registered workstream, not adjacent ownership.",
-    PRINCIPLE_3: "Check contract freshness. Reason: reconstructed pairs must follow current templates and harness-context law.",
+    PRINCIPLE_3: "Check contract freshness. Reason: migrated pairs must follow current templates and harness-context law.",
     PRINCIPLE_4: "Treat missing tests honestly. Reason: a PASS without regression evidence can hide broken convergence.",
     PRINCIPLE_5: "Escalate structural gaps. Reason: invalid planning or ownership cannot be repaired by reviewer optimism.",
     TASK_STEPS:
@@ -1494,31 +1449,19 @@ async function writePairArtifacts(
 
 function migratedSkillBody(pair: RegistryPair, sourceBody: string | null, signals: RepoSignals): string {
   const base = renderGenericPairSkill(pair, signals);
+  const source = sourceBody ?? base;
   const description = sourceBody ? frontmatterDescription(sourceBody) : null;
-  const title = sourceBody ? topHeading(sourceBody) : null;
+  const title = topHeading(source) ?? topHeading(base) ?? titleFromSlug(pair.pair);
+  const body = bodyAfterTopHeading(source) ?? bodyAfterTopHeading(base) ?? "";
   return [
     renderSkillFrontmatter(
       pair.skill,
       description ?? frontmatterDescription(base) ?? `Use when \`/harness-orchestrate\` dispatches the \`${pair.pair}\` pair in this project.`,
     ),
     "",
-    `# ${title ?? topHeading(base) ?? titleFromSlug(pair.pair)}`,
+    `# ${title}`,
     "",
-    "## Design Thinking",
-    "",
-    (sourceBody && section(sourceBody, "Design Thinking")) || section(base, "Design Thinking") || "",
-    "",
-    "## Methodology",
-    "",
-    (sourceBody && section(sourceBody, "Methodology")) || section(base, "Methodology") || "",
-    "",
-    "## Evaluation Criteria",
-    "",
-    (sourceBody && section(sourceBody, "Evaluation Criteria")) || section(base, "Evaluation Criteria") || "",
-    "",
-    "## Taboos",
-    "",
-    (sourceBody && section(sourceBody, "Taboos")) || section(base, "Taboos") || "",
+    body.trimEnd(),
     "",
   ].join("\n");
 }
@@ -1532,34 +1475,20 @@ function migratedAgentBody(
 ): string {
   const requiredSkills = [pair.skill, "harness-context"];
   const skills = [...requiredSkills, ...preservedExtraSkills(sourceBody ?? "", requiredSkills)];
+  const source = sourceBody ?? templateBody;
   const description =
     (sourceBody && frontmatterDescription(sourceBody)) ||
     frontmatterDescription(templateBody) ||
     `Use when \`/harness-orchestrate\` dispatches the \`${pair.pair}\` ${role} turn.`;
   const model = sourceBody ? frontmatterScalar(sourceBody, "model") : null;
-  const title = (sourceBody && topHeading(sourceBody)) || topHeading(templateBody) || titleFromSlug(slug);
-  const intro = (sourceBody && introAfterHeading(sourceBody)) || introAfterHeading(templateBody) || "";
-  const principles = (sourceBody && section(sourceBody, "Principles")) || section(templateBody, "Principles") || "";
-  const task = (sourceBody && section(sourceBody, "Task")) || section(templateBody, "Task") || "";
-  const outputFormat = section(templateBody, "Output Format") || "";
+  const title = topHeading(source) || topHeading(templateBody) || titleFromSlug(slug);
+  const outputFormat = (section(templateBody, "Output Format") || "").trim();
+  const tail = bodyAfterTopHeading(source) ?? bodyAfterTopHeading(templateBody) ?? "";
+  const body = replaceTopLevelSection([`# ${title}`, "", tail.trimEnd(), ""].join("\n"), "Output Format", outputFormat);
   return [
     renderAgentFrontmatter(slug, description, skills, model),
     "",
-    `# ${title}`,
-    "",
-    intro,
-    "",
-    "## Principles",
-    "",
-    principles.trim(),
-    "",
-    "## Task",
-    "",
-    task.trim(),
-    "",
-    "## Output Format",
-    "",
-    outputFormat.trim(),
+    body.trimEnd(),
     "",
   ].join("\n");
 }
@@ -1572,35 +1501,17 @@ function migratedFinalizerBody(sourceBody: string): string {
     "Use when the orchestrator dispatches the cycle-end finalizer turn.";
   const model = frontmatterScalar(sourceBody, "model");
   const title = topHeading(sourceBody) ?? topHeading(template) ?? "Finalizer";
-  const intro = introAfterHeading(sourceBody) ?? introAfterHeading(template) ?? "";
-  const principles = section(sourceBody, "Principles") ?? section(template, "Principles") ?? "";
-  const task = section(sourceBody, "Task") ?? section(template, "Task") ?? "";
-  const outputFormat = section(template, "Output Format") ?? "";
-  const structuralIssue = (() => {
-    const marker = "If a structural issue is detected, include this block immediately before the Output Format block:";
-    const index = template.indexOf(marker);
-    return index === -1 ? "" : template.slice(index).trim();
-  })();
+  const outputFormat = finalizerOutputFormatContract(template).trim();
+  const tail = bodyAfterTopHeading(sourceBody) ?? bodyAfterTopHeading(template) ?? "";
+  const body = replaceTopLevelSection(
+    removeTopLevelSection([`# ${title}`, "", tail.trimEnd(), ""].join("\n"), "Structural Issue"),
+    "Output Format",
+    outputFormat,
+  );
   return [
     renderAgentFrontmatter("harness-finalizer", description, ["harness-context"], model),
     "",
-    `# ${title}`,
-    "",
-    intro,
-    "",
-    "## Principles",
-    "",
-    principles.trim(),
-    "",
-    "## Task",
-    "",
-    task.trim(),
-    "",
-    "## Output Format",
-    "",
-    outputFormat.trim(),
-    "",
-    structuralIssue,
+    body.trimEnd(),
     "",
   ].join("\n");
 }
@@ -1668,7 +1579,7 @@ function runRegisterPair(target: string, pair: RegistryPair): unknown {
   if (result.stderr) process.stderr.write(result.stderr);
   if (result.status !== 0) {
     const detail = result.stderr.trim() || result.stdout.trim() || "registration failed";
-    die(`pair reconstruction failed for ${pair.pair}: ${detail}`);
+    die(`pair migration registration failed for ${pair.pair}: ${detail}`);
   }
   try {
     return JSON.parse(result.stdout);
@@ -1677,134 +1588,15 @@ function runRegisterPair(target: string, pair: RegistryPair): unknown {
   }
 }
 
-async function reconstructPairs(
-  target: string,
-  snapshotPath: string | null,
-  registry: RegistrySummary,
-  signals: RepoSignals,
-): Promise<PairReconstruction[]> {
-  if (!snapshotPath || registry.pairCount === 0) return [];
-  const out: PairReconstruction[] = [];
-  const seen = new Set<string>();
-  const basicInvalidReasons = registry.pairs.map((pair) => validatePairBasics(pair, seen));
-  const artifactUsage = collectArtifactUsage(registry.pairs.filter((_, index) => !basicInvalidReasons[index]));
-
-  for (const [index, pair] of registry.pairs.entries()) {
-    const invalidReason = basicInvalidReasons[index] ?? validatePairArtifacts(pair, artifactUsage);
-    if (invalidReason) {
-      out.push({
-        pair: pair.pair,
-        status: "skipped",
-        reason: invalidReason,
-        producer: pair.producer,
-        reviewers: pair.reviewers,
-        skill: pair.skill,
-        filesWritten: [],
-        registry: null,
-        evidenceLines: [],
-        preserved: [],
-        replaced: [],
-        manualReview: [],
-        source: null,
-        convergence: {
-          improvementPasses: 0,
-          stopReason: "invalid snapshot registry entry",
-          qualityVerdict: "manual-review",
-        },
-      });
-      continue;
-    }
-    const intent = await collectPairIntent(target, snapshotPath, pair);
-    const reviewerBodies = Object.fromEntries(
-      pair.reviewers.map((reviewer) => [reviewer, renderReviewerAgent(pair, reviewer)]),
-    );
-    const filesWritten = await writePairArtifacts(
-      target,
-      pair,
-      renderPairSkill(pair, intent, signals),
-      renderProducerAgent(pair),
-      reviewerBodies,
-    );
-
-    const registration = runRegisterPair(target, pair);
-    out.push({
-      pair: pair.pair,
-      status: "reconstructed",
-      reason: "current pair-dev templates rendered from snapshot evidence",
-      producer: pair.producer,
-      reviewers: pair.reviewers,
-      skill: pair.skill,
-      filesWritten,
-      registry: registration,
-      evidenceLines: intent.evidenceLines,
-      preserved: ["registered pair topology", "snapshot intent evidence"],
-      replaced: ["skill body", "producer agent", "reviewer agent(s)", "current output contract"],
-      manualReview: [...pair.evidence.missing],
-      source: {
-        kind: "snapshot",
-        locator: snapshotLocator(snapshotPath, pair.pair),
-      },
-      convergence: {
-        improvementPasses: 0,
-        stopReason: "draft met setup reconstruction bar",
-        qualityVerdict: "acceptable",
-      },
-    });
-  }
-  return out;
-}
-
-async function authorSetupPairs(target: string, signals: RepoSignals): Promise<PairReconstruction[]> {
-  const plans = setupPairPlans(signals);
-  if (plans.length === 0) return [];
-  const out: PairReconstruction[] = [];
-  for (const plan of plans) {
-    const reviewerBodies = Object.fromEntries(
-      plan.pair.reviewers.map((reviewer) => [reviewer, renderReviewerAgent(plan.pair, reviewer)]),
-    );
-    const filesWritten = await writePairArtifacts(
-      target,
-      plan.pair,
-      renderPlannedPairSkill(plan),
-      renderProducerAgent(plan.pair),
-      reviewerBodies,
-    );
-    const registration = runRegisterPair(target, plan.pair);
-    out.push({
-      pair: plan.pair.pair,
-      status: "authored",
-      reason: "setup mode authored a repo-grounded starter pair",
-      producer: plan.pair.producer,
-      reviewers: plan.pair.reviewers,
-      skill: plan.pair.skill,
-      filesWritten,
-      registry: registration,
-      evidenceLines: [`Purpose: ${plan.purpose}`, ...signals.evidence.map((signal) => `Repo signal: ${signal}`)],
-      preserved: [],
-      replaced: ["new pair skill", "new producer agent", "new reviewer agent(s)"],
-      manualReview: [],
-      source: {
-        kind: "repo-signals",
-        locator: null,
-      },
-      convergence: {
-        improvementPasses: 0,
-        stopReason: "initial authored draft met setup quality bar",
-        qualityVerdict: "acceptable",
-      },
-    });
-  }
-  return out;
-}
-
 async function migratePairs(
   target: string,
   snapshotPath: string | null,
   registry: RegistrySummary,
   signals: RepoSignals,
-): Promise<PairReconstruction[]> {
-  if (!snapshotPath || registry.pairCount === 0) return [];
-  const out: PairReconstruction[] = [];
+): Promise<PairMigrationResult> {
+  if (!snapshotPath || registry.pairCount === 0) return { operations: [], migrationPlanPairs: [] };
+  const out: PairOperation[] = [];
+  const migrationPlanPairs: MigrationPlanPair[] = [];
   const seen = new Set<string>();
   const basicInvalidReasons = registry.pairs.map((pair) => validatePairBasics(pair, seen));
   const artifactUsage = collectArtifactUsage(registry.pairs.filter((_, index) => !basicInvalidReasons[index]));
@@ -1867,19 +1659,48 @@ async function migratePairs(
       reviewerBodies,
     );
     const registration = runRegisterPair(target, pair);
+    const userSurfaces = [
+      ...h2Headings(sourceSkillBody).map((heading) => `skill:${heading}`),
+      ...h2Headings(sourceProducerBody).map((heading) => `producer:${heading}`),
+      ...sourceReviewerBodies.flatMap(([reviewer, body]) =>
+        h2Headings(body).map((heading) => `${reviewer}:${heading}`),
+      ),
+    ].filter((surface) => !surface.endsWith(":Output Format"));
     const preserved = [
-      ...(sourceSkillBody && section(sourceSkillBody, "Design Thinking") ? ["skill Design Thinking"] : []),
-      ...(sourceSkillBody && section(sourceSkillBody, "Methodology") ? ["skill Methodology"] : []),
-      ...(sourceSkillBody && section(sourceSkillBody, "Evaluation Criteria") ? ["skill Evaluation Criteria"] : []),
-      ...(sourceSkillBody && section(sourceSkillBody, "Taboos") ? ["skill Taboos"] : []),
+      ...h2Headings(sourceSkillBody).map((heading) => `skill ${heading}`),
       ...(sourceProducerBody && introAfterHeading(sourceProducerBody) ? ["producer identity paragraph"] : []),
-      ...(sourceProducerBody && section(sourceProducerBody, "Principles") ? ["producer Principles"] : []),
-      ...(sourceProducerBody && section(sourceProducerBody, "Task") ? ["producer Task"] : []),
-      ...sourceReviewerBodies.flatMap(([reviewer, body]) => (body && section(body, "Task") ? [`${reviewer} Task`] : [])),
+      ...h2Headings(sourceProducerBody)
+        .filter((heading) => heading !== "Output Format")
+        .map((heading) => `producer ${heading}`),
+      ...sourceReviewerBodies.flatMap(([reviewer, body]) =>
+        h2Headings(body)
+          .filter((heading) => heading !== "Output Format")
+          .map((heading) => `${reviewer} ${heading}`),
+      ),
     ];
     const manualReview = [...prepared.from.missingArtifacts];
     if (!sourceSkillBody) manualReview.push(`missing migration source skill for ${pair.skill}`);
     if (!sourceProducerBody) manualReview.push(`missing migration source producer for ${pair.producer}`);
+    migrationPlanPairs.push({
+      pair: pair.pair,
+      source: {
+        skillPath: prepared.from.skillPath,
+        producerPath: prepared.from.producerPath,
+        reviewerPaths: prepared.from.reviewerPaths,
+        missingArtifacts: prepared.from.missingArtifacts,
+      },
+      target: {
+        skillPath: `.harness/loom/skills/${pair.skill}/SKILL.md`,
+        producerPath: `.harness/loom/agents/${pair.producer}.md`,
+        reviewerPaths: Object.fromEntries(
+          pair.reviewers.map((reviewer) => [reviewer, `.harness/loom/agents/${reviewer}.md`]),
+        ),
+      },
+      overlayMethodology: "plugins/harness-loom/skills/harness-pair-dev/references/authoring/from-overlay.md",
+      contractSurfaces: ["frontmatter name", "frontmatter skills", "role Output Format"],
+      userSurfaces,
+      manualReviewNotes: [...new Set(manualReview)],
+    });
 
     out.push({
       pair: pair.pair,
@@ -1899,7 +1720,6 @@ async function migratePairs(
         "frontmatter name",
         "frontmatter skills",
         "current Output Format",
-        "current runtime trigger descriptions",
       ],
       manualReview: [...new Set(manualReview)],
       source: {
@@ -1916,7 +1736,7 @@ async function migratePairs(
       },
     });
   }
-  return out;
+  return { operations: out, migrationPlanPairs };
 }
 
 function finalizerEvidence(body: string, summary: FinalizerSummary): string[] {
@@ -1930,156 +1750,24 @@ function finalizerEvidence(body: string, summary: FinalizerSummary): string[] {
   return uniqueCapped(out, 10);
 }
 
-function renderFinalizerFromTemplate(template: string, evidenceLines: string[]): string {
-  const evidence = evidenceBulletBlock(evidenceLines);
-  const task =
-    "\n" +
-    "This finalizer was reconstructed by `/harness-auto-setup` from snapshot evidence. The preserved intent below is evidence, not restored contract text.\n\n" +
-    "### Preserved Intent Evidence\n\n" +
-    `${evidence}\n\n` +
-    "### Current Contract Task\n\n" +
-    "1. Read the envelope and confirm the concrete cycle-end scope.\n" +
-    "2. Use preserved intent evidence to decide which cycle-end duty applies.\n" +
-    "3. Inspect project files and cycle artifacts named by the envelope.\n" +
-    "4. Perform only writes justified by scope, current contracts, and project evidence.\n" +
-    "5. Run the smallest relevant verification for the cycle-end duty.\n" +
-    "6. Emit the Output Format block with concrete paths, verification, and any blocked or out-of-scope items.\n\n" +
-    "If the preserved intent no longer matches the current goal or project contract, emit the Structural Issue block and return `Status: FAIL`.\n";
-  return replaceSection(template, "Task", task);
-}
-
-async function reconstructFinalizer(
-  target: string,
-  snapshotPath: string | null,
-  summary: FinalizerSummary,
-): Promise<FinalizerReconstruction> {
-  const finalizerPath = join(target, ".harness", "loom", "agents", "harness-finalizer.md");
-  if (summary.status === "absent") {
-    return {
-      status: "missing",
-      reason: "no prior finalizer existed; installed default skeleton left unchanged",
-      path: rel(target, finalizerPath),
-      filesWritten: [],
-      evidenceLines: [],
-      preserved: [],
-      replaced: [],
-      manualReview: [],
-      convergence: {
-        improvementPasses: 0,
-        stopReason: "default skeleton retained",
-        qualityVerdict: "fallback",
-      },
-    };
-  }
-  if (summary.status !== "customized") {
-    return {
-      status: summary.status === "default-noop" ? "default-noop" : "skipped",
-      reason: `${summary.status} finalizer does not require reconstruction`,
-      path: rel(target, finalizerPath),
-      filesWritten: [],
-      evidenceLines: [],
-      preserved: [],
-      replaced: [],
-      manualReview: [],
-      convergence: {
-        improvementPasses: 0,
-        stopReason: "no customized finalizer intent to rebuild",
-        qualityVerdict: "acceptable",
-      },
-    };
-  }
-  if (!snapshotPath) {
-    return {
-      status: "skipped",
-      reason: "customized finalizer was detected but no snapshot path is available",
-      path: rel(target, finalizerPath),
-      filesWritten: [],
-      evidenceLines: [],
-      preserved: [],
-      replaced: [],
-      manualReview: ["missing snapshot path for customized finalizer"],
-      convergence: {
-        improvementPasses: 0,
-        stopReason: "customized finalizer could not be reconstructed without snapshot",
-        qualityVerdict: "manual-review",
-      },
-    };
-  }
-  const snapshotFinalizer = join(snapshotPath, "loom", "agents", "harness-finalizer.md");
-  const body = await readOptional(snapshotFinalizer);
-  if (!body) {
-    return {
-      status: "skipped",
-      reason: "customized finalizer evidence was not readable from snapshot",
-      path: rel(target, finalizerPath),
-      filesWritten: [],
-      evidenceLines: [],
-      preserved: [],
-      replaced: [],
-      manualReview: [rel(target, snapshotFinalizer)],
-      convergence: {
-        improvementPasses: 0,
-        stopReason: "snapshot finalizer body missing",
-        qualityVerdict: "manual-review",
-      },
-    };
-  }
-  const template = await readFile(FINALIZER_TEMPLATE, "utf8");
-  const evidenceLines = finalizerEvidence(body, summary);
-  await writeFile(finalizerPath, renderFinalizerFromTemplate(template, evidenceLines));
-  return {
-    status: "reconstructed",
-    reason: "current finalizer skeleton rendered with preserved intent evidence",
-    path: rel(target, finalizerPath),
-    filesWritten: [rel(target, finalizerPath)],
-    evidenceLines,
-    preserved: ["finalizer intent evidence"],
-    replaced: ["Task section", "Output Format", "current structural-issue contract"],
-    manualReview: [],
-    convergence: {
-      improvementPasses: 0,
-      stopReason: "setup reconstruction preserved intent evidence on the current skeleton",
-      qualityVerdict: "acceptable",
-    },
-  };
-}
-
 async function authorSetupFinalizer(
   target: string,
   signals: RepoSignals,
-): Promise<FinalizerReconstruction> {
+): Promise<FinalizerOperation> {
   const finalizerPath = join(target, ".harness", "loom", "agents", "harness-finalizer.md");
-  if (signals.evidence.length === 0) {
-    return {
-      status: "default-noop",
-      reason: "repo signals are too thin; installed default finalizer remains in place",
-      path: rel(target, finalizerPath),
-      filesWritten: [],
-      evidenceLines: [],
-      preserved: [],
-      replaced: [],
-      manualReview: [],
-      convergence: {
-        improvementPasses: 0,
-        stopReason: "no repo-grounded cycle-end duty detected",
-        qualityVerdict: "fallback",
-      },
-    };
-  }
-  await writeFile(finalizerPath, renderSetupFinalizerFromSignals(signals));
   return {
-    status: "authored",
-    reason: "setup mode authored a concrete cycle-end finalizer from repo signals",
+    status: "default-noop",
+    reason: "fresh setup keeps the installed safe no-op until a concrete project cycle-end duty is selected",
     path: rel(target, finalizerPath),
-    filesWritten: [rel(target, finalizerPath)],
+    filesWritten: [],
     evidenceLines: signals.evidence.map((signal) => `Repo signal: ${signal}`),
     preserved: [],
-    replaced: ["finalizer Task section"],
+    replaced: [],
     manualReview: [],
     convergence: {
       improvementPasses: 0,
-      stopReason: "initial authored finalizer met setup quality bar",
-      qualityVerdict: "acceptable",
+      stopReason: "repo signals are recommendation evidence, not enough proof for script-authored finalizer work",
+      qualityVerdict: "fallback",
     },
   };
 }
@@ -2088,7 +1776,7 @@ async function migrateFinalizer(
   target: string,
   snapshotPath: string | null,
   summary: FinalizerSummary,
-): Promise<FinalizerReconstruction> {
+): Promise<FinalizerOperation> {
   const finalizerPath = join(target, ".harness", "loom", "agents", "harness-finalizer.md");
   if (summary.status === "absent") {
     return {
@@ -2182,6 +1870,26 @@ async function migrateFinalizer(
   };
 }
 
+function finalizerMigrationPlan(
+  target: string,
+  snapshotPath: string | null,
+  summary: FinalizerSummary,
+): MigrationPlanFinalizer | null {
+  const targetPath = ".harness/loom/agents/harness-finalizer.md";
+  if (summary.status === "absent" || summary.status === "default-noop") return null;
+  const sourcePath = snapshotPath ? rel(target, join(snapshotPath, "loom", "agents", "harness-finalizer.md")) : null;
+  return {
+    required: summary.status === "customized",
+    source: { agentPath: sourcePath },
+    target: { agentPath: targetPath },
+    overlayMethodology: "plugins/harness-loom/skills/harness-auto-setup/references/finalizer-overlay.md",
+    contractSurfaces: ["frontmatter name", "frontmatter skills", "Output Format", "Structural Issue contract"],
+    userSurfaces: ["intro", "Principles", "Task", "compatible custom H2 sections"],
+    manualReviewNotes:
+      summary.status === "customized" ? [] : [`finalizer status is ${summary.status}; inspect snapshot before migration`],
+  };
+}
+
 async function createSnapshot(
   target: string,
   createdAt: string,
@@ -2217,7 +1925,7 @@ async function createSnapshot(
     activeCycle,
     registrySummary,
     finalizerSummary,
-    nextAction: "Foundation refresh will reseed .harness/loom and .harness/cycle; valid registered pairs and customized finalizer intent will be reconstructed after refresh, then explicit sync remains a user handoff.",
+    nextAction: "Foundation refresh will reseed .harness/loom and .harness/cycle; valid registered pairs and customized finalizer intent will be migrated after refresh, then explicit sync remains a user-run command.",
     runMode,
     targetState,
     recommendations: {
@@ -2232,7 +1940,7 @@ async function createSnapshot(
   return { created: true, path: snapshotPath, manifestPath, copiedNamespaces };
 }
 
-function runInstall(target: string): { status: number | null; stdout: string; stderr: string; summary: unknown } {
+function runInstall(target: string): InstallResult {
   const result = spawnSync(process.execPath, [INSTALL_SCRIPT], { encoding: "utf8", cwd: target });
   let summary: unknown = null;
   if (result.stdout.trim()) {
@@ -2248,6 +1956,160 @@ function runInstall(target: string): { status: number | null; stdout: string; st
     stderr: result.stderr,
     summary,
   };
+}
+
+function skippedInstall(reason: string): InstallResult {
+  return { status: null, stdout: "", stderr: "", summary: null, skipped: true, reason };
+}
+
+function skippedExistingSetupFinalizer(path: string | null): FinalizerOperation {
+  return {
+    status: "skipped",
+    reason: "setup script phase leaves existing finalizer files unchanged; author cycle-end changes only after project analysis or user clarification",
+    path,
+    filesWritten: [],
+    evidenceLines: [],
+    preserved: [],
+    replaced: [],
+    manualReview: [],
+    convergence: {
+      improvementPasses: 0,
+      stopReason: "existing setup script phase is inspection-only; assistant authoring follows when needed",
+      qualityVerdict: "acceptable",
+    },
+  };
+}
+
+function convergenceMode(runMode: RunMode, targetState: TargetState, loomExists: boolean): string {
+  if (runMode === "migration") return "protected-migration-overlay";
+  if (targetState === "fresh") return "setup-bootstrap-authoring-required";
+  if (!loomExists) return "setup-cycle-only-migration-required";
+  return "setup-inspection-authoring-required";
+}
+
+function convergenceNote(runMode: RunMode, targetState: TargetState, loomExists: boolean): string {
+  if (runMode === "migration") {
+    return "Migration mode snapshots existing harness state, refreshes foundation contracts, preserves compatible source sections, and emits an explicit migration plan.";
+  }
+  if (targetState === "fresh") {
+    return "Setup script phase installs the foundation on fresh targets; the assistant must continue with project analysis or focused user clarification before authoring concrete pair/finalizer configuration.";
+  }
+  if (!loomExists) {
+    return "Setup script phase detected .harness/cycle without .harness/loom and left cycle state untouched; run --migration to repair or refresh the foundation before pair/finalizer authoring or sync.";
+  }
+  return "Setup script phase detected an existing harness and left the foundation untouched; the assistant must continue with project analysis or focused user clarification before authoring additive pair/finalizer configuration. Use --migration for foundation refresh.";
+}
+
+function setupAuthoringSummary(
+  runMode: RunMode,
+  targetState: TargetState,
+  loomExists: boolean,
+  providers: string[],
+): unknown {
+  if (runMode !== "setup") return null;
+  if (targetState === "existing" && !loomExists) {
+    return {
+      required: false,
+      blocked: true,
+      scriptPhaseOnly: true,
+      mayAskUser: false,
+      reason: ".harness/cycle exists but .harness/loom is missing, so setup cannot safely author pairs/finalizer or offer sync.",
+      expectedNextWork: `Run ${autoSetupCommand("migration", providers)} to repair or refresh the foundation before pair/finalizer authoring or sync.`,
+      stopCondition: "Stop setup-mode authoring until the foundation has been repaired or refreshed.",
+    };
+  }
+  return {
+    required: true,
+    scriptPhaseOnly: true,
+    mayAskUser: true,
+    questionPolicy: "Ask at most three concise questions only when repo evidence cannot determine project purpose, workflow boundary, or review axes.",
+    expectedNextWork:
+      targetState === "fresh"
+        ? "Inspect the project, then author the initial registered pair roster and customize the singleton finalizer only when a concrete cycle-end duty is selected."
+        : "Inspect the project and existing roster, then author additive registered pairs or finalizer changes without refreshing existing foundation state.",
+    stopCondition: "Stop without authoring only when the project is effectively blank or the user declines to choose a workflow boundary.",
+  };
+}
+
+function nextAction(runMode: RunMode, targetState: TargetState, loomExists: boolean, command: string, providers: string[]): string {
+  if (runMode === "migration") {
+    return `From the target root, run \`${command}\` for any platform trees you want to refresh.`;
+  }
+  if (targetState === "fresh") {
+    return `Continue setup by inspecting the project, asking focused questions only if needed, and authoring the initial pair/finalizer configuration under .harness/loom; after that authoring is complete, run \`${command}\` for any platform trees you want to refresh.`;
+  }
+  if (!loomExists) {
+    return `Run \`${autoSetupCommand("migration", providers)}\` before authoring pairs/finalizer or running sync; setup left existing .harness/cycle untouched because .harness/loom is missing.`;
+  }
+  return `Continue setup by inspecting the project and existing roster, then author only additive pair/finalizer changes under .harness/loom unless the user requested improvement; after that authoring is complete, run \`${command}\` for any platform trees you want to refresh.`;
+}
+
+function pairOwnedLoomEntries(registry: RegistrySummary): { skills: Set<string>; agents: Set<string> } {
+  const skills = new Set<string>();
+  const agents = new Set<string>();
+  for (const pair of registry.pairs) {
+    skills.add(pair.skill);
+    agents.add(`${pair.producer}.md`);
+    for (const reviewer of pair.reviewers) agents.add(`${reviewer}.md`);
+  }
+  return { skills, agents };
+}
+
+async function restoreCustomLoomEntries(
+  target: string,
+  snapshotPath: string | null,
+  registry: RegistrySummary,
+): Promise<RestoredCustomEntries> {
+  const restored: RestoredCustomEntries = { skills: [], agents: [], skipped: [] };
+  if (!snapshotPath) return restored;
+  const snapshotLoom = join(snapshotPath, "loom");
+  if (!(await exists(snapshotLoom))) return restored;
+  const owned = pairOwnedLoomEntries(registry);
+
+  const skillsRoot = join(snapshotLoom, "skills");
+  if (await exists(skillsRoot)) {
+    for (const entry of await readdir(skillsRoot, { withFileTypes: true })) {
+      if (!entry.isDirectory()) {
+        restored.skipped.push({
+          path: `skills/${entry.name}`,
+          reason: "custom skill entries must be directories",
+        });
+        continue;
+      }
+      if (FOUNDATION_SLUGS.has(entry.name) || owned.skills.has(entry.name)) continue;
+      const source = join(skillsRoot, entry.name);
+      const targetPath = join(target, ".harness", "loom", "skills", entry.name);
+      await cp(source, targetPath, { recursive: true, force: true });
+      restored.skills.push(entry.name);
+    }
+  }
+
+  const agentsRoot = join(snapshotLoom, "agents");
+  if (await exists(agentsRoot)) {
+    for (const entry of await readdir(agentsRoot, { withFileTypes: true })) {
+      if (!entry.isFile() || !entry.name.endsWith(".md")) {
+        restored.skipped.push({
+          path: `agents/${entry.name}`,
+          reason: "custom agent entries must be markdown files",
+        });
+        continue;
+      }
+      const slug = entry.name.replace(/\.md$/, "");
+      if (FOUNDATION_SLUGS.has(slug) || owned.agents.has(entry.name)) continue;
+      const source = join(agentsRoot, entry.name);
+      const targetPath = join(target, ".harness", "loom", "agents", entry.name);
+      await cp(source, targetPath, { force: true });
+      restored.agents.push(entry.name);
+    }
+  }
+
+  restored.skills.sort();
+  restored.agents.sort();
+  restored.skipped.sort((a, b) => a.path.localeCompare(b.path));
+  for (const skipped of restored.skipped) {
+    process.stderr.write(`harness-auto-setup: warning - skipped custom loom entry ${skipped.path}: ${skipped.reason}\n`);
+  }
+  return restored;
 }
 
 async function main() {
@@ -2284,13 +2146,14 @@ async function main() {
       };
   const signals = await repoSignals(args.target);
   const recommendations = {
-    pairs: pairRecommendations(registrySummary, signals),
-    finalizer: finalizerRecommendation(finalizerSummary, signals),
+    pairs: pairRecommendations(registrySummary, signals, args.runMode, targetState, loomExists),
+    finalizer: finalizerRecommendation(finalizerSummary, signals, args.runMode, targetState, loomExists),
     sync: command,
   };
+  const refreshesFoundation = args.runMode === "migration" || targetState === "fresh";
 
   const snapshot =
-    targetState === "existing"
+    args.runMode === "migration"
       ? await createSnapshot(
           args.target,
           createdAt,
@@ -2304,7 +2167,10 @@ async function main() {
       : { created: false, path: null, manifestPath: null, copiedNamespaces: [] };
 
   const warnings: string[] = [];
-  if (activeCycle.classification === "active" || activeCycle.classification === "unknown") {
+  if (
+    refreshesFoundation &&
+    (activeCycle.classification === "active" || activeCycle.classification === "unknown")
+  ) {
     warnings.push(
       `Existing cycle classified as ${activeCycle.classification}; it was copied to ${snapshot.path} and will be discarded/reseeded by foundation refresh.`,
     );
@@ -2313,30 +2179,37 @@ async function main() {
     process.stderr.write(`harness-auto-setup: warning - ${warning}\n`);
   }
 
-  const install = runInstall(args.target);
+  const install = refreshesFoundation
+    ? runInstall(args.target)
+    : skippedInstall("setup mode leaves existing .harness foundation untouched; use --migration to refresh it");
   if (install.stderr) process.stderr.write(install.stderr);
-  if (install.status !== 0) {
+  if (!install.skipped && install.status !== 0) {
     const detail = install.stderr.trim() || install.stdout.trim() || "install failed";
     die(`foundation refresh failed: ${detail}`);
   }
 
-  let pairReconstructions: PairReconstruction[] = [];
-  let finalizerReconstruction: FinalizerReconstruction;
+  const restoredCustomEntries =
+    args.runMode === "migration"
+      ? await restoreCustomLoomEntries(args.target, snapshot.path, registrySummary)
+      : { skills: [], agents: [], skipped: [] };
+
+  let pairOperations: PairOperation[] = [];
+  let finalizerOperation: FinalizerOperation;
+  let migrationPlan: MigrationPlan | null = null;
   if (args.runMode === "migration") {
-    pairReconstructions = await migratePairs(args.target, snapshot.path, registrySummary, signals);
-    finalizerReconstruction = await migrateFinalizer(args.target, snapshot.path, finalizerSummary);
-  } else if (registrySummary.pairCount > 0) {
-    pairReconstructions = await reconstructPairs(args.target, snapshot.path, registrySummary, signals);
-    finalizerReconstruction =
-      finalizerSummary.status === "customized"
-        ? await reconstructFinalizer(args.target, snapshot.path, finalizerSummary)
-        : await authorSetupFinalizer(args.target, signals);
+    const migratedPairs = await migratePairs(args.target, snapshot.path, registrySummary, signals);
+    pairOperations = migratedPairs.operations;
+    finalizerOperation = await migrateFinalizer(args.target, snapshot.path, finalizerSummary);
+    migrationPlan = {
+      pairs: migratedPairs.migrationPlanPairs,
+      finalizer: finalizerMigrationPlan(args.target, snapshot.path, finalizerSummary),
+    };
+  } else if (targetState === "existing") {
+    pairOperations = [];
+    finalizerOperation = skippedExistingSetupFinalizer(finalizerSummary.path);
   } else {
-    pairReconstructions = await authorSetupPairs(args.target, signals);
-    finalizerReconstruction =
-      finalizerSummary.status === "customized"
-        ? await reconstructFinalizer(args.target, snapshot.path, finalizerSummary)
-        : await authorSetupFinalizer(args.target, signals);
+    pairOperations = [];
+    finalizerOperation = await authorSetupFinalizer(args.target, signals);
   }
 
   const summary = {
@@ -2352,24 +2225,27 @@ async function main() {
     finalizerSummary,
     repoSignals: signals,
     convergence: {
-      mode: args.runMode === "migration" ? "protected-migration-overlay" : "setup-author-first",
-      note:
-        args.runMode === "migration"
-          ? "Migration mode preserved user-authored pair/finalizer guidance where possible while refreshing contract-owned runtime surfaces."
-          : "Setup mode authors or reconstructs usable pair/finalizer outputs in one run, falling back to recommendations only when repo grounding is too thin.",
-      pairReconstructions,
-      finalizerReconstruction,
+      mode: convergenceMode(args.runMode, targetState, loomExists),
+      note: convergenceNote(args.runMode, targetState, loomExists),
+      pairOperations,
+      finalizerOperation,
+      restoredCustomEntries,
+      migrationPlan,
+      setupAuthoring: setupAuthoringSummary(args.runMode, targetState, loomExists, args.providers),
       pairRecommendations: recommendations.pairs,
+      pairRecommendationDetails: pairRecommendationDetails(registrySummary, signals, args.runMode, targetState, loomExists),
       finalizerRecommendation: recommendations.finalizer,
     },
     install: {
       status: install.status,
       summary: install.summary,
+      skipped: install.skipped ?? false,
+      reason: install.reason ?? null,
     },
     warnings,
     providerTreesWritten: [],
     syncCommand: command,
-    nextAction: `From the target root, run \`${command}\` for any platform trees you want to refresh.`,
+    nextAction: nextAction(args.runMode, targetState, loomExists, command, args.providers),
   };
   process.stdout.write(JSON.stringify(summary, null, 2) + "\n");
 }

--- a/tests/auto-setup-skill-anchors.test.mjs
+++ b/tests/auto-setup-skill-anchors.test.mjs
@@ -12,12 +12,23 @@ const SNAPSHOT_REFERENCE = join(
   REPO_ROOT,
   "plugins/harness-loom/skills/harness-auto-setup/references/snapshot-provenance.md",
 );
+const FINALIZER_OVERLAY_REFERENCE = join(
+  REPO_ROOT,
+  "plugins/harness-loom/skills/harness-auto-setup/references/finalizer-overlay.md",
+);
 
 test("harness-auto-setup skill points schema details to snapshot provenance reference", () => {
   const body = readFileSync(AUTO_SETUP_SKILL, "utf8");
   assert.ok(existsSync(SNAPSHOT_REFERENCE), "snapshot provenance reference must exist");
+  assert.ok(existsSync(FINALIZER_OVERLAY_REFERENCE), "finalizer overlay reference must exist");
   assert.match(body, /references\/snapshot-provenance\.md/);
+  assert.match(body, /references\/finalizer-overlay\.md/);
   assert.match(body, /If snapshot creation fails, stop before running install or deleting anything\./);
+  assert.match(body, /must continue with LLM project analysis/);
+  assert.match(body, /Ask the user at most three concise questions/);
+  assert.match(body, /Author the actual additional pair\/finalizer configuration rather than stopping at recommendations/);
+  assert.match(body, /Run the auto-setup script; on fresh `--setup` targets it invokes the foundation installer/);
+  assert.match(body, /convergence\.setupAuthoring/);
 });
 
 test("snapshot provenance reference preserves manifest and namespace contract", () => {

--- a/tests/auto-setup.test.mjs
+++ b/tests/auto-setup.test.mjs
@@ -76,46 +76,7 @@ function readAgentBodies(target, slugs) {
   return Object.fromEntries(slugs.map((slug) => [slug, readAgent(target, slug)]));
 }
 
-function assertReconstructedProducerAgent(body, { pair, skill, producer }) {
-  assert.match(body, new RegExp(`^name: ${producer}$`, "m"));
-  assert.match(body, new RegExp(`^skills:\\n  - ${skill}\\n  - harness-context$`, "m"));
-  assert.match(body, new RegExp(`registered \`${pair}\` harness pair`));
-  assert.match(body, /^## Output Format$/m);
-  assert.match(body, /End your response with this structured block:/);
-  assert.match(body, /Status: PASS \/ FAIL/);
-  assert.match(body, /Files created: \[\{file path\}\]/);
-  assert.match(body, /Files modified: \[\{file path\}\]/);
-  assert.match(body, /Diff summary: \{sections changed vs baseline, or "N\/A"\}/);
-  assert.match(body, /Self-verification: \{issues found and resolved during this cycle\}/);
-  assert.match(body, /Blocked or out-of-scope items: \[\{item, reason\}\]/);
-  assert.doesNotMatch(body, /Suggested next-work|Advisory-next|Regression gate|Escalation/);
-  assert.doesNotMatch(body, /Verdict: PASS \/ FAIL/);
-}
-
-function assertReconstructedReviewerAgent(body, { pair, skill, reviewer }) {
-  assert.match(body, new RegExp(`^name: ${reviewer}$`, "m"));
-  assert.match(
-    body,
-    new RegExp(
-      `^description: "Use when \`/harness-orchestrate\` dispatches the \`${pair}\` reviewer turn\\. Read the shared pair skill plus \`harness-context\`, grade the paired producer task, and end with the Reviewer Output Format block\\."$`,
-      "m",
-    ),
-  );
-  assert.match(body, new RegExp(`^skills:\\n  - ${skill}\\n  - harness-context$`, "m"));
-  assert.match(body, new RegExp(`registered \`${pair}\` harness pair`));
-  assert.match(body, /Check contract freshness\. Reason: reconstructed pairs must follow current templates and harness-context law\./);
-  assert.match(body, /Verify the producer used current contracts rather than stale snapshot copies\./);
-  assert.match(body, /^## Output Format$/m);
-  assert.match(body, /End your response with this structured block:/);
-  assert.match(body, /Verdict: PASS \/ FAIL/);
-  assert.match(body, /Criteria: \[\{criterion, result, evidence-citation \(file:line\)\}\]/);
-  assert.match(body, /FAIL items: \[\{item, level \(technical\/creative\/structural\), reason\}\]/);
-  assert.match(body, /Feedback: \{short free-form rationale\}/);
-  assert.doesNotMatch(body, /Suggested next-work|Advisory-next|Regression gate|Escalation/);
-  assert.doesNotMatch(body, /Status: PASS \/ FAIL/);
-}
-
-test("auto-setup fresh target installs foundation and prints explicit sync handoff", () => {
+test("auto-setup fresh target installs foundation and prints explicit sync command", () => {
   const target = makeTempDir();
   try {
     writeFileSync(join(target, "README.md"), "# Demo\n");
@@ -129,21 +90,57 @@ test("auto-setup fresh target installs foundation and prints explicit sync hando
     assert.equal(summary.install.summary.verification.ok, true);
     assert.equal(summary.syncCommand, "node .harness/loom/sync.ts --provider codex");
     assert.deepEqual(summary.providerTreesWritten, []);
-    assert.equal(summary.convergence.pairReconstructions.length, 1);
-    assert.equal(summary.convergence.pairReconstructions[0].status, "authored");
-    assert.equal(summary.convergence.pairReconstructions[0].pair, "harness-document");
-    assert.equal(summary.convergence.finalizerReconstruction.status, "authored");
+    assert.equal(summary.convergence.pairOperations.length, 0);
+    assert.equal(summary.convergence.finalizerOperation.status, "default-noop");
+    assert.equal(summary.convergence.setupAuthoring.required, true);
+    assert.equal(summary.convergence.setupAuthoring.scriptPhaseOnly, true);
+    assert.match(summary.convergence.setupAuthoring.expectedNextWork, /author the initial registered pair roster/);
+    assert.equal(summary.convergence.pairRecommendationDetails[0].pair, null);
+    assert.match(summary.convergence.pairRecommendations[0], /LLM project analysis/);
+    assert.match(summary.convergence.note, /authoring concrete pair\/finalizer configuration/);
+    assert.match(summary.nextAction, /Continue setup by inspecting the project/);
+    assert.match(summary.nextAction, /after that authoring is complete/);
+    assert.match(summary.nextAction, /node \.harness\/loom\/sync\.ts --provider codex/);
     assert.ok(existsSync(join(target, ".harness/loom/sync.ts")));
     assert.ok(existsSync(join(target, ".harness/cycle/state.md")));
-    assert.ok(existsSync(join(target, ".harness/loom/agents/harness-document-producer.md")));
-    assert.match(
-      readFileSync(join(target, ".harness/loom/registry.md"), "utf8"),
-      /^- harness-document:/m,
-    );
+    assert.equal(existsSync(join(target, ".harness/loom/agents/harness-document-producer.md")), false);
+    assert.doesNotMatch(readFileSync(join(target, ".harness/loom/registry.md"), "utf8"), /^- harness-document:/m);
     assert.match(
       readFileSync(join(target, ".harness/loom/agents/harness-finalizer.md"), "utf8"),
-      /Refresh README, docs, or CHANGELOG/,
+      /no cycle-end work registered for this project/,
     );
+    assertNoProviderTrees(target);
+  } finally {
+    cleanupDir(target);
+  }
+});
+
+test("auto-setup requires LLM analysis before fresh pair authoring", () => {
+  const target = makeTempDir();
+  try {
+    writeFileSync(join(target, "README.md"), "# Harness Loom Like\n");
+    mkdirSync(join(target, "plugins/harness-loom/skills/harness-init/scripts"), { recursive: true });
+    mkdirSync(join(target, "plugins/harness-loom/skills/harness-auto-setup"), { recursive: true });
+    mkdirSync(join(target, "plugins/harness-loom/skills/harness-pair-dev/scripts"), { recursive: true });
+    writeFileSync(join(target, "plugins/harness-loom/skills/harness-init/SKILL.md"), "# init\n");
+    writeFileSync(join(target, "plugins/harness-loom/skills/harness-auto-setup/SKILL.md"), "# setup\n");
+    writeFileSync(join(target, "plugins/harness-loom/skills/harness-pair-dev/SKILL.md"), "# pair\n");
+    writeFileSync(join(target, "plugins/harness-loom/skills/harness-init/scripts/sync.ts"), "// sync\n");
+    writeFileSync(join(target, "plugins/harness-loom/skills/harness-pair-dev/scripts/pair-dev.ts"), "// pair\n");
+
+    const { summary } = runAutoSetup(target, ["--setup"]);
+
+    assert.equal(summary.convergence.pairOperations.length, 0);
+    assert.equal(summary.convergence.pairRecommendationDetails.length, 1);
+    assert.match(summary.convergence.setupAuthoring.questionPolicy, /at most three concise questions/);
+    assert.equal(summary.convergence.pairRecommendationDetails[0].pair, null);
+    assert.equal(summary.convergence.pairRecommendationDetails[0].command, null);
+    assert.match(summary.convergence.pairRecommendationDetails[0].rationale, /LLM project analysis/);
+    assert.match(summary.convergence.pairRecommendationDetails[0].rationale, /authoring pair axes/);
+    assert.ok(summary.convergence.pairRecommendationDetails[0].evidence.includes("README.md"));
+    assert.doesNotMatch(summary.convergence.pairRecommendations.join("\n"), /harness-document/);
+    assert.doesNotMatch(summary.convergence.pairRecommendations.join("\n"), /harness-verification/);
+    assert.doesNotMatch(summary.convergence.pairRecommendations.join("\n"), /harness-runtime-contract/);
     assertNoProviderTrees(target);
   } finally {
     cleanupDir(target);
@@ -162,7 +159,7 @@ test("auto-setup rejects unknown flags before writing harness state", () => {
   }
 });
 
-test("auto-setup preserves pre-existing provider trees and only prints sync handoff", () => {
+test("auto-setup on an existing target leaves the foundation and provider trees untouched", () => {
   const target = makeTempDir();
   try {
     installTo(target);
@@ -179,6 +176,8 @@ test("auto-setup preserves pre-existing provider trees and only prints sync hand
     writeFileSync(join(target, ".gemini/skills/harness-stale/SKILL.md"), "STALE GEMINI SKILL\n");
 
     const before = new Map([
+      [".harness/loom", snapshotTree(join(target, ".harness/loom"))],
+      [".harness/cycle", snapshotTree(join(target, ".harness/cycle"))],
       [".claude", snapshotTree(join(target, ".claude"))],
       [".codex", snapshotTree(join(target, ".codex"))],
       [".gemini", snapshotTree(join(target, ".gemini"))],
@@ -188,15 +187,26 @@ test("auto-setup preserves pre-existing provider trees and only prints sync hand
 
     assert.equal(summary.mode, "setup");
     assert.equal(summary.targetState, "existing");
+    assert.equal(summary.snapshot.created, false);
+    assert.equal(summary.install.skipped, true);
+    assert.equal(summary.convergence.mode, "setup-inspection-authoring-required");
+    assert.match(summary.convergence.note, /left the foundation untouched/);
+    assert.equal(summary.convergence.pairOperations.length, 0);
+    assert.equal(summary.convergence.finalizerOperation.status, "skipped");
+    assert.equal(summary.convergence.setupAuthoring.required, true);
+    assert.match(summary.convergence.setupAuthoring.expectedNextWork, /author additive registered pairs/);
+    assert.match(summary.convergence.pairRecommendations[0], /script phase leaves the foundation unchanged/);
+    assert.match(summary.convergence.pairRecommendations[0], /author the needed pair\/finalizer configuration/);
     assert.equal(summary.syncCommand, "node .harness/loom/sync.ts --provider claude,gemini");
-    assert.equal(
-      summary.nextAction,
-      "From the target root, run `node .harness/loom/sync.ts --provider claude,gemini` for any platform trees you want to refresh.",
-    );
+    assert.match(summary.nextAction, /Continue setup by inspecting the project and existing roster/);
+    assert.match(summary.nextAction, /author only additive pair\/finalizer changes/);
+    assert.match(summary.nextAction, /after that authoring is complete/);
+    assert.match(summary.nextAction, /node \.harness\/loom\/sync\.ts --provider claude,gemini/);
     assert.deepEqual(summary.providerTreesWritten, []);
-    for (const platformDir of [".claude", ".codex", ".gemini"]) {
+    for (const platformDir of [".harness/loom", ".harness/cycle", ".claude", ".codex", ".gemini"]) {
       assertTreeUnchanged(before.get(platformDir), join(target, platformDir));
     }
+    assert.ok(!existsSync(join(target, ".harness/_snapshots")));
     assert.ok(!existsSync(join(target, ".claude/agents/harness-planner.md")));
     assert.ok(!existsSync(join(target, ".codex/hooks.json")));
     assert.ok(!existsSync(join(target, ".gemini/agents/harness-planner.md")));
@@ -205,7 +215,72 @@ test("auto-setup preserves pre-existing provider trees and only prints sync hand
   }
 });
 
-test("auto-setup reconstructs registered pair files and registry after refresh", () => {
+test("auto-setup setup mode directs cycle-only targets to migration before sync", () => {
+  const target = makeTempDir();
+  try {
+    installTo(target);
+    rmSync(join(target, ".harness/loom"), { recursive: true, force: true });
+
+    const { summary } = runAutoSetup(target, ["--setup", "--provider", "codex"]);
+
+    assert.equal(summary.mode, "setup");
+    assert.equal(summary.targetState, "existing");
+    assert.equal(summary.snapshot.created, false);
+    assert.equal(summary.install.skipped, true);
+    assert.equal(summary.convergence.mode, "setup-cycle-only-migration-required");
+    assert.match(summary.convergence.note, /\.harness\/cycle without \.harness\/loom/);
+    assert.equal(summary.convergence.setupAuthoring.required, false);
+    assert.equal(summary.convergence.setupAuthoring.blocked, true);
+    assert.match(summary.convergence.setupAuthoring.expectedNextWork, /\/harness-auto-setup --migration --provider codex/);
+    assert.match(summary.convergence.pairRecommendations[0], /without \.harness\/loom/);
+    assert.match(summary.convergence.finalizerRecommendation, /No \.harness\/loom foundation is present/);
+    assert.match(summary.nextAction, /\/harness-auto-setup --migration --provider codex/);
+    assert.doesNotMatch(summary.nextAction, /node \.harness\/loom\/sync\.ts/);
+    assert.equal(existsSync(join(target, ".harness/loom")), false);
+    assertNoProviderTrees(target);
+  } finally {
+    cleanupDir(target);
+  }
+});
+
+test("auto-setup restores non-pair custom loom skills and agents after reseed", () => {
+  const target = makeTempDir();
+  try {
+    installTo(target);
+    mkdirSync(join(target, ".harness/loom/skills/harness-demo"), { recursive: true });
+    mkdirSync(join(target, ".harness/loom/skills/my-playbook"), { recursive: true });
+    writeFileSync(join(target, ".harness/loom/skills/harness-demo/SKILL.md"), "# Demo Pair Skill\n");
+    writeFileSync(join(target, ".harness/loom/skills/my-playbook/SKILL.md"), "# Custom Playbook\n");
+    writeFileSync(join(target, ".harness/loom/agents/harness-demo-producer.md"), "# Demo Producer\n");
+    writeFileSync(join(target, ".harness/loom/agents/harness-demo-reviewer.md"), "# Demo Reviewer\n");
+    writeFileSync(join(target, ".harness/loom/agents/my-helper.md"), "# Custom Helper\n");
+    writeFileSync(
+      join(target, ".harness/loom/registry.md"),
+      [
+        "# Registry",
+        "",
+        "## Registered pairs",
+        "",
+        "- harness-demo: producer `harness-demo-producer` ↔ reviewer `harness-demo-reviewer`, skill `harness-demo`",
+        "",
+      ].join("\n"),
+    );
+
+    const { summary } = runAutoSetup(target, ["--migration"]);
+
+    assert.deepEqual(summary.convergence.restoredCustomEntries.skills, ["my-playbook"]);
+    assert.deepEqual(summary.convergence.restoredCustomEntries.agents, ["my-helper.md"]);
+    assert.deepEqual(summary.convergence.restoredCustomEntries.skipped, []);
+    assert.match(readFileSync(join(target, ".harness/loom/skills/my-playbook/SKILL.md"), "utf8"), /Custom Playbook/);
+    assert.match(readFileSync(join(target, ".harness/loom/agents/my-helper.md"), "utf8"), /Custom Helper/);
+    assert.equal(summary.convergence.pairOperations[0].pair, "harness-demo");
+    assertNoProviderTrees(target);
+  } finally {
+    cleanupDir(target);
+  }
+});
+
+test("auto-setup setup mode preserves registered pairs before additive authoring", () => {
   const target = makeTempDir();
   try {
     installTo(target);
@@ -222,9 +297,13 @@ test("auto-setup reconstructs registered pair files and registry after refresh",
       "",
       "Own custom demo release packaging.",
       "",
-      "## Methodology",
+      "## Approach",
       "",
       "Keep custom build scripts and fixture snapshots aligned.",
+      "",
+      "## Rollout Plan",
+      "",
+      "Preserve fixture promotion steps.",
       "",
       "## Evaluation Criteria",
       "",
@@ -261,44 +340,26 @@ test("auto-setup reconstructs registered pair files and registry after refresh",
       ].join("\n"),
     );
 
+    const loomBefore = snapshotTree(join(target, ".harness/loom"));
+    const cycleBefore = snapshotTree(join(target, ".harness/cycle"));
     const { summary } = runAutoSetup(target, ["--setup"]);
-    const manifest = readJson(summary.snapshot.manifestPath);
 
     assert.equal(summary.mode, "setup");
     assert.equal(summary.targetState, "existing");
-    assert.equal(summary.snapshot.created, true);
-    assert.deepEqual(summary.snapshot.copiedNamespaces, [".harness/cycle", ".harness/loom"]);
-    assertManifestShape(manifest);
-    assert.equal(manifest.registrySummary.pairCount, 1);
-    assert.equal(manifest.registrySummary.pairs[0].pair, "harness-demo");
-    assert.equal(manifest.activeCycle.classification, "pristine");
-    assert.ok(existsSync(join(summary.snapshot.path, "loom/skills/harness-demo/SKILL.md")));
-    assert.ok(existsSync(join(summary.snapshot.path, "cycle/state.md")));
+    assert.equal(summary.snapshot.created, false);
+    assert.equal(summary.install.skipped, true);
+    assert.equal(summary.convergence.mode, "setup-inspection-authoring-required");
+    assert.equal(summary.convergence.pairOperations.length, 0);
+    assert.equal(summary.convergence.finalizerOperation.status, "skipped");
+    assert.match(summary.convergence.setupAuthoring.stopCondition, /Stop without authoring only/);
+    assert.match(summary.convergence.pairRecommendationDetails[0].rationale, /script phase leaves them unchanged/);
+    assert.match(summary.convergence.pairRecommendationDetails[0].rationale, /author only additive pair\/finalizer changes/);
+    assert.match(summary.convergence.pairRecommendationDetails[0].rationale, /Use --migration/);
+    assertTreeUnchanged(loomBefore, join(target, ".harness/loom"));
+    assertTreeUnchanged(cycleBefore, join(target, ".harness/cycle"));
 
-    assert.equal(summary.convergence.pairReconstructions[0].status, "reconstructed");
-    assert.deepEqual(summary.convergence.pairReconstructions[0].reviewers, [
-      "harness-demo-reviewer",
-      "harness-demo-security-reviewer",
-    ]);
     const currentSkill = readFileSync(join(target, ".harness/loom/skills/harness-demo/SKILL.md"), "utf8");
-    assert.notEqual(currentSkill, oldSkill);
-    assert.match(currentSkill, /name: harness-demo/);
-    assert.match(currentSkill, /### Preserved Snapshot Intent/);
-    assert.match(currentSkill, /custom build scripts/);
-    assert.match(currentSkill, /Current project files and tests are cited/);
-
-    assertReconstructedProducerAgent(readAgent(target, "harness-demo-producer"), {
-      pair: "harness-demo",
-      skill: "harness-demo",
-      producer: "harness-demo-producer",
-    });
-    for (const reviewer of ["harness-demo-reviewer", "harness-demo-security-reviewer"]) {
-      assertReconstructedReviewerAgent(readAgent(target, reviewer), {
-        pair: "harness-demo",
-        skill: "harness-demo",
-        reviewer,
-      });
-    }
+    assert.equal(currentSkill, oldSkill);
 
     const registry = readFileSync(join(target, ".harness/loom/registry.md"), "utf8");
     assert.match(
@@ -306,6 +367,7 @@ test("auto-setup reconstructs registered pair files and registry after refresh",
       /- harness-demo: producer `harness-demo-producer` ↔ reviewers \[`harness-demo-reviewer`, `harness-demo-security-reviewer`\], skill `harness-demo`/,
     );
     assert.equal(registry.match(/^- harness-demo:/gm).length, 1);
+    assert.ok(!existsSync(join(target, ".harness/_snapshots")));
     assertNoProviderTrees(target);
   } finally {
     cleanupDir(target);
@@ -329,9 +391,13 @@ test("auto-setup migration preserves custom pair and finalizer bodies while refr
       "",
       "Own custom demo release packaging.",
       "",
-      "## Methodology",
+      "## Approach",
       "",
       "Keep custom build scripts and fixture snapshots aligned.",
+      "",
+      "## Rollout Plan",
+      "",
+      "Preserve fixture promotion steps.",
       "",
       "## Evaluation Criteria",
       "",
@@ -368,6 +434,15 @@ test("auto-setup migration preserves custom pair and finalizer bodies while refr
         "",
         "1. Maintain custom build scripts.",
         "",
+        "## Rollout Plan",
+        "",
+        "Keep demo release packaging sequenced.",
+        "",
+        "```markdown",
+        "## Output Format",
+        "fenced producer example should survive",
+        "```",
+        "",
         "## Output Format",
         "",
         "Status: PASS / FAIL",
@@ -398,6 +473,10 @@ test("auto-setup migration preserves custom pair and finalizer bodies while refr
         "",
         "1. Audit fixture snapshots.",
         "",
+        "## Review Notes",
+        "",
+        "Escalate packaging drift.",
+        "",
       ].join("\n"),
     );
     writeFileSync(
@@ -421,6 +500,20 @@ test("auto-setup migration preserves custom pair and finalizer bodies while refr
         "",
         "1. Refresh docs/ and CHANGELOG.md after verified release work.",
         "",
+        "## Output Format",
+        "",
+        "Status: PASS / FAIL",
+        "Summary: stale finalizer block",
+        "",
+        "```markdown",
+        "## Structural Issue",
+        "- legacy fenced example",
+        "```",
+        "",
+        "## Release Checklist",
+        "",
+        "Keep release notes and docs aligned.",
+        "",
       ].join("\n"),
     );
     writeFileSync(
@@ -439,29 +532,52 @@ test("auto-setup migration preserves custom pair and finalizer bodies while refr
 
     assert.equal(summary.mode, "migration");
     assert.equal(summary.targetState, "existing");
-    assert.equal(summary.convergence.pairReconstructions[0].status, "migrated");
-    assert.equal(summary.convergence.pairReconstructions[0].source.kind, "snapshot");
-    assert.match(summary.convergence.pairReconstructions[0].replaced.join("\n"), /frontmatter skills/);
+    assert.equal(summary.convergence.pairOperations[0].status, "migrated");
+    assert.equal(summary.convergence.setupAuthoring, null);
+    assert.equal(summary.convergence.pairOperations[0].source.kind, "snapshot");
+    assert.match(summary.convergence.pairOperations[0].replaced.join("\n"), /frontmatter skills/);
+    assert.doesNotMatch(
+      summary.convergence.pairOperations[0].replaced.join("\n"),
+      /current runtime trigger descriptions/,
+    );
+    assert.equal(summary.convergence.migrationPlan.pairs[0].pair, "harness-demo");
+    assert.match(summary.convergence.migrationPlan.pairs[0].overlayMethodology, /from-overlay\.md/);
+    assert.ok(summary.convergence.migrationPlan.pairs[0].userSurfaces.includes("skill:Approach"));
+    assert.ok(summary.convergence.migrationPlan.pairs[0].userSurfaces.includes("skill:Rollout Plan"));
+    assert.match(summary.convergence.migrationPlan.finalizer.overlayMethodology, /finalizer-overlay\.md/);
     const currentSkill = readFileSync(join(target, ".harness/loom/skills/harness-demo/SKILL.md"), "utf8");
     assert.match(currentSkill, /Own custom demo release packaging/);
+    assert.match(currentSkill, /## Approach/);
     assert.match(currentSkill, /Keep custom build scripts and fixture snapshots aligned/);
+    assert.match(currentSkill, /## Rollout Plan/);
+    assert.match(currentSkill, /Preserve fixture promotion steps/);
     assert.doesNotMatch(currentSkill, /### Preserved Snapshot Intent/);
 
     const currentProducer = readFileSync(join(target, ".harness/loom/agents/harness-demo-producer.md"), "utf8");
     assert.match(currentProducer, /Producer identity that should survive migration/);
     assert.match(currentProducer, /1\. Maintain custom build scripts\./);
+    assert.match(currentProducer, /## Rollout Plan/);
+    assert.match(currentProducer, /Keep demo release packaging sequenced/);
+    assert.match(currentProducer, /fenced producer example should survive/);
     assert.match(currentProducer, /^skills:\n  - harness-demo\n  - harness-context\n  - demo-domain$/m);
     assert.match(currentProducer, /^Status: PASS \/ FAIL$/m);
+    assert.doesNotMatch(currentProducer, /Summary: legacy block/);
 
     const currentReviewer = readFileSync(join(target, ".harness/loom/agents/harness-demo-reviewer.md"), "utf8");
     assert.match(currentReviewer, /Reviewer identity that should survive migration/);
     assert.match(currentReviewer, /1\. Audit fixture snapshots\./);
+    assert.match(currentReviewer, /## Review Notes/);
+    assert.match(currentReviewer, /Escalate packaging drift/);
     assert.match(currentReviewer, /^Verdict: PASS \/ FAIL$/m);
 
-    assert.equal(summary.convergence.finalizerReconstruction.status, "migrated");
+    assert.equal(summary.convergence.finalizerOperation.status, "migrated");
     const currentFinalizer = readFileSync(join(target, ".harness/loom/agents/harness-finalizer.md"), "utf8");
     assert.match(currentFinalizer, /Finalizer intro that should survive migration/);
     assert.match(currentFinalizer, /Refresh docs\/ and CHANGELOG\.md after verified release work/);
+    assert.match(currentFinalizer, /## Release Checklist/);
+    assert.match(currentFinalizer, /Keep release notes and docs aligned/);
+    assert.doesNotMatch(currentFinalizer, /Summary: stale finalizer block/);
+    assert.doesNotMatch(currentFinalizer, /legacy fenced example/);
     assert.match(currentFinalizer, /^Status: PASS \/ FAIL$/m);
     assert.match(currentFinalizer, /## Structural Issue/);
     assertNoProviderTrees(target);
@@ -1110,7 +1226,7 @@ test("auto-setup migration rejects a fresh target", () => {
   }
 });
 
-test("auto-setup skips registry pairs that reuse foundation slugs before reconstruction writes", () => {
+test("auto-setup skips registry pairs that reuse foundation slugs before migration writes", () => {
   const target = makeTempDir();
   try {
     installTo(target);
@@ -1128,12 +1244,12 @@ test("auto-setup skips registry pairs that reuse foundation slugs before reconst
       ].join("\n"),
     );
 
-    const { summary } = runAutoSetup(target);
+    const { summary } = runAutoSetup(target, ["--migration"]);
 
-    assert.equal(summary.convergence.pairReconstructions.length, 1);
-    assert.equal(summary.convergence.pairReconstructions[0].status, "skipped");
+    assert.equal(summary.convergence.pairOperations.length, 1);
+    assert.equal(summary.convergence.pairOperations[0].status, "skipped");
     assert.match(
-      summary.convergence.pairReconstructions[0].reason,
+      summary.convergence.pairOperations[0].reason,
       /producer slug is reserved for a foundation or singleton role: harness-planner/,
     );
     assert.equal(
@@ -1153,7 +1269,7 @@ test("auto-setup skips registry pairs that reuse foundation slugs before reconst
   }
 });
 
-test("auto-setup skips registry pairs with shared or colliding reconstruction artifacts", () => {
+test("auto-setup skips registry pairs with shared or colliding migration artifacts", () => {
   const target = makeTempDir();
   try {
     installTo(target);
@@ -1171,12 +1287,12 @@ test("auto-setup skips registry pairs with shared or colliding reconstruction ar
       ].join("\n"),
     );
 
-    const { summary } = runAutoSetup(target);
+    const { summary } = runAutoSetup(target, ["--migration"]);
     const byPair = Object.fromEntries(
-      summary.convergence.pairReconstructions.map((reconstruction) => [reconstruction.pair, reconstruction]),
+      summary.convergence.pairOperations.map((operation) => [operation.pair, operation]),
     );
 
-    assert.equal(summary.convergence.pairReconstructions.length, 3);
+    assert.equal(summary.convergence.pairOperations.length, 3);
     assert.equal(byPair["harness-alpha"].status, "skipped");
     assert.equal(byPair["harness-beta"].status, "skipped");
     assert.equal(byPair["harness-collision"].status, "skipped");
@@ -1199,67 +1315,54 @@ test("auto-setup skips registry pairs with shared or colliding reconstruction ar
   }
 });
 
-test("auto-setup reconstructs customized finalizer on current skeleton", () => {
+test("auto-setup setup mode leaves customized finalizer unchanged", () => {
   const target = makeTempDir();
   try {
     installTo(target);
+    const customFinalizer = [
+      "---",
+      "name: harness-finalizer",
+      "skills:",
+      "  - harness-context",
+      "---",
+      "",
+      "# Finalizer",
+      "",
+      "## Task",
+      "",
+      "1. Refresh docs/ and CHANGELOG.md after verified release work.",
+      "",
+      "## Output Format",
+      "",
+      "Status: PASS / FAIL",
+      "Summary: release docs refreshed",
+      "Self-verification: docs and changelog checked",
+      "",
+    ].join("\n");
     writeFileSync(
       join(target, ".harness/loom/agents/harness-finalizer.md"),
-      [
-        "---",
-        "name: harness-finalizer",
-        "skills:",
-        "  - harness-context",
-        "---",
-        "",
-        "# Finalizer",
-        "",
-        "## Task",
-        "",
-        "1. Refresh docs/ and CHANGELOG.md after verified release work.",
-        "",
-        "## Output Format",
-        "",
-        "Status: PASS / FAIL",
-        "Summary: release docs refreshed",
-        "Self-verification: docs and changelog checked",
-        "",
-      ].join("\n"),
+      customFinalizer,
     );
 
-    const { summary } = runAutoSetup(target);
-    const manifest = readJson(summary.snapshot.manifestPath);
+    const { summary } = runAutoSetup(target, ["--setup"]);
 
     assert.equal(summary.finalizerSummary.status, "customized");
     assert.equal(summary.finalizerSummary.customized, true);
     assert.ok(summary.finalizerSummary.signals.includes("docs"));
-    assert.equal(manifest.finalizerSummary.status, "customized");
-    assert.match(manifest.finalizerSummary.recommendation, /snapshot finalizer as intent evidence/);
-    assert.match(readFileSync(join(summary.snapshot.path, "loom/agents/harness-finalizer.md"), "utf8"), /CHANGELOG/);
-
-    assert.equal(summary.convergence.finalizerReconstruction.status, "reconstructed");
+    assert.equal(summary.snapshot.created, false);
+    assert.equal(summary.install.skipped, true);
+    assert.equal(summary.convergence.finalizerOperation.status, "skipped");
+    assert.match(summary.convergence.finalizerRecommendation, /left unchanged/);
     const currentFinalizer = readFileSync(join(target, ".harness/loom/agents/harness-finalizer.md"), "utf8");
-    assert.match(currentFinalizer, /The finalizer is a \*\*singleton cycle-end role\*\*/);
-    assert.match(currentFinalizer, /### Preserved Intent Evidence/);
-    assert.match(currentFinalizer, /CHANGELOG/);
-    assert.match(currentFinalizer, /Files left alone \(intentionally\)/);
-    assert.match(currentFinalizer, /Status: PASS \/ FAIL/);
-    assert.match(currentFinalizer, /Self-verification:/);
-    assert.match(currentFinalizer, /Blocked or out-of-scope items: \[\{item, reason\}\]/);
-    assert.match(currentFinalizer, /## Structural Issue/);
-    assert.match(currentFinalizer, /Suspected upstream stage:\s*planner/i);
-    assert.doesNotMatch(currentFinalizer, /^(Suggested next-work|Advisory-next|Regression gate|Escalation):/m);
-    assert.doesNotMatch(currentFinalizer, /^Verdict: PASS \/ FAIL$/m);
-    assert.doesNotMatch(currentFinalizer, /^Criteria:/m);
-    assert.doesNotMatch(currentFinalizer, /^FAIL items:/m);
-    assert.doesNotMatch(currentFinalizer, /Summary: release docs refreshed/);
+    assert.equal(currentFinalizer, customFinalizer);
+    assert.ok(!existsSync(join(target, ".harness/_snapshots")));
     assertNoProviderTrees(target);
   } finally {
     cleanupDir(target);
   }
 });
 
-test("auto-setup rerun allocates a new snapshot and keeps reconstructed pair idempotent", () => {
+test("auto-setup migration rerun allocates a new snapshot and keeps migrated pair idempotent", () => {
   const target = makeTempDir();
   try {
     installTo(target);
@@ -1301,7 +1404,7 @@ test("auto-setup rerun allocates a new snapshot and keeps reconstructed pair ide
       ].join("\n"),
     );
 
-    const first = runAutoSetup(target).summary;
+    const first = runAutoSetup(target, ["--migration"]).summary;
     const skillAfterFirst = readFileSync(join(target, ".harness/loom/skills/harness-demo/SKILL.md"), "utf8");
     const agentBodiesAfterFirst = readAgentBodies(target, [
       "harness-demo-producer",
@@ -1309,7 +1412,7 @@ test("auto-setup rerun allocates a new snapshot and keeps reconstructed pair ide
     ]);
     const registryAfterFirst = readFileSync(join(target, ".harness/loom/registry.md"), "utf8");
 
-    const second = runAutoSetup(target).summary;
+    const second = runAutoSetup(target, ["--migration"]).summary;
     const skillAfterSecond = readFileSync(join(target, ".harness/loom/skills/harness-demo/SKILL.md"), "utf8");
     const agentBodiesAfterSecond = readAgentBodies(target, [
       "harness-demo-producer",
@@ -1322,16 +1425,20 @@ test("auto-setup rerun allocates a new snapshot and keeps reconstructed pair ide
     assert.ok(existsSync(second.snapshot.path));
     assert.equal(skillAfterSecond, skillAfterFirst);
     assert.deepEqual(agentBodiesAfterSecond, agentBodiesAfterFirst);
-    assertReconstructedProducerAgent(agentBodiesAfterSecond["harness-demo-producer"], {
-      pair: "harness-demo",
-      skill: "harness-demo",
-      producer: "harness-demo-producer",
-    });
-    assertReconstructedReviewerAgent(agentBodiesAfterSecond["harness-demo-reviewer"], {
-      pair: "harness-demo",
-      skill: "harness-demo",
-      reviewer: "harness-demo-reviewer",
-    });
+    assert.match(
+      agentBodiesAfterSecond["harness-demo-producer"],
+      /^skills:\n  - harness-demo\n  - harness-context$/m,
+    );
+    assert.match(agentBodiesAfterSecond["harness-demo-producer"], /1\. Produce demo workflow changes\./);
+    assert.match(agentBodiesAfterSecond["harness-demo-producer"], /^## Output Format$/m);
+    assert.match(agentBodiesAfterSecond["harness-demo-producer"], /Status: PASS \/ FAIL/);
+    assert.match(
+      agentBodiesAfterSecond["harness-demo-reviewer"],
+      /^skills:\n  - harness-demo\n  - harness-context$/m,
+    );
+    assert.match(agentBodiesAfterSecond["harness-demo-reviewer"], /1\. Review demo workflow changes\./);
+    assert.match(agentBodiesAfterSecond["harness-demo-reviewer"], /^## Output Format$/m);
+    assert.match(agentBodiesAfterSecond["harness-demo-reviewer"], /Verdict: PASS \/ FAIL/);
     assert.equal(registryAfterSecond, registryAfterFirst);
     assert.equal(registryAfterSecond.match(/^- harness-demo:/gm).length, 1);
     assertNoProviderTrees(target);
@@ -1348,7 +1455,7 @@ test("auto-setup warns and snapshots active cycle before discard and reseed", ()
     const activeState = readFileSync(statePath, "utf8").replace("loop: false", "loop: true");
     writeFileSync(statePath, `<!-- active-cycle-sentinel -->\n${activeState}`);
 
-    const { result, summary } = runAutoSetup(target);
+    const { result, summary } = runAutoSetup(target, ["--migration"]);
     const manifest = readJson(summary.snapshot.manifestPath);
 
     assert.match(result.stderr, /warning .*Existing cycle classified as active/);
@@ -1375,7 +1482,7 @@ test("auto-setup warns and preserves unknown cycle before discard and reseed", (
     writeFileSync(join(cycleDir, "unknown-cycle-sentinel.txt"), "preserve me\n");
     rmSync(statePath);
 
-    const { result, summary } = runAutoSetup(target);
+    const { result, summary } = runAutoSetup(target, ["--migration"]);
     const manifest = readJson(summary.snapshot.manifestPath);
 
     assert.match(result.stderr, /warning .*Existing cycle classified as unknown/);


### PR DESCRIPTION
## Summary

- Split `/harness-auto-setup --setup` into a deterministic script phase plus required assistant-side project analysis/authoring, so setup no longer creates stock docs/tests pairs from coarse repo signals.
- Keep existing-target `--setup` additive and non-destructive: no snapshot, foundation refresh, pair reconstruction, cycle reseed, or provider sync.
- Make `--migration` own existing foundation refresh, restore non-pair custom loom entries, preserve compatible custom H2 sections, emit `convergence.migrationPlan`, and add a finalizer overlay reference.
- Bump plugin/repo release metadata and README status to `0.3.2`.

## Design Notes

This resolves the issue goals through a narrower design than the original proposals: setup is project-shaped authoring after repo/user analysis, while migration remains the deterministic foundation-refresh path. For the migration overlay issue, the root bug was silent loss of renamed/custom sections; this PR fixes that by preserving compatible body surfaces and making the source/target overlay explicit without moving all migration writes into a separate LLM-only phase.

## Linked Issues

- Resolves for `v0.3.2`: #26
- Resolves for `v0.3.2`: #27
- Resolves for `v0.3.2`: #30

Note: this PR targets `milestone/v0.3.2`, not the default branch, so GitHub may not populate automatic `closingIssuesReferences` until the milestone branch is merged/released. The issue threads are linked back to this PR explicitly.

## Validation

- `node --test`
- `git diff --check HEAD~1 HEAD`