### PR TITLE
fix(readme): make Mermaid diagram render on GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,18 +44,18 @@ That gets the foundation in place. To add project-specific producer-reviewer pai
 
 ```mermaid
 flowchart LR
-    subgraph Factory["harness-loom (factory plugin)"]
+    subgraph Factory [harness-loom factory plugin]
         AS["/harness-auto-setup"]
         PD["/harness-pair-dev"]
         GI["/harness-goal-interview"]
         OR["/harness-orchestrate"]
     end
-    subgraph Target["target repository"]
+    subgraph Target [target repository]
         L[".harness/loom/<br/>canonical staging"]
         C[".harness/cycle/<br/>runtime state"]
-        P[".claude/ / .codex/ / .gemini/<br/>derived provider trees"]
+        P[".claude / .codex / .gemini<br/>derived provider trees"]
     end
-    AS -->|seed / migrate| L
+    AS -->|seed or migrate| L
     PD -->|author pairs| L
     GI -->|writes goal file| Target
     L -->|node sync.ts --provider| P

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -46,18 +46,18 @@ Hasta aquí queda la foundation. Para añadir parejas producer-reviewer específ
 
 ```mermaid
 flowchart LR
-    subgraph Factory["harness-loom (factory plugin)"]
+    subgraph Factory [harness-loom factory plugin]
         AS["/harness-auto-setup"]
         PD["/harness-pair-dev"]
         GI["/harness-goal-interview"]
         OR["/harness-orchestrate"]
     end
-    subgraph Target["target repository"]
+    subgraph Target [target repository]
         L[".harness/loom/<br/>canonical staging"]
         C[".harness/cycle/<br/>runtime state"]
-        P[".claude/ / .codex/ / .gemini/<br/>derived provider trees"]
+        P[".claude / .codex / .gemini<br/>derived provider trees"]
     end
-    AS -->|seed / migrate| L
+    AS -->|seed or migrate| L
     PD -->|author pairs| L
     GI -->|writes goal file| Target
     L -->|node sync.ts --provider| P

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -46,18 +46,18 @@ node .harness/loom/sync.ts --provider claude
 
 ```mermaid
 flowchart LR
-    subgraph Factory["harness-loom (factory plugin)"]
+    subgraph Factory [harness-loom factory plugin]
         AS["/harness-auto-setup"]
         PD["/harness-pair-dev"]
         GI["/harness-goal-interview"]
         OR["/harness-orchestrate"]
     end
-    subgraph Target["target repository"]
+    subgraph Target [target repository]
         L[".harness/loom/<br/>canonical staging"]
         C[".harness/cycle/<br/>runtime state"]
-        P[".claude/ / .codex/ / .gemini/<br/>derived provider trees"]
+        P[".claude / .codex / .gemini<br/>derived provider trees"]
     end
-    AS -->|seed / migrate| L
+    AS -->|seed or migrate| L
     PD -->|author pairs| L
     GI -->|writes goal file| Target
     L -->|node sync.ts --provider| P

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -46,18 +46,18 @@ node .harness/loom/sync.ts --provider claude
 
 ```mermaid
 flowchart LR
-    subgraph Factory["harness-loom (factory plugin)"]
+    subgraph Factory [harness-loom factory plugin]
         AS["/harness-auto-setup"]
         PD["/harness-pair-dev"]
         GI["/harness-goal-interview"]
         OR["/harness-orchestrate"]
     end
-    subgraph Target["target repository"]
+    subgraph Target [target repository]
         L[".harness/loom/<br/>canonical staging"]
         C[".harness/cycle/<br/>runtime state"]
-        P[".claude/ / .codex/ / .gemini/<br/>derived provider trees"]
+        P[".claude / .codex / .gemini<br/>derived provider trees"]
     end
-    AS -->|seed / migrate| L
+    AS -->|seed or migrate| L
     PD -->|author pairs| L
     GI -->|writes goal file| Target
     L -->|node sync.ts --provider| P

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -46,18 +46,18 @@ node .harness/loom/sync.ts --provider claude
 
 ```mermaid
 flowchart LR
-    subgraph Factory["harness-loom (factory plugin)"]
+    subgraph Factory [harness-loom factory plugin]
         AS["/harness-auto-setup"]
         PD["/harness-pair-dev"]
         GI["/harness-goal-interview"]
         OR["/harness-orchestrate"]
     end
-    subgraph Target["target repository"]
+    subgraph Target [target repository]
         L[".harness/loom/<br/>canonical staging"]
         C[".harness/cycle/<br/>runtime state"]
-        P[".claude/ / .codex/ / .gemini/<br/>derived provider trees"]
+        P[".claude / .codex / .gemini<br/>derived provider trees"]
     end
-    AS -->|seed / migrate| L
+    AS -->|seed or migrate| L
     PD -->|author pairs| L
     GI -->|writes goal file| Target
     L -->|node sync.ts --provider| P


### PR DESCRIPTION
## Summary

The README Mermaid diagram introduced in v0.3.5 (#42) doesn't render on GitHub — it shows up as raw text. This patch fixes the syntax so the diagram renders.

## Why it didn't render

Two likely culprits in the original block:

1. **`subgraph X["..."]`** (quoted subgraph label) is a recent Mermaid syntax that some renderers don't accept. Switched to the long-supported bracket form `subgraph X [label]`.
2. **`|seed / migrate|`** edge label and **`.claude/ / .codex/ / .gemini/`** node label both contained slash-only sequences that some Mermaid parsers treat ambiguously. Switched to `seed or migrate` and `.claude / .codex / .gemini` (single slash with surrounding spaces).

## What changed

Same Mermaid block, fixed identically across root README and all 4 locale READMEs (ko / ja / zh-CN / es). 5 files, 20 insertions / 20 deletions.

## Test plan

- [ ] Open the rendered README on GitHub (this branch's compare view, or a fork preview) and confirm the flowchart renders as a diagram, not as raw text.
- [ ] Same for ko / ja / zh-CN / es.

## Milestone

Attached to v0.3.6 since v0.3.5 has already been released and tagged. This will land in the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)