### PR TITLE
docs(v0.3.5): rework README onboarding with quick start and mermaid diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,3 +342,4 @@ Issues, bug fixes, and rubric refinements are welcome. See [CONTRIBUTING.md](./C
 - [SECURITY.md](./SECURITY.md) - responsible disclosure
 - [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md) - community expectations
 - [LICENSE](./LICENSE) - Apache 2.0
+- [NOTICE](./NOTICE) - attribution notice required by Apache 2.0

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This is harness fine-tuning, not model fine-tuning — you encode your repo's re
 
 ## Quick Start
 
-Install the factory into Claude Code (or Codex / Gemini — see [Install The Factory](#install-the-factory) for full options):
+Install the factory into Claude Code. Codex and Gemini have similar flows — see [Install The Factory](#install-the-factory) for those.
 
 ```text
 /plugin marketplace add KingGyuSuh/harness-loom
@@ -149,13 +149,13 @@ Add the marketplace source — the argument points at the repo root (which conta
 
 ```bash
 # local checkout
-codex marketplace add /path/to/harness-loom
+codex plugin marketplace add /path/to/harness-loom
 
 # public git repo
-codex marketplace add KingGyuSuh/harness-loom
+codex plugin marketplace add KingGyuSuh/harness-loom
 
 # pin a tag if needed
-codex marketplace add KingGyuSuh/harness-loom@<tag>
+codex plugin marketplace add KingGyuSuh/harness-loom@<tag>
 ```
 
 Then, inside the Codex TUI, run `/plugins`, open the `Harness Loom` marketplace entry, and install the plugin.

--- a/README.md
+++ b/README.md
@@ -12,22 +12,58 @@
 
 <br clear="left" />
 
-`harness-loom` is a factory plugin that installs a runtime harness into a target repository and grows it pair by pair.
+## What It Does
 
-Modern assistant products are no longer just "a model plus a prompt". They ship a general-purpose harness — planners, hooks, subagents, skills, tool routing, control flow — that decides how work gets planned, delegated, reviewed, and resumed. That layer is valuable, but it does not know your production system: which reviews matter, which artifacts should persist, how your work decomposes, where your authority boundaries sit.
+`harness-loom` is a factory plugin that installs a runtime harness into a target repository and grows it pair by pair. The factory ships four user-facing slash commands (`/harness-init`, `/harness-auto-setup`, `/harness-pair-dev`, `/harness-goal-interview`) plus a `sync.ts` script. Once installed, your target gets a planner, an orchestrator, a shared control plane under `.harness/`, and a place to add project-specific producer-reviewer pairs over time.
 
-Once your chosen model stack is already capable enough to produce production-quality work, the main leverage shifts from model choice to **harness engineering** — encoding your repo's review standards, task shapes, and definition of done into versioned infrastructure instead of re-prompting it every session. This is harness fine-tuning, not model fine-tuning.
+This is harness fine-tuning, not model fine-tuning — you encode your repo's review standards, task shapes, and definition of done into versioned infrastructure instead of re-prompting it every session. `harness-loom` is for teams that already see production-quality potential in their assistant stack and now want it to behave like a system rather than a session.
 
-`harness-loom` is for teams that already see production-quality potential in their assistant stack and now want it to behave like a system rather than a session.
+## Quick Start
 
-This repo is the factory. It seeds or converges a target-side runtime harness made of:
+Install the factory into Claude Code (or Codex / Gemini — see [Install The Factory](#install-the-factory) for full options):
 
-- a planner and orchestrator
-- a shared control plane under `.harness/`
-- a common runtime context for all subagents
-- project-specific producer-reviewer pairs that you add over time
+```text
+/plugin marketplace add KingGyuSuh/harness-loom
+/plugin install harness-loom@harness-loom-marketplace
+```
 
-A target's `.harness/` is split into two sibling namespaces — `loom/` is the canonical staging tree owned by setup and pair authoring, and `cycle/` holds runtime state owned by the orchestrator. Out-of-cycle artifacts (target-root `*.md`, `docs/`, release notes, audit output) are written directly at the target root by the cycle-end **Finalizer** turn, not inside `.harness/`. Platform trees (`.claude/`, `.codex/`, `.gemini/`) are derived from `.harness/loom/` on demand.
+Inside your target repository:
+
+```bash
+# 1. seed or migrate .harness/
+/harness-auto-setup --setup
+
+# 2. derive the assistant runtime tree
+node .harness/loom/sync.ts --provider claude
+#   (add codex,gemini for multi-platform)
+```
+
+That gets the foundation in place. To add project-specific producer-reviewer pairs and run your first cycle, see [Start A Target Project](#start-a-target-project).
+
+## How It Works
+
+```mermaid
+flowchart LR
+    subgraph Factory["harness-loom (factory plugin)"]
+        AS["/harness-auto-setup"]
+        PD["/harness-pair-dev"]
+        GI["/harness-goal-interview"]
+        OR["/harness-orchestrate"]
+    end
+    subgraph Target["target repository"]
+        L[".harness/loom/<br/>canonical staging"]
+        C[".harness/cycle/<br/>runtime state"]
+        P[".claude/ / .codex/ / .gemini/<br/>derived provider trees"]
+    end
+    AS -->|seed / migrate| L
+    PD -->|author pairs| L
+    GI -->|writes goal file| Target
+    L -->|node sync.ts --provider| P
+    OR -->|reads| L
+    OR -->|writes| C
+```
+
+The factory plugin lives in your assistant CLI; running its slash commands inside a target repository writes to `.harness/loom/` (canonical staging owned by setup and pair authoring) and `.harness/cycle/` (runtime state owned by the orchestrator). Provider trees (`.claude/`, `.codex/`, `.gemini/`) are derived artifacts you regenerate with `sync.ts` whenever canonical staging changes — never edit them directly. The cycle-end **Finalizer** turn writes target-root output (docs, audits, release notes) directly into the target, not inside `.harness/`.
 
 ## Why This Shape
 
@@ -39,35 +75,24 @@ A target's `.harness/` is split into two sibling namespaces — `loom/` is the c
 
 ## What Gets Installed
 
-When you run `/harness-init` inside a target repository, `harness-loom` installs a runtime harness rather than a one-off prompt template. When you run `/harness-auto-setup`, it uses that same foundation installer inside a safer setup/migration workflow.
-
 ```text
 target project
 └── .harness/
     ├── loom/                    # canonical staging (setup + pair authoring own; sync reads)
-    │   ├── skills/
-    │   │   ├── harness-orchestrate/
-    │   │   ├── harness-planning/
-    │   │   └── harness-context/
-    │   ├── agents/
-    │   │   ├── harness-planner.md
-    │   │   └── harness-finalizer.md     # generic cycle-end skeleton; project fills in
+    │   ├── skills/{harness-orchestrate, harness-planning, harness-context}/
+    │   ├── agents/{harness-planner, harness-finalizer}.md
     │   ├── hook.sh
     │   └── sync.ts
     ├── cycle/                   # runtime state (orchestrator owns)
-    │   ├── state.md
-    │   ├── events.md
-    │   ├── epics/
-    │   └── finalizer/
-    │       └── tasks/
-    ├── _snapshots/              # auto-setup provenance, when convergence runs
-    │   └── auto-setup/
-    └── _archive/                # past cycles, created on goal-different reset
+    │   ├── state.md, events.md
+    │   └── epics/, finalizer/tasks/
+    ├── _snapshots/              # auto-setup provenance (when migration runs)
+    └── _archive/                # past cycles (created on goal-different reset)
 ```
 
-Project documentation (target-root `*.md` files, `docs/`) is authored **directly in the target**, not inside `.harness/`. You then derive at least one platform tree with `node .harness/loom/sync.ts --provider claude` (and add `codex,gemini` for multi-platform), then add domain-specific pairs with `/harness-pair-dev`. The install scaffold does not create request snapshots. On direct `/harness-orchestrate <file.md>` entry, the orchestrator preserves the full request body in `.harness/cycle/user-request-snapshot.md` and keeps `state.md`'s `Goal` header as a compact summary. The orchestrator runs as a four-state DFA — `Planner | Pair | Finalizer | Halt`. When every EPIC reaches terminal and no planner continuation remains, it enters the **Finalizer state** and dispatches the singleton `harness-finalizer` agent before halting. The seeded `harness-finalizer` agent is a generic skeleton; you replace its body with the concrete cycle-end work this project needs — documentation refresh (`CLAUDE.md`, `AGENTS.md`, `docs/`), request-coverage inspection against `events.md` and the user request snapshot, release prep, audit output, etc. You do not invoke the finalizer directly; the orchestrator dispatches it as the cycle-end turn before halting.
+Project documentation (target-root `*.md`, `docs/`) is authored **directly in the target**, not inside `.harness/`. The orchestrator runs as a four-state DFA — `Planner | Pair | Finalizer | Halt`. When every EPIC reaches terminal and no planner continuation remains, it dispatches the singleton `harness-finalizer` agent before halting; you replace its body with the cycle-end work this project needs (documentation refresh, request-coverage inspection, release prep, audit output).
 
-`/harness-auto-setup` is the safer entry point for first setup, project-shaped configuration, or existing-harness migration. `--setup` (the default) bootstraps a fresh target; when an existing `.harness/` is present, it leaves the foundation untouched and continues into additive pair/finalizer authoring after project analysis and any needed user clarification. `--migration` is the mode that handles existing foundations: it snapshots live `.harness/loom/` and `.harness/cycle/`, refreshes the foundation, restores non-pair custom loom entries, preserves compatible pair/finalizer guidance, and rewrites only the contract-owned runtime surface. It never writes `.claude/`, `.codex/`, or `.gemini/` itself.
+`/harness-auto-setup` is the safer entry point: `--setup` (default) bootstraps a fresh target or extends an existing harness additively; `--migration` snapshots live `.harness/loom/` and `.harness/cycle/`, refreshes the foundation, and preserves compatible custom pair/finalizer guidance.
 
 ## Requirements
 
@@ -285,37 +310,6 @@ A few terms recur across commands, files, and state. Knowing these is enough to 
 | `/harness-pair-dev --remove <slug>` | Safely unregister a pair and delete only pair-owned `.harness/loom/` files. Removal refuses foundation/singleton targets and active-cycle references in `## Next` or live EPIC roster/current fields before mutating, preserves `.harness/cycle/` task/review history, and touches no provider tree; re-run sync afterward. |
 | `/harness-orchestrate <file.md>` | Target-side runtime entry point. Reads the request file, preserves its full body in `.harness/cycle/user-request-snapshot.md`, and runs a four-state DFA (`Planner | Pair | Finalizer | Halt`) dispatching exactly one producer per response; hook re-entry advances the cycle from `state.md` and the existing snapshot path. When every EPIC reaches terminal and planner continuation is clear, the orchestrator enters the Finalizer state and dispatches the singleton `harness-finalizer` before halting. |
 
-## Factory And Runtime
-
-```text
-factory (this repo)                            target project
------------------------------------------      ----------------------------------
-plugins/harness-loom/skills/harness-init/          installs ->      .harness/loom/{skills,agents,hook.sh,sync.ts}
-plugins/harness-loom/skills/harness-init/                            .harness/cycle/{state.md,events.md,epics/,finalizer/tasks/}
-plugins/harness-loom/skills/harness-init/references/runtime/ seeds -> .harness/loom/skills/<slug>/SKILL.md
-plugins/harness-loom/skills/harness-auto-setup/    migrates ->      .harness/_snapshots/auto-setup/<timestamp>/
-                                                                    .harness/loom/ + .harness/cycle/ refreshed in --migration
-plugins/harness-loom/skills/harness-pair-dev/      authors  ->      .harness/loom/agents/<slug>-producer.md
-                                                                    .harness/loom/agents/<reviewer>.md
-                                                                    .harness/loom/skills/<slug>/SKILL.md
-                                                     |
-                                                     +-- node .harness/loom/sync.ts --provider <list>
-                                                         -> .claude/{agents,skills,settings.json}
-                                                         -> .codex/
-                                                         -> .gemini/
-                                                     |
-                                                     +-- Finalizer state auto-fires at cycle halt
-                                                         -> .harness/loom/agents/harness-finalizer.md
-                                                         -> whatever that finalizer body writes
-```
-
-This split is intentional:
-
-- the factory stays small and user-invocable
-- the target runtime holds the project-specific working state
-- the cycle-end hook stays singleton and project-customizable
-- provider-specific trees are derived artifacts, not authoring surfaces
-
 ## Multi-platform
 
 Platform pins applied by `sync.ts`:
@@ -348,4 +342,3 @@ Issues, bug fixes, and rubric refinements are welcome. See [CONTRIBUTING.md](./C
 - [SECURITY.md](./SECURITY.md) - responsible disclosure
 - [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md) - community expectations
 - [LICENSE](./LICENSE) - Apache 2.0
-- [NOTICE](./NOTICE) - required attribution notice per Apache 2.0

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -22,7 +22,7 @@ Esto es ajuste fino del harness, no del modelo —codifica los estándares de re
 
 ## Inicio rápido
 
-Instala la fábrica en Claude Code (o Codex / Gemini —ver [Instalar la fábrica](#instalar-la-fábrica) para todas las opciones):
+Instala la fábrica en Claude Code. Codex y Gemini siguen flujos similares —ver [Instalar la fábrica](#instalar-la-fábrica).
 
 ```text
 /plugin marketplace add KingGyuSuh/harness-loom
@@ -151,13 +151,13 @@ Añade la fuente de marketplace —el argumento apunta a la raíz del repo (que 
 
 ```bash
 # checkout local
-codex marketplace add /path/to/harness-loom
+codex plugin marketplace add /path/to/harness-loom
 
 # repo git público
-codex marketplace add KingGyuSuh/harness-loom
+codex plugin marketplace add KingGyuSuh/harness-loom
 
 # fija un tag si es necesario
-codex marketplace add KingGyuSuh/harness-loom@<tag>
+codex plugin marketplace add KingGyuSuh/harness-loom@<tag>
 ```
 
 Después, dentro del TUI de Codex, ejecuta `/plugins`, abre la entrada de marketplace `Harness Loom` e instala el plugin.

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -14,22 +14,58 @@
 
 > En caso de discrepancia, el [README en inglés](../README.md) es la versión normativa.
 
-`harness-loom` es un plugin de fábrica que instala un harness en tiempo de ejecución dentro de un repositorio destino y lo hace crecer pareja por pareja.
+## Qué hace
 
-Los productos de asistente modernos ya no son solo "un modelo más un prompt". Vienen con un harness de propósito general —planificadores, hooks, subagentes, skills, enrutamiento de herramientas, control de flujo— que decide cómo se planifica, delega, revisa y reanuda el trabajo. Esa capa es valiosa, pero no conoce tu sistema de producción: qué revisiones importan, qué artefactos deben persistir, cómo se descompone tu trabajo, dónde están tus límites de autoridad.
+`harness-loom` es un plugin de fábrica que instala un harness en tiempo de ejecución dentro de un repositorio destino y lo hace crecer pareja por pareja. La fábrica entrega cuatro comandos slash para el usuario (`/harness-init`, `/harness-auto-setup`, `/harness-pair-dev`, `/harness-goal-interview`) y un script `sync.ts`. Una vez instalado, tu destino dispone de un planner, un orquestador, un plano de control compartido bajo `.harness/`, y un sitio donde añadir parejas producer-reviewer específicas del proyecto a lo largo del tiempo.
 
-Una vez que el stack de modelos elegido ya es lo bastante capaz para producir trabajo de calidad de producción, la palanca principal se traslada de la elección del modelo a la **ingeniería del harness** —codificar los estándares de revisión de tu repo, las formas de las tareas y la definición de hecho en infraestructura versionada en lugar de re-promptearla en cada sesión. Esto es ajuste fino del harness, no del modelo.
+Esto es ajuste fino del harness, no del modelo —codifica los estándares de revisión de tu repo, las formas de las tareas y la definición de hecho en infraestructura versionada en lugar de re-promptearla en cada sesión. `harness-loom` es para equipos que ya ven el potencial de calidad de producción en su stack de asistentes y ahora quieren que se comporte como un sistema en lugar de como una sesión.
 
-`harness-loom` es para equipos que ya ven el potencial de calidad de producción en su stack de asistentes y ahora quieren que se comporte como un sistema en lugar de como una sesión.
+## Inicio rápido
 
-Este repo es la fábrica. Siembra o converge un harness en tiempo de ejecución del lado del destino compuesto por:
+Instala la fábrica en Claude Code (o Codex / Gemini —ver [Instalar la fábrica](#instalar-la-fábrica) para todas las opciones):
 
-- un planificador y un orquestador
-- un plano de control compartido bajo `.harness/`
-- un contexto en tiempo de ejecución común para todos los subagentes
-- parejas producer-reviewer específicas del proyecto que vas añadiendo con el tiempo
+```text
+/plugin marketplace add KingGyuSuh/harness-loom
+/plugin install harness-loom@harness-loom-marketplace
+```
 
-El `.harness/` del destino se divide en dos espacios de nombres hermanos —`loom/` es el árbol de staging canónico que poseen el setup y la autoría de pares, y `cycle/` contiene el estado en tiempo de ejecución que posee el orquestador. Los artefactos fuera de ciclo (`*.md` en la raíz del destino, `docs/`, notas de versión, salida de auditoría) los escribe el turno **Finalizer** de cierre de ciclo directamente en la raíz del destino, no dentro de `.harness/`. Los árboles de plataforma (`.claude/`, `.codex/`, `.gemini/`) se derivan a demanda desde `.harness/loom/`.
+Dentro de tu repositorio destino:
+
+```bash
+# 1. sembrar o migrar .harness/
+/harness-auto-setup --setup
+
+# 2. derivar el árbol de runtime del asistente
+node .harness/loom/sync.ts --provider claude
+#   (añade codex,gemini para multi-plataforma)
+```
+
+Hasta aquí queda la foundation. Para añadir parejas producer-reviewer específicas del proyecto y ejecutar tu primer ciclo, ver [Empezar un proyecto destino](#empezar-un-proyecto-destino).
+
+## Cómo funciona
+
+```mermaid
+flowchart LR
+    subgraph Factory["harness-loom (factory plugin)"]
+        AS["/harness-auto-setup"]
+        PD["/harness-pair-dev"]
+        GI["/harness-goal-interview"]
+        OR["/harness-orchestrate"]
+    end
+    subgraph Target["target repository"]
+        L[".harness/loom/<br/>canonical staging"]
+        C[".harness/cycle/<br/>runtime state"]
+        P[".claude/ / .codex/ / .gemini/<br/>derived provider trees"]
+    end
+    AS -->|seed / migrate| L
+    PD -->|author pairs| L
+    GI -->|writes goal file| Target
+    L -->|node sync.ts --provider| P
+    OR -->|reads| L
+    OR -->|writes| C
+```
+
+El plugin de fábrica vive en tu CLI de asistente; ejecutar sus comandos slash dentro de un repositorio destino escribe en `.harness/loom/` (staging canónico que poseen el setup y el authoring de pares) y `.harness/cycle/` (estado en tiempo de ejecución que posee el orquestador). Los árboles de plataforma (`.claude/`, `.codex/`, `.gemini/`) son artefactos derivados que regeneras con `sync.ts` cada vez que el staging canónico cambia —nunca los edites directamente. El turno **Finalizer** de cierre de ciclo escribe los artefactos de la raíz del destino (documentación, auditoría, notas de release) directamente en el destino, no dentro de `.harness/`.
 
 ## Por qué esta forma
 
@@ -41,35 +77,24 @@ El `.harness/` del destino se divide en dos espacios de nombres hermanos —`loo
 
 ## Qué se instala
 
-Cuando ejecutas `/harness-init` dentro de un repositorio destino, `harness-loom` instala un harness en tiempo de ejecución y no una plantilla de prompt de un solo uso. Cuando ejecutas `/harness-auto-setup`, usa ese mismo instalador de foundation dentro de un flujo más seguro de setup/migración.
-
 ```text
 target project
 └── .harness/
     ├── loom/                    # canonical staging (setup + pair authoring own; sync reads)
-    │   ├── skills/
-    │   │   ├── harness-orchestrate/
-    │   │   ├── harness-planning/
-    │   │   └── harness-context/
-    │   ├── agents/
-    │   │   ├── harness-planner.md
-    │   │   └── harness-finalizer.md     # generic cycle-end skeleton; project fills in
+    │   ├── skills/{harness-orchestrate, harness-planning, harness-context}/
+    │   ├── agents/{harness-planner, harness-finalizer}.md
     │   ├── hook.sh
     │   └── sync.ts
     ├── cycle/                   # runtime state (orchestrator owns)
-    │   ├── state.md
-    │   ├── events.md
-    │   ├── epics/
-    │   └── finalizer/
-    │       └── tasks/
-    ├── _snapshots/              # auto-setup provenance, when convergence runs
-    │   └── auto-setup/
-    └── _archive/                # past cycles, created on goal-different reset
+    │   ├── state.md, events.md
+    │   └── epics/, finalizer/tasks/
+    ├── _snapshots/              # auto-setup provenance (when migration runs)
+    └── _archive/                # past cycles (created on goal-different reset)
 ```
 
-La documentación del proyecto (archivos `*.md` en la raíz del destino, `docs/`) se author **directamente en el destino**, no dentro de `.harness/`. Después derivas al menos un árbol de plataforma con `node .harness/loom/sync.ts --provider claude` (y añade `codex,gemini` para multi-plataforma), y luego añades pares específicos del dominio con `/harness-pair-dev`. El scaffold de instalación no crea snapshots de request. Al entrar directamente con `/harness-orchestrate <file.md>`, el orquestador conserva el cuerpo completo de la request en `.harness/cycle/user-request-snapshot.md` y mantiene la cabecera `Goal` de `state.md` como un resumen compacto. El orquestador funciona como un DFA de cuatro estados —`Planner | Pair | Finalizer | Halt`. Cuando todo EPIC alcanza terminal y no queda continuación del planner, entra en el **estado Finalizer** y despacha el agente singleton `harness-finalizer` antes de detenerse. El `harness-finalizer` sembrado es un esqueleto genérico; reemplazas su cuerpo por el trabajo de cierre de ciclo concreto que necesite este proyecto —refresco de documentación (`CLAUDE.md`, `AGENTS.md`, `docs/`), inspección de cobertura de la request frente a `events.md` y la snapshot de request del usuario, preparación de release, salida de auditoría, etc. No invocas el finalizer directamente; el orquestador lo despacha como turno de cierre de ciclo antes de detenerse.
+La documentación del proyecto (`*.md` en la raíz del destino, `docs/`) se author **directamente en el destino**, no dentro de `.harness/`. El orquestador funciona como un DFA de cuatro estados —`Planner | Pair | Finalizer | Halt`. Cuando todo EPIC alcanza terminal y no queda continuación del planner, despacha el agente singleton `harness-finalizer` antes de detenerse; reemplazas su cuerpo por el trabajo de cierre de ciclo concreto que necesite el proyecto (refresco de documentación, inspección de cobertura de la request, preparación de release, salida de auditoría).
 
-`/harness-auto-setup` es el punto de entrada más seguro para la primera instalación, configuración por forma de proyecto o migración de un harness existente. `--setup` (por defecto) hace bootstrap de un destino nuevo; cuando hay un `.harness/` existente, deja la foundation intacta y continúa hacia authoring aditivo de pares/finalizer tras el análisis de proyecto y cualquier aclaración necesaria con el usuario. `--migration` es el modo que maneja foundations existentes: hace snapshot de los `.harness/loom/` y `.harness/cycle/` vivos, refresca la foundation, restaura entradas custom de loom que no son pares, conserva la guía compatible de pares/finalizer y reescribe solo la superficie en tiempo de ejecución que es propiedad del contract. Nunca escribe `.claude/`, `.codex/` ni `.gemini/` por sí solo.
+`/harness-auto-setup` es el punto de entrada más seguro: `--setup` (por defecto) hace bootstrap de un destino nuevo o extiende un harness existente de forma aditiva; `--migration` hace snapshot de `.harness/loom/` y `.harness/cycle/` vivos, refresca la foundation y conserva la guía custom compatible de pares/finalizer.
 
 ## Requisitos
 
@@ -286,37 +311,6 @@ Algunos términos se repiten a través de comandos, archivos y estado. Conocerlo
 | `/harness-pair-dev --improve <slug> "<purpose>" [--before <slug> \| --after <slug>]` | Mejora una pareja registrada existente con el `<purpose>` posicional como eje primario de revisión, y luego incorpora higiene de rubric y evidencia actual del repo. Si una pareja se ha convertido en dos trabajos distintos, usa pasos explícitos de add/improve/remove. Vuelve a ejecutar sync después para refrescar los árboles de plataforma. |
 | `/harness-pair-dev --remove <slug>` | Da de baja de forma segura una pareja y borra solo los archivos `.harness/loom/` que pertenecen a esa pareja. Antes de mutar rechaza objetivos de foundation/singleton y referencias de ciclo activo en `## Next` o en los campos roster/current de los EPICs vivos, conserva el historial de tasks/reviews de `.harness/cycle/`, y no toca ningún árbol de provider; vuelve a ejecutar sync después. |
 | `/harness-orchestrate <file.md>` | Punto de entrada de runtime del lado del destino. Lee el archivo de request, conserva su cuerpo completo en `.harness/cycle/user-request-snapshot.md`, y corre un DFA de cuatro estados (`Planner | Pair | Finalizer | Halt`) despachando exactamente un producer por respuesta; la re-entrada por hook avanza el ciclo desde `state.md` y la ruta de snapshot existente. Cuando todo EPIC alcanza terminal y la continuación del planner está clara, el orquestador entra en el estado Finalizer y despacha el singleton `harness-finalizer` antes de detenerse. |
-
-## Fábrica y Runtime
-
-```text
-factory (this repo)                            target project
------------------------------------------      ----------------------------------
-plugins/harness-loom/skills/harness-init/          installs ->      .harness/loom/{skills,agents,hook.sh,sync.ts}
-plugins/harness-loom/skills/harness-init/                            .harness/cycle/{state.md,events.md,epics/,finalizer/tasks/}
-plugins/harness-loom/skills/harness-init/references/runtime/ seeds -> .harness/loom/skills/<slug>/SKILL.md
-plugins/harness-loom/skills/harness-auto-setup/    migrates ->      .harness/_snapshots/auto-setup/<timestamp>/
-                                                                    .harness/loom/ + .harness/cycle/ refreshed in --migration
-plugins/harness-loom/skills/harness-pair-dev/      authors  ->      .harness/loom/agents/<slug>-producer.md
-                                                                    .harness/loom/agents/<reviewer>.md
-                                                                    .harness/loom/skills/<slug>/SKILL.md
-                                                     |
-                                                     +-- node .harness/loom/sync.ts --provider <list>
-                                                         -> .claude/{agents,skills,settings.json}
-                                                         -> .codex/
-                                                         -> .gemini/
-                                                     |
-                                                     +-- Finalizer state auto-fires at cycle halt
-                                                         -> .harness/loom/agents/harness-finalizer.md
-                                                         -> whatever that finalizer body writes
-```
-
-Esta separación es intencional:
-
-- la fábrica permanece pequeña e invocable por el usuario
-- el runtime del destino mantiene el estado de trabajo específico del proyecto
-- el hook de cierre de ciclo permanece singleton y personalizable por el proyecto
-- los árboles específicos de plataforma son artefactos derivados, no superficies de authoring
 
 ## Multi-plataforma
 

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -14,22 +14,58 @@
 
 > 表現に齟齬がある場合、正本は [英語版 README](../README.md) です。
 
-`harness-loom` はターゲットリポジトリにランタイムハーネスをインストールし、プロジェクト固有の producer-reviewer pair をペアごとに育てていくファクトリープラグインです。
+## 何をするか
 
-最近のアシスタント製品はもはや「モデル + プロンプト」だけではありません。planner、hook、subagent、skill、ツールルーティング、制御フローを束ねた汎用ハーネスを同梱しており、作業がどう計画され、委譲され、レビューされ、再開されるかを決めます。そのレイヤーには価値がありますが、あなたのプロダクションシステム —— どのレビューが重要か、どの成果物を永続化すべきか、作業がどう分解されるか、権限境界がどこにあるか —— までは知りません。
+`harness-loom` はターゲットリポジトリにランタイムハーネスをインストールし、プロジェクト固有の producer-reviewer pair をペアごとに育てていくファクトリープラグインです。ファクトリーはユーザーが呼び出すスラッシュコマンドを 4 つ (`/harness-init`、`/harness-auto-setup`、`/harness-pair-dev`、`/harness-goal-interview`) と `sync.ts` スクリプトを出荷します。インストールされると、ターゲットには planner、orchestrator、`.harness/` 配下の共有コントロールプレーン、そして時間とともに追加していくプロジェクト固有の producer-reviewer pair の場所が揃います。
 
-選んだモデルスタックがすでにプロダクション品質の作業を生み出すだけの能力を持っているなら、レバレッジの主軸はモデル選定から **ハーネスエンジニアリング** へと移ります —— つまり、リポジトリのレビュー基準、タスク形状、完了の定義を、毎セッションでプロンプトし直す代わりに、バージョン管理されたインフラに刻み込むという仕事です。これはモデルのファインチューンではなく、ハーネスのファインチューンです。
+これはモデルのファインチューンではなく、ハーネスのファインチューンです —— リポのレビュー基準、タスク形状、完了の定義を、毎セッションでプロンプトし直す代わりに、バージョン管理されたインフラに刻み込みます。`harness-loom` はアシスタントスタックにすでにプロダクション品質の可能性を見出していて、それをセッションではなくシステムとして振る舞わせたいチームのためのものです。
 
-`harness-loom` はアシスタントスタックにすでにプロダクション品質の可能性を見出していて、それをセッションではなくシステムとして振る舞わせたいチームのためのものです。
+## クイックスタート
 
-このリポはファクトリーです。次の構成からなるターゲット側ランタイムハーネスをシードまたは収束させます:
+ファクトリーを Claude Code (または Codex / Gemini —— 全オプションは [ファクトリーのインストール](#ファクトリーのインストール) を参照) にインストールします:
 
-- planner と orchestrator
-- `.harness/` 配下の共有コントロールプレーン
-- すべての subagent のための共通ランタイムコンテキスト
-- 時間とともに追加していくプロジェクト固有の producer-reviewer pair
+```text
+/plugin marketplace add KingGyuSuh/harness-loom
+/plugin install harness-loom@harness-loom-marketplace
+```
 
-ターゲットの `.harness/` は 2 つの兄弟ネームスペースに分かれます —— `loom/` は setup と pair authoring が所有する正本ステージングツリー、`cycle/` は orchestrator が所有するランタイム状態です。サイクル外の成果物(ターゲットルートの `*.md`、`docs/`、リリースノート、監査出力など)は、サイクル終了の **Finalizer** ターンが `.harness/` の中ではなくターゲットルートに直接書き込みます。プラットフォームツリー(`.claude/`、`.codex/`、`.gemini/`)は必要なときに `.harness/loom/` から派生します。
+ターゲットリポジトリの中で:
+
+```bash
+# 1. .harness/ をシードまたは移行
+/harness-auto-setup --setup
+
+# 2. アシスタントランタイムツリーを派生
+node .harness/loom/sync.ts --provider claude
+#   (マルチプラットフォームには codex,gemini を追加)
+```
+
+ここまでが foundation のセットアップです。プロジェクト固有の producer-reviewer pair を追加して最初のサイクルを実行する手順は [ターゲットプロジェクトを始める](#ターゲットプロジェクトを始める) を参照してください。
+
+## どう動くか
+
+```mermaid
+flowchart LR
+    subgraph Factory["harness-loom (factory plugin)"]
+        AS["/harness-auto-setup"]
+        PD["/harness-pair-dev"]
+        GI["/harness-goal-interview"]
+        OR["/harness-orchestrate"]
+    end
+    subgraph Target["target repository"]
+        L[".harness/loom/<br/>canonical staging"]
+        C[".harness/cycle/<br/>runtime state"]
+        P[".claude/ / .codex/ / .gemini/<br/>derived provider trees"]
+    end
+    AS -->|seed / migrate| L
+    PD -->|author pairs| L
+    GI -->|writes goal file| Target
+    L -->|node sync.ts --provider| P
+    OR -->|reads| L
+    OR -->|writes| C
+```
+
+ファクトリープラグインはアシスタント CLI の中に存在し、ターゲットリポジトリの中でスラッシュコマンドを実行すると `.harness/loom/` (setup と pair authoring が所有する正本ステージング) と `.harness/cycle/` (orchestrator が所有するランタイム状態) に書き込みます。プラットフォームツリー (`.claude/`、`.codex/`、`.gemini/`) は正本ステージングが変わるたびに `sync.ts` で再派生する成果物 —— 直接編集してはいけません。サイクル終了の **Finalizer** ターンは、ターゲットルートの成果物 (ドキュメント、監査、リリースノート) を `.harness/` の中ではなくターゲットに直接書き込みます。
 
 ## なぜこの形なのか
 
@@ -41,35 +77,24 @@
 
 ## インストールされるもの
 
-ターゲットリポジトリの中で `/harness-init` を実行すると、`harness-loom` は使い捨てプロンプトテンプレートではなくランタイムハーネスをインストールします。`/harness-auto-setup` を実行すると、同じ foundation インストーラーをより安全な setup/migration ワークフローの中で使います。
-
 ```text
 target project
 └── .harness/
     ├── loom/                    # canonical staging (setup + pair authoring own; sync reads)
-    │   ├── skills/
-    │   │   ├── harness-orchestrate/
-    │   │   ├── harness-planning/
-    │   │   └── harness-context/
-    │   ├── agents/
-    │   │   ├── harness-planner.md
-    │   │   └── harness-finalizer.md     # generic cycle-end skeleton; project fills in
+    │   ├── skills/{harness-orchestrate, harness-planning, harness-context}/
+    │   ├── agents/{harness-planner, harness-finalizer}.md
     │   ├── hook.sh
     │   └── sync.ts
     ├── cycle/                   # runtime state (orchestrator owns)
-    │   ├── state.md
-    │   ├── events.md
-    │   ├── epics/
-    │   └── finalizer/
-    │       └── tasks/
-    ├── _snapshots/              # auto-setup provenance, when convergence runs
-    │   └── auto-setup/
-    └── _archive/                # past cycles, created on goal-different reset
+    │   ├── state.md, events.md
+    │   └── epics/, finalizer/tasks/
+    ├── _snapshots/              # auto-setup provenance (when migration runs)
+    └── _archive/                # past cycles (created on goal-different reset)
 ```
 
-プロジェクトドキュメント(ターゲットルートの `*.md` ファイル、`docs/`)は `.harness/` の中ではなく **ターゲットの中に直接** author します。その後 `node .harness/loom/sync.ts --provider claude` で少なくとも 1 つのプラットフォームツリーを派生し(マルチプラットフォームには `codex,gemini` を追加)、`/harness-pair-dev` でドメイン固有のペアを追加します。インストール scaffold はリクエストスナップショットを作成しません。`/harness-orchestrate <file.md>` で直接エントリした場合、orchestrator は完全なリクエスト本文を `.harness/cycle/user-request-snapshot.md` に保存し、`state.md` の `Goal` ヘッダーは圧縮された要約として保ちます。orchestrator は 4 状態 DFA —— `Planner | Pair | Finalizer | Halt` —— として動作します。すべての EPIC が terminal に到達し、planner がそれ以上続行することがなくなったとき、**Finalizer 状態** に入って singleton `harness-finalizer` エージェントを dispatch してから停止します。シードされた `harness-finalizer` は generic skeleton です; プロジェクトが必要とする具体的なサイクル終了作業 —— ドキュメント更新(`CLAUDE.md`、`AGENTS.md`、`docs/`)、`events.md` とユーザーリクエストスナップショットに対するリクエストカバレッジ点検、リリース準備、監査出力など —— で本文を置き換えます。finalizer を直接呼び出すことはなく、orchestrator が停止直前のサイクル終了ターンとして dispatch します。
+プロジェクトドキュメント (ターゲットルートの `*.md`、`docs/`) は `.harness/` の中ではなく **ターゲットの中に直接** author します。orchestrator は 4 状態 DFA —— `Planner | Pair | Finalizer | Halt` —— として動作します。すべての EPIC が terminal に到達し、planner がそれ以上続行することがなくなったとき、singleton `harness-finalizer` エージェントを dispatch してから停止します; 本文はプロジェクトが必要とするサイクル終了作業 (ドキュメント更新、リクエストカバレッジ点検、リリース準備、監査出力) で置き換えます。
 
-`/harness-auto-setup` は初回セットアップ、プロジェクト形状に合わせた設定、または既存ハーネスの移行のためのより安全なエントリポイントです。`--setup`(デフォルト)は新規ターゲットをブートストラップし、既存の `.harness/` がある場合は foundation には触れずに、プロジェクト分析と必要に応じたユーザー確認の後、追加的な pair/finalizer authoring を続行します。`--migration` は既存 foundation を扱うモードです: ライブの `.harness/loom/` と `.harness/cycle/` をスナップショットし、foundation を更新し、ペアではないカスタム loom 項目を復元し、互換性のある pair/finalizer ガイドを保ちながら contract 所有のランタイム表面のみを書き直します。`.claude/`、`.codex/`、`.gemini/` を直接書くことはありません。
+`/harness-auto-setup` はより安全なエントリポイントです: `--setup` (デフォルト) は新規ターゲットをブートストラップするか、既存ハーネスを追加的 (additive) に拡張します; `--migration` はライブの `.harness/loom/` と `.harness/cycle/` をスナップショットし、foundation を更新し、互換性のあるカスタムの pair/finalizer ガイドを保ちます。
 
 ## 要件
 
@@ -286,37 +311,6 @@ EOF
 | `/harness-pair-dev --improve <slug> "<purpose>" [--before <slug> \| --after <slug>]` | positional `<purpose>` を主な改訂軸として登録済みペアを改善し、その後 rubric 整備と現在のリポ証拠を取り込みます。1 つのペアが 2 つの異なる仕事になっていたら、明示的な add/improve/remove ステップを使ってください。その後 sync を再実行してプラットフォームツリーを更新してください。 |
 | `/harness-pair-dev --remove <slug>` | ペアを安全に登録解除し、ペア所有の `.harness/loom/` ファイルだけを削除します。変異前に foundation/singleton ターゲットや、`## Next` または ライブ EPIC roster/current フィールドの active-cycle 参照を拒否し、`.harness/cycle/` の task/review 履歴を保ち、いかなる provider ツリーにも触れません; その後 sync を再実行してください。 |
 | `/harness-orchestrate <file.md>` | ターゲット側ランタイムエントリポイント。リクエストファイルを読み、その完全な本文を `.harness/cycle/user-request-snapshot.md` に保存し、応答ごとに正確に 1 名の producer を dispatch する 4 状態 DFA(`Planner | Pair | Finalizer | Halt`)を実行します; hook 再進入は `state.md` と既存のスナップショットパスからサイクルを進めます。すべての EPIC が terminal に到達し planner の継続性が明確なとき、orchestrator は Finalizer 状態に入って singleton `harness-finalizer` を dispatch してから停止します。 |
-
-## ファクトリーとランタイム
-
-```text
-factory (this repo)                            target project
------------------------------------------      ----------------------------------
-plugins/harness-loom/skills/harness-init/          installs ->      .harness/loom/{skills,agents,hook.sh,sync.ts}
-plugins/harness-loom/skills/harness-init/                            .harness/cycle/{state.md,events.md,epics/,finalizer/tasks/}
-plugins/harness-loom/skills/harness-init/references/runtime/ seeds -> .harness/loom/skills/<slug>/SKILL.md
-plugins/harness-loom/skills/harness-auto-setup/    migrates ->      .harness/_snapshots/auto-setup/<timestamp>/
-                                                                    .harness/loom/ + .harness/cycle/ refreshed in --migration
-plugins/harness-loom/skills/harness-pair-dev/      authors  ->      .harness/loom/agents/<slug>-producer.md
-                                                                    .harness/loom/agents/<reviewer>.md
-                                                                    .harness/loom/skills/<slug>/SKILL.md
-                                                     |
-                                                     +-- node .harness/loom/sync.ts --provider <list>
-                                                         -> .claude/{agents,skills,settings.json}
-                                                         -> .codex/
-                                                         -> .gemini/
-                                                     |
-                                                     +-- Finalizer state auto-fires at cycle halt
-                                                         -> .harness/loom/agents/harness-finalizer.md
-                                                         -> whatever that finalizer body writes
-```
-
-この分離は意図的です:
-
-- ファクトリーは小さく、ユーザーが直接呼び出せる状態を保つ
-- ターゲットランタイムはプロジェクト固有の作業状態を保持する
-- サイクル終了 hook は singleton で、プロジェクトがカスタマイズ可能
-- プラットフォーム固有のツリーは派生成果物であり authoring surface ではない
 
 ## マルチプラットフォーム
 

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -22,7 +22,7 @@
 
 ## クイックスタート
 
-ファクトリーを Claude Code (または Codex / Gemini —— 全オプションは [ファクトリーのインストール](#ファクトリーのインストール) を参照) にインストールします:
+ファクトリーを Claude Code にインストールします。Codex と Gemini も同様のフロー —— [ファクトリーのインストール](#ファクトリーのインストール) を参照してください。
 
 ```text
 /plugin marketplace add KingGyuSuh/harness-loom
@@ -151,13 +151,13 @@ claude --plugin-dir ./plugins/harness-loom
 
 ```bash
 # ローカルチェックアウト
-codex marketplace add /path/to/harness-loom
+codex plugin marketplace add /path/to/harness-loom
 
 # 公開 git リポ
-codex marketplace add KingGyuSuh/harness-loom
+codex plugin marketplace add KingGyuSuh/harness-loom
 
 # 必要に応じてタグにピン
-codex marketplace add KingGyuSuh/harness-loom@<tag>
+codex plugin marketplace add KingGyuSuh/harness-loom@<tag>
 ```
 
 その後、Codex TUI の中で `/plugins` を実行し、`Harness Loom` マーケットプレースエントリーを開いてプラグインをインストールします。

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -22,7 +22,7 @@
 
 ## 빠른 시작
 
-팩토리를 Claude Code (또는 Codex / Gemini — 전체 옵션은 [팩토리 설치](#팩토리-설치) 참고) 에 설치합니다:
+팩토리를 Claude Code 에 설치합니다. Codex 와 Gemini 도 비슷한 흐름 — [팩토리 설치](#팩토리-설치) 참고.
 
 ```text
 /plugin marketplace add KingGyuSuh/harness-loom
@@ -151,13 +151,13 @@ claude --plugin-dir ./plugins/harness-loom
 
 ```bash
 # 로컬 체크아웃
-codex marketplace add /path/to/harness-loom
+codex plugin marketplace add /path/to/harness-loom
 
 # 공개 git 리포
-codex marketplace add KingGyuSuh/harness-loom
+codex plugin marketplace add KingGyuSuh/harness-loom
 
 # 필요하면 태그 핀
-codex marketplace add KingGyuSuh/harness-loom@<tag>
+codex plugin marketplace add KingGyuSuh/harness-loom@<tag>
 ```
 
 그런 다음 Codex TUI 안에서 `/plugins` 를 실행하고 `Harness Loom` 마켓플레이스 항목을 열어 플러그인을 설치합니다.

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -14,22 +14,58 @@
 
 > 표현이 충돌할 경우 [영문 README](../README.md) 가 정본입니다.
 
-`harness-loom` 은 타깃 리포지토리에 런타임 하네스를 설치하고, 프로젝트 고유의 producer-reviewer pair를 점진적으로 키워 나가는 팩토리 플러그인입니다.
+## 무엇을 하는가
 
-오늘날의 어시스턴트 제품은 더 이상 "모델 + 프롬프트" 조합이 아닙니다. planner, hook, subagent, skill, 도구 라우팅, 제어 흐름까지 묶인 범용 하네스가 함께 출하되며, 작업이 어떻게 계획되고 위임되고 검토되고 재개되는지를 결정합니다. 그 레이어는 가치 있지만, 여러분의 프로덕션 시스템 — 어떤 리뷰가 중요한지, 어떤 산출물이 영속화돼야 하는지, 작업이 어떻게 분해되는지, 권한 경계는 어디인지 — 까지는 모릅니다.
+`harness-loom` 은 타깃 리포지토리에 런타임 하네스를 설치하고, 프로젝트 고유의 producer-reviewer pair를 점진적으로 키워 나가는 팩토리 플러그인입니다. 팩토리는 사용자가 호출하는 슬래시 커맨드 4개 (`/harness-init`, `/harness-auto-setup`, `/harness-pair-dev`, `/harness-goal-interview`) 와 `sync.ts` 스크립트를 출하합니다. 설치되면 타깃은 planner, orchestrator, `.harness/` 아래의 공유 컨트롤 플레인, 그리고 시간이 지나며 추가하는 프로젝트 고유 producer-reviewer pair 자리를 갖게 됩니다.
 
-선택한 모델 스택이 이미 프로덕션 품질을 만들어낼 만큼 충분히 강력하다면, 레버리지의 무게중심은 모델 선택에서 **하네스 엔지니어링** 으로 옮겨갑니다 — 즉 리포지토리의 리뷰 기준, 작업 형태, "완료" 정의를 매 세션마다 재프롬프팅하는 대신 버전 관리되는 인프라에 인코딩하는 일입니다. 이것이 모델 파인튜닝이 아닌 하네스 파인튜닝입니다.
+이것은 모델 파인튜닝이 아닌 하네스 파인튜닝입니다 — 리포의 리뷰 기준, 작업 형태, "완료" 정의를 매 세션마다 재프롬프팅하는 대신 버전 관리되는 인프라에 인코딩합니다. `harness-loom` 은 어시스턴트 스택의 프로덕션 품질 가능성을 이미 확인했고, 그것이 세션이 아닌 시스템처럼 동작하길 원하는 팀을 위한 것입니다.
 
-`harness-loom` 은 어시스턴트 스택의 프로덕션 품질 가능성을 이미 확인한 팀, 그리고 그것이 세션이 아닌 시스템처럼 동작하길 원하는 팀을 위한 것입니다.
+## 빠른 시작
 
-이 리포는 팩토리입니다. 다음 구성 요소로 이뤄진 타깃 측 런타임 하네스를 시드하거나 수렴시킵니다:
+팩토리를 Claude Code (또는 Codex / Gemini — 전체 옵션은 [팩토리 설치](#팩토리-설치) 참고) 에 설치합니다:
 
-- planner와 orchestrator
-- `.harness/` 아래의 공유 컨트롤 플레인
-- 모든 subagent를 위한 공통 런타임 컨텍스트
-- 시간이 지나며 추가하는 프로젝트 고유 producer-reviewer pair
+```text
+/plugin marketplace add KingGyuSuh/harness-loom
+/plugin install harness-loom@harness-loom-marketplace
+```
 
-타깃의 `.harness/` 는 두 형제 네임스페이스로 나뉩니다 — `loom/` 은 setup과 pair authoring이 소유하는 정본 staging tree이고, `cycle/` 은 orchestrator가 소유하는 런타임 상태입니다. 사이클 외부 산출물(타깃 루트의 `*.md`, `docs/`, 릴리스 노트, 감사 출력 등) 은 사이클 종료의 **Finalizer** 턴이 `.harness/` 안이 아닌 타깃 루트에 직접 작성합니다. 플랫폼 트리(`.claude/`, `.codex/`, `.gemini/`) 는 필요할 때 `.harness/loom/` 에서 파생됩니다.
+타깃 리포지토리 안에서:
+
+```bash
+# 1. .harness/ 시드 또는 마이그레이션
+/harness-auto-setup --setup
+
+# 2. 어시스턴트 런타임 트리 파생
+node .harness/loom/sync.ts --provider claude
+#   (멀티 플랫폼은 codex,gemini 추가)
+```
+
+여기까지가 foundation 셋업입니다. 프로젝트 고유 producer-reviewer pair 추가와 첫 사이클 실행은 [타깃 프로젝트 시작하기](#타깃-프로젝트-시작하기) 를 보세요.
+
+## 동작 방식
+
+```mermaid
+flowchart LR
+    subgraph Factory["harness-loom (factory plugin)"]
+        AS["/harness-auto-setup"]
+        PD["/harness-pair-dev"]
+        GI["/harness-goal-interview"]
+        OR["/harness-orchestrate"]
+    end
+    subgraph Target["target repository"]
+        L[".harness/loom/<br/>canonical staging"]
+        C[".harness/cycle/<br/>runtime state"]
+        P[".claude/ / .codex/ / .gemini/<br/>derived provider trees"]
+    end
+    AS -->|seed / migrate| L
+    PD -->|author pairs| L
+    GI -->|writes goal file| Target
+    L -->|node sync.ts --provider| P
+    OR -->|reads| L
+    OR -->|writes| C
+```
+
+팩토리 플러그인은 어시스턴트 CLI 안에 살고, 타깃 리포지토리 안에서 슬래시 커맨드를 실행하면 `.harness/loom/` (setup 과 pair authoring 이 소유하는 정본 staging) 과 `.harness/cycle/` (orchestrator 가 소유하는 런타임 상태) 에 작성합니다. 플랫폼 트리 (`.claude/`, `.codex/`, `.gemini/`) 는 정본 staging이 변할 때마다 `sync.ts` 로 다시 파생하는 산출물 — 직접 편집하지 마세요. 사이클 종료의 **Finalizer** 턴은 타깃 루트 산출물 (문서, 감사, 릴리스 노트) 을 `.harness/` 안이 아닌 타깃에 직접 작성합니다.
 
 ## 왜 이 모양인가
 
@@ -41,35 +77,24 @@
 
 ## 무엇이 설치되는가
 
-타깃 리포지토리 안에서 `/harness-init` 을 실행하면, `harness-loom` 은 일회성 프롬프트 템플릿이 아닌 런타임 하네스를 설치합니다. `/harness-auto-setup` 을 실행하면 동일한 foundation 설치자를 더 안전한 setup/migration 워크플로우 안에서 사용합니다.
-
 ```text
 target project
 └── .harness/
     ├── loom/                    # canonical staging (setup + pair authoring own; sync reads)
-    │   ├── skills/
-    │   │   ├── harness-orchestrate/
-    │   │   ├── harness-planning/
-    │   │   └── harness-context/
-    │   ├── agents/
-    │   │   ├── harness-planner.md
-    │   │   └── harness-finalizer.md     # generic cycle-end skeleton; project fills in
+    │   ├── skills/{harness-orchestrate, harness-planning, harness-context}/
+    │   ├── agents/{harness-planner, harness-finalizer}.md
     │   ├── hook.sh
     │   └── sync.ts
     ├── cycle/                   # runtime state (orchestrator owns)
-    │   ├── state.md
-    │   ├── events.md
-    │   ├── epics/
-    │   └── finalizer/
-    │       └── tasks/
-    ├── _snapshots/              # auto-setup provenance, when convergence runs
-    │   └── auto-setup/
-    └── _archive/                # past cycles, created on goal-different reset
+    │   ├── state.md, events.md
+    │   └── epics/, finalizer/tasks/
+    ├── _snapshots/              # auto-setup provenance (when migration runs)
+    └── _archive/                # past cycles (created on goal-different reset)
 ```
 
-프로젝트 문서(타깃 루트의 `*.md` 파일, `docs/`) 는 `.harness/` 안이 아닌 **타깃 안에 직접** 작성합니다. 그런 다음 `node .harness/loom/sync.ts --provider claude` (멀티 플랫폼이 필요하면 `codex,gemini` 추가) 로 최소 하나의 플랫폼 트리를 파생하고, `/harness-pair-dev` 로 도메인 특화 pair를 추가합니다. 설치 scaffold는 request 스냅샷을 만들지 않습니다. `/harness-orchestrate <file.md>` 로 직접 진입하면, orchestrator가 전체 request 본문을 `.harness/cycle/user-request-snapshot.md` 에 보존하고 `state.md` 의 `Goal` 헤더는 압축된 요약으로 유지합니다. orchestrator는 4-state DFA — `Planner | Pair | Finalizer | Halt` — 로 동작합니다. 모든 EPIC이 terminal에 도달하고 planner가 더 이어갈 게 없을 때, **Finalizer 상태** 로 진입해 singleton `harness-finalizer` 에이전트를 dispatch한 뒤 정지합니다. 시드된 `harness-finalizer` 는 generic skeleton입니다; 프로젝트가 필요로 하는 구체적 사이클 종료 작업 — 문서 갱신(`CLAUDE.md`, `AGENTS.md`, `docs/`), `events.md` 와 user request 스냅샷에 대비한 request coverage 점검, 릴리스 준비, 감사 출력 등 — 으로 본문을 교체합니다. finalizer를 직접 호출하지 않고, orchestrator가 정지 직전의 사이클 종료 턴으로 dispatch합니다.
+프로젝트 문서 (타깃 루트의 `*.md`, `docs/`) 는 `.harness/` 안이 아닌 **타깃 안에 직접** 작성합니다. orchestrator는 4-state DFA — `Planner | Pair | Finalizer | Halt` — 로 동작합니다. 모든 EPIC이 terminal에 도달하고 planner가 더 이어갈 게 없을 때, singleton `harness-finalizer` 에이전트를 dispatch한 뒤 정지합니다; 본문은 프로젝트가 필요로 하는 사이클 종료 작업 (문서 갱신, request coverage 점검, 릴리스 준비, 감사 출력) 으로 교체합니다.
 
-`/harness-auto-setup` 은 첫 설치, 프로젝트 형태에 맞춘 구성, 또는 기존 하네스 마이그레이션의 더 안전한 진입점입니다. `--setup` (기본값) 은 fresh target을 부트스트랩하고, 기존 `.harness/` 가 있으면 foundation은 건드리지 않은 채 프로젝트 분석과 필요한 사용자 명확화 후 추가적인 pair/finalizer authoring을 이어갑니다. `--migration` 은 기존 foundation을 다루는 모드입니다: `.harness/loom/` 과 `.harness/cycle/` 의 라이브 상태를 스냅샷하고, foundation을 갱신하고, pair가 아닌 사용자 정의 loom 항목을 복원하고, 호환되는 pair/finalizer 가이드를 보존하면서 contract 소유의 런타임 표면만 다시 작성합니다. `.claude/`, `.codex/`, `.gemini/` 는 직접 쓰지 않습니다.
+`/harness-auto-setup` 은 더 안전한 진입점입니다: `--setup` (기본) 은 fresh target을 부트스트랩하거나 기존 하네스를 추가적(additive) 으로 확장합니다; `--migration` 은 라이브 `.harness/loom/` 과 `.harness/cycle/` 을 스냅샷하고, foundation을 갱신하고, 호환되는 사용자 정의 pair/finalizer 가이드를 보존합니다.
 
 ## 요구사항
 
@@ -286,37 +311,6 @@ EOF
 | `/harness-pair-dev --improve <slug> "<purpose>" [--before <slug> \| --after <slug>]` | positional `<purpose>` 를 주된 개정 축으로 등록된 pair를 개선하고, 그 다음 rubric 정비와 현재 리포 증거를 접목합니다. 한 pair가 두 개의 다른 일이 됐다면 명시적인 add/improve/remove 단계를 사용하세요. 이후 sync를 다시 실행해 플랫폼 트리를 갱신하세요. |
 | `/harness-pair-dev --remove <slug>` | pair를 안전하게 등록 해제하고 pair 소유의 `.harness/loom/` 파일만 삭제합니다. 변형 전 foundation/singleton 타깃과 `## Next` 또는 라이브 EPIC roster/current 필드의 active-cycle 참조를 거부하고, `.harness/cycle/` task/review 히스토리는 보존하며, 어떤 provider 트리도 건드리지 않습니다; 이후 sync를 다시 실행하세요. |
 | `/harness-orchestrate <file.md>` | 타깃 측 런타임 진입점. request 파일을 읽고 그 전체 본문을 `.harness/cycle/user-request-snapshot.md` 에 보존한 뒤, 응답마다 정확히 한 명의 producer를 dispatch하는 4-state DFA(`Planner | Pair | Finalizer | Halt`) 를 실행합니다; hook 재진입은 `state.md` 와 기존 스냅샷 경로에서 사이클을 진행합니다. 모든 EPIC이 terminal에 도달하고 planner 연속성이 분명할 때, orchestrator가 Finalizer 상태로 진입해 singleton `harness-finalizer` 를 dispatch한 뒤 정지합니다. |
-
-## 팩토리와 런타임
-
-```text
-factory (this repo)                            target project
------------------------------------------      ----------------------------------
-plugins/harness-loom/skills/harness-init/          installs ->      .harness/loom/{skills,agents,hook.sh,sync.ts}
-plugins/harness-loom/skills/harness-init/                            .harness/cycle/{state.md,events.md,epics/,finalizer/tasks/}
-plugins/harness-loom/skills/harness-init/references/runtime/ seeds -> .harness/loom/skills/<slug>/SKILL.md
-plugins/harness-loom/skills/harness-auto-setup/    migrates ->      .harness/_snapshots/auto-setup/<timestamp>/
-                                                                    .harness/loom/ + .harness/cycle/ refreshed in --migration
-plugins/harness-loom/skills/harness-pair-dev/      authors  ->      .harness/loom/agents/<slug>-producer.md
-                                                                    .harness/loom/agents/<reviewer>.md
-                                                                    .harness/loom/skills/<slug>/SKILL.md
-                                                     |
-                                                     +-- node .harness/loom/sync.ts --provider <list>
-                                                         -> .claude/{agents,skills,settings.json}
-                                                         -> .codex/
-                                                         -> .gemini/
-                                                     |
-                                                     +-- Finalizer state auto-fires at cycle halt
-                                                         -> .harness/loom/agents/harness-finalizer.md
-                                                         -> whatever that finalizer body writes
-```
-
-이 분리는 의도적입니다:
-
-- 팩토리는 작고 사용자가 직접 호출 가능한 상태로 유지
-- 타깃 런타임은 프로젝트 고유의 작업 상태를 보유
-- 사이클 종료 hook은 singleton이며 프로젝트가 커스터마이즈 가능
-- 플랫폼 고유 트리는 파생 산출물이지 authoring surface가 아님
 
 ## 멀티 플랫폼
 

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -14,22 +14,58 @@
 
 > 如有表述差异,以[英文 README](../README.md) 为准。
 
-`harness-loom` 是一个工厂插件,会把运行时 harness 装入目标仓库,并按 pair 逐步扩展 producer-reviewer 组合。
+## 它做什么
 
-如今的助手产品早已不再只是"模型 + 提示词"。它们随附一整套通用 harness —— planner、hook、subagent、skill、工具路由、控制流 —— 决定工作如何被规划、委派、复核与续接。这一层很有价值,但它并不了解你的生产体系:哪些 review 重要、哪些产物需要长存、工作如何被分解、权限边界在哪里。
+`harness-loom` 是一个工厂插件,会把运行时 harness 装入目标仓库,并按 pair 逐步扩展 producer-reviewer 组合。工厂提供四个面向用户的斜杠命令 (`/harness-init`、`/harness-auto-setup`、`/harness-pair-dev`、`/harness-goal-interview`) 以及一个 `sync.ts` 脚本。安装之后,目标仓库就具备 planner、orchestrator、`.harness/` 之下的共享控制平面,以及随时间累积的、项目特有的 producer-reviewer pair 的位置。
 
-一旦你选定的模型栈已经具备足以产出生产级别成果的能力,杠杆点就从模型选择转向 **harness 工程** —— 把仓库的 review 标准、任务形态与"完成"定义编码进版本化的基础设施,而不是每个会话都重新提示一次。这是 harness 微调,不是模型微调。
+这是 harness 微调,不是模型微调 —— 把仓库的 review 标准、任务形态与"完成"定义编码进版本化的基础设施,而不是每个会话都重新提示一次。`harness-loom` 面向的是已经在助手栈中看到生产质量潜力,且希望它像一个系统而不是一次会话那样运转的团队。
 
-`harness-loom` 面向的是已经在助手栈中看到生产质量潜力,且希望它像一个系统而不是一次会话那样运转的团队。
+## 快速开始
 
-本仓库就是工厂。它会种入或收敛一份目标侧的运行时 harness,由以下部分组成:
+把工厂安装到 Claude Code (或 Codex / Gemini —— 完整选项见 [安装工厂](#安装工厂)):
 
-- 一个 planner 与一个 orchestrator
-- 位于 `.harness/` 之下的共享控制平面
-- 服务于所有 subagent 的通用运行时上下文
-- 你随时间累积的、项目特有的 producer-reviewer pair
+```text
+/plugin marketplace add KingGyuSuh/harness-loom
+/plugin install harness-loom@harness-loom-marketplace
+```
 
-目标的 `.harness/` 划分为两个并列命名空间 —— `loom/` 是由 setup 与 pair authoring 拥有的正本 staging 树,`cycle/` 是由 orchestrator 拥有的运行时状态。周期之外的产物(目标根目录下的 `*.md`、`docs/`、发布说明、审计输出等)由周期收尾的 **Finalizer** 轮次直接写到目标根目录,而不是写入 `.harness/`。平台树(`.claude/`、`.codex/`、`.gemini/`)按需从 `.harness/loom/` 派生。
+在目标仓库内:
+
+```bash
+# 1. 种入或迁移 .harness/
+/harness-auto-setup --setup
+
+# 2. 派生助手运行时树
+node .harness/loom/sync.ts --provider claude
+#   (多平台时再追加 codex,gemini)
+```
+
+到这里 foundation 就位了。要为你的仓库添加项目特定的 producer-reviewer pair 并运行第一个周期,请见 [启动一个目标项目](#启动一个目标项目)。
+
+## 工作方式
+
+```mermaid
+flowchart LR
+    subgraph Factory["harness-loom (factory plugin)"]
+        AS["/harness-auto-setup"]
+        PD["/harness-pair-dev"]
+        GI["/harness-goal-interview"]
+        OR["/harness-orchestrate"]
+    end
+    subgraph Target["target repository"]
+        L[".harness/loom/<br/>canonical staging"]
+        C[".harness/cycle/<br/>runtime state"]
+        P[".claude/ / .codex/ / .gemini/<br/>derived provider trees"]
+    end
+    AS -->|seed / migrate| L
+    PD -->|author pairs| L
+    GI -->|writes goal file| Target
+    L -->|node sync.ts --provider| P
+    OR -->|reads| L
+    OR -->|writes| C
+```
+
+工厂插件存在于你的助手 CLI 中;在目标仓库内运行它的斜杠命令,会写入 `.harness/loom/`(由 setup 与 pair authoring 拥有的正本 staging)与 `.harness/cycle/`(由 orchestrator 拥有的运行时状态)。平台树 (`.claude/`、`.codex/`、`.gemini/`) 是每当正本 staging 变化时用 `sync.ts` 重新派生的产物 —— 不要直接编辑它们。周期收尾的 **Finalizer** 轮次把目标根产物(文档、审计、发布说明)直接写到目标里,而不是写入 `.harness/`。
 
 ## 为什么是这种形态
 
@@ -41,35 +77,24 @@
 
 ## 安装的内容
 
-在目标仓库中运行 `/harness-init` 时,`harness-loom` 安装的是一个运行时 harness,而不是一份一次性的提示词模板。运行 `/harness-auto-setup` 则在更安全的 setup/migration 工作流中复用同一套 foundation 安装器。
-
 ```text
 target project
 └── .harness/
     ├── loom/                    # canonical staging (setup + pair authoring own; sync reads)
-    │   ├── skills/
-    │   │   ├── harness-orchestrate/
-    │   │   ├── harness-planning/
-    │   │   └── harness-context/
-    │   ├── agents/
-    │   │   ├── harness-planner.md
-    │   │   └── harness-finalizer.md     # generic cycle-end skeleton; project fills in
+    │   ├── skills/{harness-orchestrate, harness-planning, harness-context}/
+    │   ├── agents/{harness-planner, harness-finalizer}.md
     │   ├── hook.sh
     │   └── sync.ts
     ├── cycle/                   # runtime state (orchestrator owns)
-    │   ├── state.md
-    │   ├── events.md
-    │   ├── epics/
-    │   └── finalizer/
-    │       └── tasks/
-    ├── _snapshots/              # auto-setup provenance, when convergence runs
-    │   └── auto-setup/
-    └── _archive/                # past cycles, created on goal-different reset
+    │   ├── state.md, events.md
+    │   └── epics/, finalizer/tasks/
+    ├── _snapshots/              # auto-setup provenance (when migration runs)
+    └── _archive/                # past cycles (created on goal-different reset)
 ```
 
-项目文档(目标根目录的 `*.md` 文件、`docs/`)是 **直接在目标里** author 的,不在 `.harness/` 里。然后用 `node .harness/loom/sync.ts --provider claude` 至少派生一棵平台树(多平台时再追加 `codex,gemini`),再用 `/harness-pair-dev` 添加领域特定的 pair。安装 scaffold 不会创建请求快照。当你直接以 `/harness-orchestrate <file.md>` 进入时,orchestrator 会把请求全文保存在 `.harness/cycle/user-request-snapshot.md`,而 `state.md` 的 `Goal` 头部保留为压缩摘要。orchestrator 以四状态 DFA —— `Planner | Pair | Finalizer | Halt` —— 运行。当所有 EPIC 都到达 terminal 且 planner 没有可继续的工作时,它进入 **Finalizer 状态**,dispatch 单例 `harness-finalizer` 代理后停机。种入的 `harness-finalizer` 是一份通用骨架;你需要把项目实际所需的周期收尾工作 —— 文档刷新(`CLAUDE.md`、`AGENTS.md`、`docs/`)、对照 `events.md` 与用户请求快照检查请求覆盖、发布准备、审计输出等 —— 写进它的正文。你不会直接调用 finalizer,而是由 orchestrator 在停机前作为周期收尾轮次 dispatch 它。
+项目文档(目标根目录的 `*.md`、`docs/`)是 **直接在目标里** author 的,不在 `.harness/` 里。orchestrator 以四状态 DFA —— `Planner | Pair | Finalizer | Halt` —— 运行。当所有 EPIC 都到达 terminal 且 planner 没有可继续的工作时,它 dispatch 单例 `harness-finalizer` 代理后停机;由项目用具体的周期收尾工作(文档刷新、请求覆盖检查、发布准备、审计输出)替换正文。
 
-`/harness-auto-setup` 是首次安装、按项目形态进行配置或迁移既有 harness 的更安全入口。`--setup`(默认)用于从零启动新的目标,如果已经存在 `.harness/`,它不会触动 foundation,会在项目分析与必要的用户澄清之后,继续以增量方式 author pair/finalizer。`--migration` 是处理既有 foundation 的模式:对当前的 `.harness/loom/` 与 `.harness/cycle/` 做快照,刷新 foundation,恢复非 pair 的自定义 loom 条目,在保留兼容的 pair/finalizer 指引的同时只重写 contract 所拥有的运行时表面。它从不直接写 `.claude/`、`.codex/`、`.gemini/`。
+`/harness-auto-setup` 是更安全的入口:`--setup`(默认)用于从零启动新的目标,或对既有 harness 做增量(additive)扩展;`--migration` 对实时的 `.harness/loom/` 与 `.harness/cycle/` 做快照,刷新 foundation,并保留兼容的自定义 pair/finalizer 指引。
 
 ## 要求
 
@@ -286,37 +311,6 @@ EOF
 | `/harness-pair-dev --improve <slug> "<purpose>" [--before <slug> \| --after <slug>]` | 以位置参数 `<purpose>` 为主要修订维度改进已注册的 pair,然后整合 rubric 卫生与当前仓库证据。如果一个 pair 已经变成两份不同的工作,请使用显式的 add/improve/remove 步骤。之后重新运行 sync 以刷新平台树。 |
 | `/harness-pair-dev --remove <slug>` | 安全地注销 pair,并且只删除该 pair 所拥有的 `.harness/loom/` 文件。在变更前会拒绝 foundation/单例目标以及 `## Next` 或活动 EPIC roster/current 字段中的 active-cycle 引用,会保留 `.harness/cycle/` 中的 task/review 历史,且不触碰任何 provider 树;之后请重新运行 sync。 |
 | `/harness-orchestrate <file.md>` | 目标侧运行时入口。读取请求文件,把全文保存在 `.harness/cycle/user-request-snapshot.md`,并以四状态 DFA(`Planner | Pair | Finalizer | Halt`)运行,每次响应正好 dispatch 一个 producer;hook 重新进入会从 `state.md` 与已有的快照路径推进周期。当所有 EPIC 到达 terminal 且 planner 续接清晰时,orchestrator 进入 Finalizer 状态,dispatch 单例 `harness-finalizer` 后停机。 |
-
-## 工厂与运行时
-
-```text
-factory (this repo)                            target project
------------------------------------------      ----------------------------------
-plugins/harness-loom/skills/harness-init/          installs ->      .harness/loom/{skills,agents,hook.sh,sync.ts}
-plugins/harness-loom/skills/harness-init/                            .harness/cycle/{state.md,events.md,epics/,finalizer/tasks/}
-plugins/harness-loom/skills/harness-init/references/runtime/ seeds -> .harness/loom/skills/<slug>/SKILL.md
-plugins/harness-loom/skills/harness-auto-setup/    migrates ->      .harness/_snapshots/auto-setup/<timestamp>/
-                                                                    .harness/loom/ + .harness/cycle/ refreshed in --migration
-plugins/harness-loom/skills/harness-pair-dev/      authors  ->      .harness/loom/agents/<slug>-producer.md
-                                                                    .harness/loom/agents/<reviewer>.md
-                                                                    .harness/loom/skills/<slug>/SKILL.md
-                                                     |
-                                                     +-- node .harness/loom/sync.ts --provider <list>
-                                                         -> .claude/{agents,skills,settings.json}
-                                                         -> .codex/
-                                                         -> .gemini/
-                                                     |
-                                                     +-- Finalizer state auto-fires at cycle halt
-                                                         -> .harness/loom/agents/harness-finalizer.md
-                                                         -> whatever that finalizer body writes
-```
-
-这种拆分是有意为之的:
-
-- 工厂保持小巧,可由用户直接调用
-- 目标运行时持有项目特定的工作状态
-- 周期收尾 hook 保持单例,且可由项目自定义
-- 平台特定树是派生产物,而不是 authoring surface
 
 ## 多平台
 

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -22,7 +22,7 @@
 
 ## 快速开始
 
-把工厂安装到 Claude Code (或 Codex / Gemini —— 完整选项见 [安装工厂](#安装工厂)):
+把工厂安装到 Claude Code。Codex 与 Gemini 也是类似流程 —— 见 [安装工厂](#安装工厂)。
 
 ```text
 /plugin marketplace add KingGyuSuh/harness-loom
@@ -151,13 +151,13 @@ claude --plugin-dir ./plugins/harness-loom
 
 ```bash
 # 本地检出
-codex marketplace add /path/to/harness-loom
+codex plugin marketplace add /path/to/harness-loom
 
 # 公共 git 仓库
-codex marketplace add KingGyuSuh/harness-loom
+codex plugin marketplace add KingGyuSuh/harness-loom
 
 # 如需固定 tag
-codex marketplace add KingGyuSuh/harness-loom@<tag>
+codex plugin marketplace add KingGyuSuh/harness-loom@<tag>
 ```
 
 然后在 Codex TUI 内运行 `/plugins`,打开 `Harness Loom` marketplace 条目并安装该插件。


### PR DESCRIPTION
## Summary

Closes the v0.3.5 milestone (now empty after #41 was scoped out) by reshaping the README so a new user reaches an actionable install step within the first screen, instead of scrolling through ~80 lines of motivation prose. Same change applied to all 4 locale READMEs (ko/ja/zh-CN/es).

## What changed

- New first three sections (after title/badges):
  - `What It Does` — 2-paragraph orientation, abstract philosophy removed.
  - `Quick Start` — install factory + `/harness-auto-setup --setup` + `node sync.ts --provider claude`. Four commands, one screen.
  - `How It Works` — Mermaid flowchart of factory plugin ↔ target trees (`.harness/loom/`, `.harness/cycle/`, derived providers).
- Compressed `What Gets Installed` (tree + DFA summary into one block).
- Removed standalone ASCII `Factory And Runtime` section — its information is now carried by the new Mermaid diagram.
- All other sections preserved verbatim.
- `docs/README.{ko,ja,zh-CN,es}.md` synchronized with the new structure (15 H2 sections + 1 mermaid block + Factory And Runtime removed in all 5 files).

## Stats

| File | before | after |
|------|--------|-------|
| `README.md` | 351 | 344 |
| `docs/README.ko.md` | 354 | 347 |
| `docs/README.ja.md` | 354 | 347 |
| `docs/README.zh-CN.md` | 354 | 347 |
| `docs/README.es.md` | 354 | 347 |

First install action moved from line 81 → line 21 (≈60-line reduction to first action).

## Test plan

- [ ] Visual: open root README on GitHub and verify Quick Start renders within first screen, Mermaid diagram renders.
- [ ] Visual: same for ko/ja/zh-CN/es.
- [ ] No broken anchors in `[Install The Factory](#install-the-factory)` style links.
- [ ] Confirm `## Project Documents` link list still resolves (CHANGELOG, CONTRIBUTING, SECURITY, CODE_OF_CONDUCT, LICENSE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)