### PR TITLE
Release v0.3.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Weave Producer-Reviewer agent harnesses with auto-execution hooks and self-improving skill loops.",
-    "version": "0.3.2"
+    "version": "0.3.3"
   },
   "plugins": [
     {
       "name": "harness-loom",
       "source": "./plugins/harness-loom",
       "description": "Producer-Reviewer harness generator for Claude Code, Codex CLI, and Gemini CLI.",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "tags": ["harness", "agent-team", "producer-reviewer", "orchestration", "multi-platform"],
       "category": "productivity"
     }

--- a/plugins/harness-loom/.claude-plugin/plugin.json
+++ b/plugins/harness-loom/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "harness-loom",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Seed a planner + producer-reviewer pair harness into any repository, then grow it pair by pair.",
   "author": {
     "name": "KingGyuSuh",

--- a/plugins/harness-loom/.codex-plugin/plugin.json
+++ b/plugins/harness-loom/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "harness-loom",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Install and grow producer-reviewer harnesses for repository work.",
   "author": {
     "name": "KingGyuSuh",

--- a/plugins/harness-loom/skills/harness-goal-interview/SKILL.md
+++ b/plugins/harness-loom/skills/harness-goal-interview/SKILL.md
@@ -107,11 +107,13 @@ When a file already exists at the target path, show a diff-style summary and req
 
 ### 6. Write and hand off
 
-Write the final body to the chosen path and stop. End the turn with the exact next command the user should run:
+Write the final body to the chosen path and stop. End the turn with the exact next command the user should run, substituting the path you actually wrote:
 
 ```bash
-/harness-orchestrate ./goal-notification-center.md
+/harness-orchestrate ./<the-file-you-just-wrote>.md
 ```
+
+For example, after writing `./goal-notification-center.md`, the line reads `/harness-orchestrate ./goal-notification-center.md`. Do not echo that example filename when the file you wrote was named something else.
 
 Do not invoke `/harness-orchestrate` automatically. The harness cycle is a separate decision point — the user may want to review the file, `git add` it, or have a teammate look at it first.
 

--- a/plugins/harness-loom/skills/harness-goal-interview/SKILL.md
+++ b/plugins/harness-loom/skills/harness-goal-interview/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: harness-goal-interview
+description: "Use when `/harness-goal-interview` is invoked to produce a harness-ready goal markdown file at the target project root. Runs a full user interview focused on requirements precision and user-side technical decisions, then writes the five canonical sections (Why / Goal / Constraints / Out of scope / Completion criteria) that `/harness-orchestrate <file.md>` will consume as the original user request."
+argument-hint: "[--out <path>]"
+user-invocable: true
+---
+
+# harness-goal-interview
+
+## Design Thinking
+
+`harness-goal-interview` is the front door for a harness cycle. `/harness-orchestrate <file.md>` treats the trimmed body of that file as the original user request and anchors every downstream dispatch envelope to it (see `harness-orchestrate` `§Request-anchored entry`). The quality of that file sets the ceiling for every EPIC, task, and review that follows.
+
+The goal file is a **goal**, not a plan. Planner and producer-reviewer pairs own file paths, implementation strategy, and test shape. This skill's output must not leak that territory. Instead, it elicits two things only the user can supply:
+
+1. **Requirements precision** — who this is for, what behavior or outcome is expected, what success looks like, what is intentionally excluded.
+2. **User-side technical decisions** — choices the planner must not make unilaterally: scope boundaries, axis trade-offs (e.g., build vs. integrate, sync vs. async, strict vs. permissive), acceptance signals, release gating.
+
+Everything else (file layout, function names, library picks that follow from repo evidence) belongs in planner and producer turns, not in the goal file.
+
+The skill always writes to the **target project root** so the user can invoke `/harness-orchestrate ./<file>.md` directly. It does not touch `.harness/loom/` or `.harness/cycle/`; those are orchestrator territory.
+
+## Methodology
+
+### 1. Arguments
+
+`/harness-goal-interview [--out <path>]`
+
+No positional topic. The interview itself elicits the topic as its first move. `--out` is optional; when omitted, pick the filename during the interview once the goal's shape is clear. Resolve `--out` relative to the current working directory (target project root) and reject anything under `.harness/`, `.claude/`, `.codex/`, `.gemini/`, or outside the project root.
+
+### 2. Read before asking
+
+Before the first question, read available repo signals so the interview does not ask what the repo already answers:
+
+- `README.md`, `AGENTS.md` / `CLAUDE.md`, top-level pointer docs
+- `.harness/loom/registry.md` and `.harness/loom/agents/harness-finalizer.md` when present (pair roster + cycle-end duty)
+- last few commits, active branches, `.harness/cycle/state.md` when present (what the harness is currently chewing on)
+
+The goal interview is not a codebase audit. Skim only enough to avoid duplicate or contradictory goals and to ground follow-ups in real context.
+
+### 3. Interview axes
+
+Drive the interview along these axes, in roughly this order. Stop an axis the moment you have a citable answer; do not pad with filler.
+
+1. **Topic and motivation** — what the user wants to accomplish, and *why now*. Reject vague topics ("improve the app") by pushing on the triggering event or pain.
+2. **Users / consumers** — who benefits, and what their current friction or expectation is. Skip if the answer is trivially "the developer".
+3. **Expected behavior or outcome** — the externally visible change. Prefer user-observable verbs ("user can...", "job emits...", "build rejects...") over implementation verbs.
+4. **Boundaries** — hard constraints (compatibility, performance, budgets, deadlines, compliance) and explicit non-goals. Probe for non-goals actively; users tend to under-specify them.
+5. **User-side technical decisions** — only surface axes the planner cannot resolve from repo evidence. Frame each as a choice with named options and brief trade-offs. Skip this section entirely when no such axis exists; do not invent decisions to look thorough.
+6. **Completion signals** — how the user will recognize "done". Prefer observable signals (artifact present, behavior verifiable, metric threshold) over process signals ("PR merged").
+
+Ask one axis per turn unless several are tightly coupled. When an answer is sufficient, move on; do not re-ask for polish.
+
+### 4. What not to ask
+
+- File paths, class names, module layout, refactor strategy.
+- Specific library picks that follow from existing repo conventions.
+- Task ordering, EPIC shape, review checklist design.
+- Test file locations, CI wiring details.
+
+These belong to planner and producer-reviewer turns. If the user volunteers such detail, capture it as a constraint only if it is load-bearing; otherwise note it aside and do not write it into the goal file.
+
+### 5. Assemble and confirm
+
+Once the axes above are covered, draft the goal file using `references/output-template.md`. The five sections are mandatory in this order: `## Why`, `## Goal`, `## Constraints`, `## Out of scope`, `## Completion criteria`. The top-level `# <title>` summarizes the goal in one line.
+
+Show the draft inline, then ask the user for a final confirmation or edits before writing. Resolve the filename at this point:
+
+- if `--out` was supplied, use it verbatim
+- otherwise propose `goal-<slug>.md` at the project root where `<slug>` is a short kebab-case derivation of the goal title; confirm with the user before writing
+
+If a file already exists at the target path, show a diff-style summary and require explicit user confirmation to overwrite.
+
+### 6. Write and hand off
+
+Write the final body to the chosen path and stop. Do not invoke `/harness-orchestrate` automatically. End the turn with the exact next command the user should run from the target root, e.g.:
+
+```bash
+/harness-orchestrate ./goal-notification-center.md
+```
+
+### 7. Re-run and revision
+
+Re-invoking the skill with the same `--out` path is a revision request: read the existing file, incorporate the user's new input as amendments, and ask before overwriting. Never silently mutate a previously authored goal file.
+
+## Evaluation Criteria
+
+- Output file contains exactly the five sections in canonical order under a concise title; no planner/producer-level detail leaks into any section.
+- Every section is grounded in user answers or cited repo evidence; no filler such as "TBD" or "to be decided during implementation".
+- `## Out of scope` is explicit, not absent; at least one non-goal is present unless the user explicitly declined.
+- `## Completion criteria` is observable (user-visible behavior, artifact presence, metric threshold), not process-based.
+- User-side technical decisions are recorded as resolved choices with a brief rationale when they came up; unresolved axes are named as explicit decisions deferred to the user, not silently dropped.
+- File is written to the target project root (or an `--out` path inside the project root) with a user-confirmed filename; overwrite of an existing file required explicit confirmation.
+- The skill stops after writing and prints the exact `/harness-orchestrate` invocation for the new file.
+
+## Taboos
+
+- Name files, functions, modules, or tests in the goal body. That is planner/producer territory.
+- Prescribe task ordering, EPIC structure, review axes, or CI steps.
+- Ask the user implementation-level questions such as "which directory should this live in?" or "should we use library X or Y?" when the answer follows from repo conventions.
+- Fabricate constraints or completion criteria when the user did not supply them; prefer asking or leaving the section thin but honest.
+- Write the file under `.harness/loom/`, `.harness/cycle/`, `.claude/`, `.codex/`, `.gemini/`, or outside the target project root.
+- Invoke `/harness-orchestrate`, `node .harness/loom/sync.ts`, or edit the pair registry as part of this skill.
+- Silently overwrite an existing goal file.
+- Pack multiple unrelated goals into a single file. One request-anchor file per cycle.
+
+## References
+
+- `references/output-template.md` — canonical five-section skeleton and per-section guidance
+- `references/interview-axes.md` — prompts and probes per axis, and what to push back on
+- `../harness-init/references/runtime/harness-orchestrate/SKILL.template.md` — `§Request-anchored entry`, the contract this skill's output must satisfy
+- `../harness-init/references/runtime/harness-planning/SKILL.template.md` — planner's EPIC decomposition rubric (consumer of this output)

--- a/plugins/harness-loom/skills/harness-goal-interview/SKILL.md
+++ b/plugins/harness-loom/skills/harness-goal-interview/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: harness-goal-interview
-description: "Use when `/harness-goal-interview` is invoked to produce a harness-ready goal markdown file at the target project root. Runs a full user interview focused on requirements precision and user-side technical decisions, then writes the five canonical sections (Why / Goal / Constraints / Out of scope / Completion criteria) that `/harness-orchestrate <file.md>` will consume as the original user request."
+description: "Produces the goal markdown that `/harness-orchestrate` consumes as the original user request. Use when `/harness-goal-interview` is invoked, when the user wants to start a harness cycle on a new feature or initiative, when they ask to 'write down what we're trying to do' before running the harness, when they need to articulate requirements precisely, or when an earlier `/harness-orchestrate` invocation failed because the goal file was vague or plan-shaped. Runs a full user interview focused on requirements precision and user-side technical decisions — implementation detail is the planner's and producer pairs' job, not the goal file's — then writes the five canonical sections (Why / Goal / Constraints / Out of scope / Completion criteria) to the target project root. Use this skill whenever the user is about to hand a goal file to `/harness-orchestrate`, even if they don't explicitly ask for a 'goal interview'; a ten-minute structured elicitation up front pays back across every EPIC, task, and review the cycle produces."
 argument-hint: "[--out <path>]"
 user-invocable: true
 ---
@@ -9,16 +9,21 @@ user-invocable: true
 
 ## Design Thinking
 
-`harness-goal-interview` is the front door for a harness cycle. `/harness-orchestrate <file.md>` treats the trimmed body of that file as the original user request and anchors every downstream dispatch envelope to it (see `harness-orchestrate` `§Request-anchored entry`). The quality of that file sets the ceiling for every EPIC, task, and review that follows.
+`/harness-orchestrate <file.md>` treats the trimmed body of its argument file as the original user request and anchors every downstream dispatch envelope to it (see `harness-orchestrate` `§Request-anchored entry`). The quality of that file sets the ceiling for every EPIC, task, and review the harness produces.
 
-The goal file is a **goal**, not a plan. Planner and producer-reviewer pairs own file paths, implementation strategy, and test shape. This skill's output must not leak that territory. Instead, it elicits two things only the user can supply:
+This skill exists because users tend to either under-specify goals ("fix the auth stuff") or over-specify them into plans ("add `refreshToken()` to `AuthService` in `src/auth/service.ts`"). Both cripple the planner:
+
+- **Under-specified** — the planner fabricates motivation and scope, and the resulting cycle reflects the planner's guesses more than the user's intent.
+- **Over-specified** — the file crowds out *why* and *what* with premature *how*, so EPICs become transcriptions of pre-decided implementation steps instead of outcome decompositions.
+
+The interview elicits exactly the two things the planner cannot supply on its own:
 
 1. **Requirements precision** — who this is for, what behavior or outcome is expected, what success looks like, what is intentionally excluded.
-2. **User-side technical decisions** — choices the planner must not make unilaterally: scope boundaries, axis trade-offs (e.g., build vs. integrate, sync vs. async, strict vs. permissive), acceptance signals, release gating.
+2. **User-side technical decisions** — choices the planner must not make unilaterally: scope boundaries, axis trade-offs, acceptance signals, release gating.
 
-Everything else (file layout, function names, library picks that follow from repo evidence) belongs in planner and producer turns, not in the goal file.
+Everything else — file layout, function names, library picks that follow from repo evidence, task ordering, EPIC shape, review axes — belongs to planner and producer turns. Leaving those decisions to the harness is a feature of the design, not a gap in the goal file.
 
-The skill always writes to the **target project root** so the user can invoke `/harness-orchestrate ./<file>.md` directly. It does not touch `.harness/loom/` or `.harness/cycle/`; those are orchestrator territory.
+Files always land at the **target project root** so the user can run `/harness-orchestrate ./<file>.md` directly. The skill does not touch `.harness/loom/` or `.harness/cycle/`; those are orchestrator territory.
 
 ## Methodology
 
@@ -26,87 +31,144 @@ The skill always writes to the **target project root** so the user can invoke `/
 
 `/harness-goal-interview [--out <path>]`
 
-No positional topic. The interview itself elicits the topic as its first move. `--out` is optional; when omitted, pick the filename during the interview once the goal's shape is clear. Resolve `--out` relative to the current working directory (target project root) and reject anything under `.harness/`, `.claude/`, `.codex/`, `.gemini/`, or outside the project root.
+No positional topic. The interview's first move elicits the topic — forcing the user to name something upfront often gets a generic label ("improve notifications") when the real trigger is specific ("last week's customer complaints about missed order confirmations"). Let the conversation surface the concrete thing.
+
+`--out` is optional. Choose the filename during the interview once the goal's shape is clear when it is omitted. Resolve `--out` relative to the current working directory (target project root) and refuse paths under `.harness/`, `.claude/`, `.codex/`, `.gemini/`, or outside the project root.
 
 ### 2. Read before asking
 
-Before the first question, read available repo signals so the interview does not ask what the repo already answers:
+Before the first question, skim enough repo context that the interview does not ask what the repo already answers:
 
 - `README.md`, `AGENTS.md` / `CLAUDE.md`, top-level pointer docs
 - `.harness/loom/registry.md` and `.harness/loom/agents/harness-finalizer.md` when present (pair roster + cycle-end duty)
-- last few commits, active branches, `.harness/cycle/state.md` when present (what the harness is currently chewing on)
+- the last few commits, active branches, `.harness/cycle/state.md` when present (what the harness is currently chewing on)
 
-The goal interview is not a codebase audit. Skim only enough to avoid duplicate or contradictory goals and to ground follow-ups in real context.
+This is not a codebase audit. The aim is to avoid duplicate or contradictory goals and to ground follow-ups — not to write the goal file for the user.
 
 ### 3. Interview axes
 
-Drive the interview along these axes, in roughly this order. Stop an axis the moment you have a citable answer; do not pad with filler.
+Drive the interview along these axes, roughly in this order. Stop an axis the moment the user's answer is citable; polishing past "clear enough" burns trust for no quality gain.
 
-1. **Topic and motivation** — what the user wants to accomplish, and *why now*. Reject vague topics ("improve the app") by pushing on the triggering event or pain.
-2. **Users / consumers** — who benefits, and what their current friction or expectation is. Skip if the answer is trivially "the developer".
-3. **Expected behavior or outcome** — the externally visible change. Prefer user-observable verbs ("user can...", "job emits...", "build rejects...") over implementation verbs.
-4. **Boundaries** — hard constraints (compatibility, performance, budgets, deadlines, compliance) and explicit non-goals. Probe for non-goals actively; users tend to under-specify them.
-5. **User-side technical decisions** — only surface axes the planner cannot resolve from repo evidence. Frame each as a choice with named options and brief trade-offs. Skip this section entirely when no such axis exists; do not invent decisions to look thorough.
-6. **Completion signals** — how the user will recognize "done". Prefer observable signals (artifact present, behavior verifiable, metric threshold) over process signals ("PR merged").
+Full prompts and push-back patterns per axis live in `references/interview-axes.md`. The axes:
 
-Ask one axis per turn unless several are tightly coupled. When an answer is sufficient, move on; do not re-ask for polish.
+1. **Topic and motivation** — what the user wants, and *why now*. Push past generic ambition ("improve X") to the concrete trigger (the complaint, the incident, the deadline).
+2. **Users / consumers** — who benefits and what their current friction is. Skip when the answer is trivially "the developer".
+3. **Expected behavior or outcome** — the externally visible change, stated in user-observable verbs ("user can...", "job emits...", "build rejects...").
+4. **Boundaries** — hard constraints and explicit non-goals. Probe non-goals at least twice; they are chronically under-supplied and they shape the cycle as strongly as the positive goals do.
+5. **User-side technical decisions** — choices the planner cannot resolve from repo evidence. Frame each as named options with one-line trade-offs. Skip this axis entirely when no genuine surface exists; invented decisions erode user trust faster than missed ones.
+6. **Completion signals** — observable signals for "done". Strip process signals like "PR merged" or "tests pass"; the harness running to terminal state implies those, and listing them crowds out the signals that actually discriminate success from failure.
 
-### 4. What not to ask
+Ask one axis per turn unless several are tightly coupled. Summarize captured answers back to the user before axes 5 and 6 so early misunderstandings are cheap to correct.
 
-- File paths, class names, module layout, refactor strategy.
-- Specific library picks that follow from existing repo conventions.
-- Task ordering, EPIC shape, review checklist design.
-- Test file locations, CI wiring details.
+### 4. What belongs here vs. what belongs to the harness
 
-These belong to planner and producer-reviewer turns. If the user volunteers such detail, capture it as a constraint only if it is load-bearing; otherwise note it aside and do not write it into the goal file.
+The judgment line between "goal material" and "planner material" is the most important call this skill makes. These questions do **not** belong in the interview:
+
+- file paths, module layout, class names, refactor strategy
+- specific library picks that follow from existing repo conventions
+- task ordering, EPIC shape, reviewer axis design
+- test file locations, CI wiring details
+
+They are off-limits not because they're unimportant but because the planner and producer pairs make *better* decisions about them with the repo open in front of them. Premature commitment in the goal file becomes a constraint the planner has to work around instead of an outcome it can freely decompose.
+
+When the user volunteers such detail, capture it as a constraint only when it is genuinely load-bearing (e.g., "must keep the existing `/v1/` endpoints working"). Otherwise acknowledge it in conversation and do not write it into the goal file.
 
 ### 5. Assemble and confirm
 
-Once the axes above are covered, draft the goal file using `references/output-template.md`. The five sections are mandatory in this order: `## Why`, `## Goal`, `## Constraints`, `## Out of scope`, `## Completion criteria`. The top-level `# <title>` summarizes the goal in one line.
+Once the axes are covered, draft the goal file in this exact section order:
 
-Show the draft inline, then ask the user for a final confirmation or edits before writing. Resolve the filename at this point:
+```markdown
+# <one-line outcome-noun title>
 
-- if `--out` was supplied, use it verbatim
-- otherwise propose `goal-<slug>.md` at the project root where `<slug>` is a short kebab-case derivation of the goal title; confirm with the user before writing
+## Why
+<2–5 sentences: trigger, who is affected, why now>
 
-If a file already exists at the target path, show a diff-style summary and require explicit user confirmation to overwrite.
+## Goal
+<externally visible outcome, in user-observable verbs>
+
+## Constraints
+- <hard requirement, budget, deadline, compliance rule>
+
+## Out of scope
+- <explicit non-goal or deferral>
+
+## Completion criteria
+- <observable signal: behavior, artifact, metric>
+```
+
+Per-section guidance and a longer skeleton are in `references/output-template.md`. Show the draft inline, then ask the user for a final confirmation or edits before writing anything to disk.
+
+Resolve the filename at confirmation time:
+
+- when `--out` was supplied, use it verbatim
+- otherwise propose `goal-<slug>.md` at the project root where `<slug>` is a short kebab-case derivation of the title, and confirm with the user before writing
+
+When a file already exists at the target path, show a diff-style summary and require explicit user confirmation before overwriting.
 
 ### 6. Write and hand off
 
-Write the final body to the chosen path and stop. Do not invoke `/harness-orchestrate` automatically. End the turn with the exact next command the user should run from the target root, e.g.:
+Write the final body to the chosen path and stop. End the turn with the exact next command the user should run:
 
 ```bash
 /harness-orchestrate ./goal-notification-center.md
 ```
 
+Do not invoke `/harness-orchestrate` automatically. The harness cycle is a separate decision point — the user may want to review the file, `git add` it, or have a teammate look at it first.
+
 ### 7. Re-run and revision
 
-Re-invoking the skill with the same `--out` path is a revision request: read the existing file, incorporate the user's new input as amendments, and ask before overwriting. Never silently mutate a previously authored goal file.
+Re-invoking the skill with the same `--out` path is a revision request, not a clean write: read the existing file, incorporate the user's new input as amendments, and ask before overwriting. Silent mutation of a previously authored goal file destroys evidence the user may rely on.
+
+## Example extraction
+
+A short trace, to calibrate voice and depth:
+
+> **User:** "I want to run the harness on the new notification thing."
+>
+> **Skill:** "What happened recently that made that feel worth doing now?"
+>
+> **User:** "Ops team got three tickets last week about missed order confirmations. The emails went out, but the in-app banner didn't."
+>
+> **Skill:** "So the missed surface is the in-app banner specifically — email is fine. Who's affected?"
+>
+> **User:** "End customers on the order detail page. They refresh and see no banner, so they think the order didn't go through and contact support."
+
+From which the skill extracts:
+
+```markdown
+## Why
+Customers who place orders and then refresh the order detail page currently see no in-app confirmation banner, leading them to contact support believing the order failed. Three such tickets arrived in the last week.
+
+## Goal
+After placing an order, a customer visiting the order detail page sees an in-app confirmation banner that survives page refresh until the order transitions to its next state.
+```
+
+No file paths, no library picks, no React/backend choice spelled out — the planner decides that. The goal file records what success looks like and why it matters.
 
 ## Evaluation Criteria
 
-- Output file contains exactly the five sections in canonical order under a concise title; no planner/producer-level detail leaks into any section.
-- Every section is grounded in user answers or cited repo evidence; no filler such as "TBD" or "to be decided during implementation".
-- `## Out of scope` is explicit, not absent; at least one non-goal is present unless the user explicitly declined.
-- `## Completion criteria` is observable (user-visible behavior, artifact presence, metric threshold), not process-based.
-- User-side technical decisions are recorded as resolved choices with a brief rationale when they came up; unresolved axes are named as explicit decisions deferred to the user, not silently dropped.
-- File is written to the target project root (or an `--out` path inside the project root) with a user-confirmed filename; overwrite of an existing file required explicit confirmation.
+- The file contains exactly the five sections in canonical order under a concise outcome-noun title.
+- Every section is grounded in user answers or cited repo evidence; no filler like "TBD" or "to be decided during implementation".
+- `## Out of scope` is explicit, not absent; at least one non-goal is present unless the user explicitly declined and that refusal is recorded.
+- `## Completion criteria` is observable (behavior, artifact, metric), not process-based.
+- No planner/producer-level detail — file paths, function names, library picks that follow from repo evidence — appears anywhere.
+- The file is written inside the target project root at a filename the user confirmed; overwrite of an existing file required explicit confirmation.
 - The skill stops after writing and prints the exact `/harness-orchestrate` invocation for the new file.
 
 ## Taboos
 
-- Name files, functions, modules, or tests in the goal body. That is planner/producer territory.
-- Prescribe task ordering, EPIC structure, review axes, or CI steps.
-- Ask the user implementation-level questions such as "which directory should this live in?" or "should we use library X or Y?" when the answer follows from repo conventions.
-- Fabricate constraints or completion criteria when the user did not supply them; prefer asking or leaving the section thin but honest.
-- Write the file under `.harness/loom/`, `.harness/cycle/`, `.claude/`, `.codex/`, `.gemini/`, or outside the target project root.
-- Invoke `/harness-orchestrate`, `node .harness/loom/sync.ts`, or edit the pair registry as part of this skill.
-- Silently overwrite an existing goal file.
-- Pack multiple unrelated goals into a single file. One request-anchor file per cycle.
+- **Naming files, functions, modules, or tests in the goal body.** Premature commitment here becomes a constraint the planner has to work around instead of an outcome it can freely decompose.
+- **Prescribing task ordering, EPIC structure, review axes, or CI steps.** These are the planner's and producers' jobs; a goal file that dictates them defeats the harness's reason to exist.
+- **Asking implementation-level questions** like "which directory should this live in?" or "library X or Y?" when the answer follows from repo conventions. These waste user attention on choices the harness can make better.
+- **Fabricating constraints or completion criteria** when the user did not supply them. Thin but honest beats padded and invented; the planner will flag real gaps.
+- **Writing the file under `.harness/loom/`, `.harness/cycle/`, `.claude/`, `.codex/`, `.gemini/`, or outside the target project root.** Those trees belong to the orchestrator or provider derivation, not to request-anchor authoring.
+- **Invoking `/harness-orchestrate`, `node .harness/loom/sync.ts`, or editing the pair registry.** The handoff is the user's move.
+- **Silently overwriting an existing goal file.** A revision is a conversation, not a file operation.
+- **Packing multiple unrelated goals into a single file.** The orchestrator anchors one cycle to one request; mixing goals pollutes EPIC decomposition downstream.
 
 ## References
 
-- `references/output-template.md` — canonical five-section skeleton and per-section guidance
-- `references/interview-axes.md` — prompts and probes per axis, and what to push back on
+- `references/output-template.md` — canonical five-section skeleton with per-section guidance
+- `references/interview-axes.md` — prompts, probes, and push-back patterns per axis; anti-patterns for what not to ask
 - `../harness-init/references/runtime/harness-orchestrate/SKILL.template.md` — `§Request-anchored entry`, the contract this skill's output must satisfy
-- `../harness-init/references/runtime/harness-planning/SKILL.template.md` — planner's EPIC decomposition rubric (consumer of this output)
+- `../harness-init/references/runtime/harness-planning/SKILL.template.md` — planner's EPIC decomposition rubric (primary consumer of this file)

--- a/plugins/harness-loom/skills/harness-goal-interview/references/interview-axes.md
+++ b/plugins/harness-loom/skills/harness-goal-interview/references/interview-axes.md
@@ -1,0 +1,109 @@
+# Interview axes
+
+Structured prompts for each axis of the goal interview. Use these as starting points; adapt the phrasing to the conversation. Stop an axis as soon as the user gives a citable answer — do not keep asking for polish.
+
+The axes below are ordered by typical dependency. Earlier answers often make later axes faster or unnecessary.
+
+## 1. Topic and motivation
+
+**Goal:** surface the concrete trigger, not a generic ambition.
+
+Starter prompts:
+- "What do you want this cycle to accomplish?"
+- "What happened recently that made this feel worth doing now?"
+- "Who or what is currently blocked or frustrated?"
+
+Push back when the answer is:
+- a generic verb phrase ("improve X", "clean up Y") → ask for the specific pain or complaint behind it
+- a solution in disguise ("rewrite the auth layer") → ask what problem the rewrite solves
+- a future-proofing story with no present pain → name it explicitly and confirm the user still wants to proceed
+
+## 2. Users and consumers
+
+**Goal:** identify who benefits and what they currently experience.
+
+Starter prompts:
+- "Who is going to notice this change? End users, developers on this team, an external integrator, an on-call rotation?"
+- "What does their current workflow look like? Where does it hurt?"
+
+Skip this axis when the answer is trivially "the developer working in this repo" and nothing else. Do not pad the goal file with imagined stakeholders.
+
+## 3. Expected behavior or outcome
+
+**Goal:** elicit the externally visible change in user-observable verbs.
+
+Starter prompts:
+- "When this cycle finishes, what is someone doing that they couldn't do before?"
+- "What artifact, endpoint, or behavior exists after the cycle that doesn't exist now?"
+
+Push back when the answer is:
+- implementation-flavored ("we'll add a service that...") → ask what the service lets the user *do*
+- aspirational ("make it faster") → ask for the threshold or observable signal
+- framed as work rather than outcome ("write tests for X") → ask what those tests prove to the consumer
+
+## 4. Boundaries: constraints and non-goals
+
+**Goal:** surface hard rules the cycle must honor and work it must not drift into.
+
+Starter prompts (constraints):
+- "Are there compatibility, performance, cost, or compliance requirements I should bake in?"
+- "Is there a deadline or external event tied to this?"
+- "Any platform, library, or integration that must keep working untouched?"
+
+Starter prompts (non-goals):
+- "What are we explicitly *not* doing this cycle?"
+- "Is there adjacent work you considered and chose to defer?"
+- "Where could the planner wander that you want to rule out now?"
+
+Non-goals are almost always under-supplied. Probe at least twice before moving on. If the user declines to name any, record that decision explicitly rather than leaving the section empty.
+
+## 5. User-side technical decisions
+
+**Goal:** resolve choices only the user can make, before the planner has to guess.
+
+A user-side decision has these properties:
+- multiple viable options exist and repo evidence alone cannot pick between them
+- the choice changes the shape of the outcome, not just the implementation route
+- reversing it later would cost a significant re-do
+
+Typical surfaces:
+- **build vs. integrate** (write it ourselves vs. adopt an existing tool or service)
+- **sync vs. async**, **push vs. pull**, **server-side vs. client-side** when both are viable
+- **strict vs. permissive** (reject edge cases vs. tolerate them)
+- **scope depth** (MVP slice vs. full coverage in one cycle)
+- **coupling** (shared module vs. duplicated per-consumer)
+
+Frame each surface as a short choice with named options and one-line trade-offs. Do **not** invent decision surfaces to look thorough. If no genuine user-side axis exists, skip this entirely.
+
+Anti-patterns — do not ask:
+- "Should this live in `src/lib/` or `src/utils/`?" (planner's call from repo convention)
+- "Use library A or library B?" when the repo already standardizes on one
+- "What should the function be called?"
+- "Which tests should we write?"
+
+## 6. Completion signals
+
+**Goal:** name the observable signals that prove the cycle is done.
+
+Starter prompts:
+- "How will you know this cycle is done — what will you check or demonstrate?"
+- "Is there a metric, threshold, or user demo that has to work?"
+- "What artifact must exist at the end?"
+
+Prefer observable signals. Reject or rewrite:
+- "PR merged" → implied by the harness finishing; strip it
+- "all tests green" → implied; strip it unless a specific suite or new coverage is a completion gate
+- "finalizer passes" → implied
+- "code looks clean" → subjective; rewrite as the underlying behavior being clean
+
+Good signals:
+- "A user can perform <action> in the deployed environment."
+- "The `<name>` dashboard panel shows <metric> within <threshold> under load test <scenario>."
+- "Running `<command>` against <input> produces <output>."
+- "Before/after comparison on <dataset> shows <specific change>."
+
+## Flow control
+
+- Ask one axis per turn unless several are tightly coupled.
+- Summarize captured answers back to the user at natural stopping points, especially before axis 5 and axis 6, so the user can correct early misunderstandings cheaply.
+- When enough material exists to write all five output sections honestly, stop interviewing even if there are axes you did not touch. Over-interviewing costs user trust and does not improve EPIC quality.

--- a/plugins/harness-loom/skills/harness-goal-interview/references/output-template.md
+++ b/plugins/harness-loom/skills/harness-goal-interview/references/output-template.md
@@ -18,7 +18,7 @@ Canonical shape for the file produced by `/harness-goal-interview`. The file is 
 ## Constraints
 
 - <hard requirement, compatibility rule, performance/latency/cost budget, deadline, compliance rule, platform or dependency that must be honored>
-- <keep one item per line; omit the section only when there are genuinely no user-supplied constraints>
+- <one item per line; the section stays even when empty — record `- none surfaced during the interview` rather than dropping the heading, since the contract requires all five sections in canonical order>
 
 ## Out of scope
 

--- a/plugins/harness-loom/skills/harness-goal-interview/references/output-template.md
+++ b/plugins/harness-loom/skills/harness-goal-interview/references/output-template.md
@@ -1,0 +1,81 @@
+# Goal file output template
+
+Canonical shape for the file produced by `/harness-goal-interview`. The file is consumed by `/harness-orchestrate <file.md>` as the original user request (see `harness-orchestrate` `§Request-anchored entry`).
+
+## Skeleton
+
+```markdown
+# <one-line goal title>
+
+## Why
+
+<2–5 sentences: triggering event or pain, who is affected, why now. Concrete enough that a stranger can tell why the cycle exists, without reading the codebase.>
+
+## Goal
+
+<2–6 sentences or a short bulleted list: the externally visible change this cycle delivers. Use user-observable verbs ("user can...", "job emits...", "build rejects..."). Describe the outcome, not the implementation route.>
+
+## Constraints
+
+- <hard requirement, compatibility rule, performance/latency/cost budget, deadline, compliance rule, platform or dependency that must be honored>
+- <keep one item per line; omit the section only when there are genuinely no user-supplied constraints>
+
+## Out of scope
+
+- <explicit non-goal the cycle must not drift into>
+- <deliberate deferral to a later cycle>
+- <adjacent work the user considered and chose not to include>
+
+## Completion criteria
+
+- <observable signal #1: a behavior you can verify, an artifact that must exist, a metric threshold, a before/after demonstration>
+- <observable signal #2>
+- <include a user-side technical decision here only if it is itself a completion gate; otherwise keep decisions inside Constraints or Goal>
+```
+
+## Per-section guidance
+
+### Title
+
+One line. Prefer a noun phrase naming the outcome (`notification center for internal tools`) over a verb phrase naming the work (`add notifications`). Avoid version numbers, branch names, or ticket ids.
+
+### Why
+
+Answers "why is this cycle happening *now*?" Cite the triggering event or pain: a user complaint, a recurring operational cost, a compliance deadline, a blocked downstream team. Avoid vague motivations like "improve quality"; push back during the interview until a concrete trigger surfaces.
+
+### Goal
+
+Answers "what will be externally different when the cycle ends?" Describe the outcome in terms a non-implementer can verify. Do not name files, functions, directories, or specific libraries. "User can export filtered logs as CSV from the dashboard" is a goal. "Add `exportLogsCSV()` to `DashboardService`" is a plan.
+
+### Constraints
+
+Hard rules the cycle must honor. These often come from outside engineering: compliance, SLAs, existing integrations, business commitments. Record performance or cost ceilings with numbers when the user supplies them. Leave out soft preferences; those belong in the interview notes, not the goal file.
+
+### Out of scope
+
+The most under-specified section in practice. Probe actively during the interview: "what are we explicitly *not* doing?" Record deferred work, adjacent features the user considered, and areas the planner might otherwise wander into. If the user genuinely declines to name non-goals, say so in one line rather than leaving the section empty.
+
+### Completion criteria
+
+Observable signals only. Prefer:
+
+- user-visible behavior the user or a reviewer can exercise
+- artifacts that must exist (a dashboard panel, an exported file, a deployed endpoint)
+- metric thresholds with numbers
+- before/after comparisons the user can perform
+
+Avoid process-based signals such as "PR merged", "all tests green", or "finalizer passes"; those are implied by the harness running to terminal state and do not help the planner shape EPICs.
+
+## Decision-surface convention
+
+User-side technical decisions belong inline in the section they shape, not in a separate "Decisions" section:
+
+- a resolved build-vs-integrate choice → a sentence in **Goal** or a line in **Constraints**
+- a deliberate deferral of a feature axis → a bullet in **Out of scope**
+- an acceptance signal tied to a user decision → a bullet in **Completion criteria**
+
+If a decision is genuinely undecided and must be resolved before the cycle can proceed, surface it in the interview and resolve it before writing the file. The goal file is not a decision log.
+
+## Length
+
+Aim for 30–80 lines total. Shorter files usually mean the interview stopped too early; longer files usually mean implementation detail leaked in. Neither rule is hard — trust substance over word count.


### PR DESCRIPTION
## Summary

Promotes the v0.3.3 milestone branch to main.

This release introduces a new factory-side user-invocable skill, `/harness-goal-interview`, that runs a full interview with the user and writes a harness-ready goal markdown file (Why / Goal / Constraints / Out of scope / Completion criteria) at the target project root. The output file is the direct input to `/harness-orchestrate <file.md>`. The interview is scoped to **requirements precision** and **user-side technical decisions** only — implementation detail stays with the planner and producer-reviewer pairs.

This release includes:

- New `/harness-goal-interview` skill with `references/output-template.md` and `references/interview-axes.md` (#33, PR #34)
- skill-creator-aligned polish on the skill description and body (pushy triggering, why-first explanations, inline output skeleton, example extraction)
- Marketplace and plugin metadata bumped to `0.3.3` across `.claude-plugin/marketplace.json`, `plugins/harness-loom/.claude-plugin/plugin.json`, and `plugins/harness-loom/.codex-plugin/plugin.json`

## Linked Issues

Closes #33

## Validation

- Codex automated review on PR #34 raised three P2 findings (marketplace version split-brain, Constraints-section omit contradiction, hard-coded handoff filename); all three were addressed before merge.
- No script-level test suite changes; no runtime contracts altered. The new skill ships SKILL.md + references only.